### PR TITLE
Add branching and committing strategy docs

### DIFF
--- a/docs/doc-strategy-branching.md
+++ b/docs/doc-strategy-branching.md
@@ -1,0 +1,27 @@
+# Branch Strategy
+
+## Current approach: trunk-based development with continuous deployment
+
+We use a single `main` branch (the trunk) with short-lived feature branches. Feature branches PR into `main`, and `main` auto-deploys to production on Vercel. There is no staging branch or staging environment.
+
+This is a deliberate choice toward Continuous Deployment — code that passes CI goes to production.
+
+## Why no staging/release branch distinction
+
+A `develop`/staging branch adds a layer of safety (preview new features before they hit real users) but also adds cognitive cost (which branch is this on? which environment has what?) and slows delivery to users. For a small team deploying to a forgiving user base, we're starting simple and trying to build up our CI muscles.
+
+The alternative was considered: a `release` branch with its own Vercel environment (configurable in Vercel Settings → Environments → Branch Tracking), with and periodic `main → release` PRs for production releases. This remains available if we need it.
+
+## When to reconsider
+
+When production breaks happen, the question to ask is: **"do we strengthen CI, or add a staging branch?"** The hypothesis is that stronger CI (better tests, migration checks, linting) is the higher-leverage answer — especially with AI-assisted development — but we're open to being wrong.
+
+## TODO: We need to support a "dev environment"
+This requires separate-from-prod dev-testing database(s) for the e2e tests. We also want a "copy prod data to testing db" for testing the preview deploys, to give us db migration testing against real data.
+
+## Feature branch conventions
+
+- Branch from `main`
+- PR back into `main`
+- CI must pass before merge (lint, functional tests, e2e against Vercel preview)
+- Keep branches short-lived

--- a/docs/doc-strategy-committing.md
+++ b/docs/doc-strategy-committing.md
@@ -1,0 +1,27 @@
+# Committing Strategy
+
+## Before committing
+
+If you touch code, have test coverage for it! Make sure you're keeping the docs and CLAUDE.md in sync with the state of the code as well.
+
+If you've done work your teammates should know about, add a `docs/devjournal.md` entry (typically at a higher level than all the commit messages on that branch).
+
+Run `npm test` (all suites) and confirm green before committing. Don't push code that you haven't tested locally. If you're changing frontend layout, check both phone and desktop rendering.
+
+## Branch discipline
+
+Always commit on a feature branch, never directly to `main`. PRs into `main` require CI to pass before merge.
+
+## Schema and data migrations: expand-contract pattern
+
+When a change touches the database schema or API response shape, deploy it in phases:
+
+1. **Expand** — deploy a backend version that supports both the old and new shape. Add new columns/fields/endpoints alongside the old ones. Both old and new clients continue to work.
+2. **Migrate** — update clients (frontend, mobile, etc.) to use the new shape. Deploy.
+3. **Contract** — remove the old columns/fields/endpoints. Deploy.
+
+Each phase is its own PR and deploy. Never combine expand and contract in a single deploy — that's the window where things break.
+
+## AI-assisted commits
+
+We allow and encourage AI coding support, but you are responsible for the quality of both the code changes and the commit message. Commits made fully by AI assistance include a `Co-Authored-By` trailer for attribution and traceability.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- . ':!docs/'"
+}


### PR DESCRIPTION
## Summary
- Branching strategy: trunk-based development, no staging branch, with conditions for reconsidering
- Committing strategy: test before commit, expand-contract migrations, AI attribution
- Skip Vercel deployment for docs-only changes via vercel.json ignoreCommand

## Test plan
- [ ] CI passes (lint + functional)
- [ ] Vercel build is skipped (docs-only change) or deploys successfully
- [ ] E2E tests pass if Vercel deploys

🤖 Generated with [Claude Code](https://claude.ai/code)