### PR TITLE
Add Axiom logging and update Vercel team config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Requires Docker Desktop. `npm run dev` auto-starts a local Supabase stack (Postg
 - Trunk-based development: feature branches PR into `main`, which auto-deploys to production
 - Run `npm test` before committing. Keep docs and CLAUDE.md in sync with code changes.
 - Schema/API migrations use the **expand-contract pattern** (see `docs/doc-strategy-committing.md`)
-- Docs-only changes skip Vercel deployment (configured in `vercel.json`)
+- All pushes trigger Vercel deployment
 - Add `docs/devjournal.md` entries for decisions teammates should know about
 
 ## CI/CD

--- a/docs/doc-vercel.md
+++ b/docs/doc-vercel.md
@@ -4,8 +4,10 @@ Current configuration for the Vercel project as deployed. This documents setting
 
 ---
 
+- **Team:** `intentional-society-vercel`
 - **Project name:** `is-app-vercel`
+- **Dashboard:** https://vercel.com/intentional-society-vercel/is-app-vercel
 - **Framework preset:** Next.js (must be set manually — Vercel does not auto-detect from an existing repo)
 - **Domain:** `app.intentionalsociety.org` (DNS configured to point to Vercel)
 - **Deployment Protection:** Vercel Authentication disabled on preview deployments, so GitHub Actions can run Playwright e2e tests against preview URLs without hitting a login wall
-- **Environment variables:** `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`, `DATABASE_URL` — set in Vercel dashboard (Settings → Environment Variables), not committed to the repo
+- **Environment variables:** `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`, `DATABASE_URL`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` — set in Vercel dashboard (Settings → Environment Variables), not committed to the repo

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,12 @@
 import type { NextConfig } from "next";
+import { withAxiom } from "next-axiom";
 import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   typedRoutes: true,
 };
 
-export default withSentryConfig(nextConfig, {
+export default withSentryConfig(withAxiom(nextConfig), {
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
   authToken: process.env.SENTRY_AUTH_TOKEN,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "drizzle-orm": "^0.45.2",
         "hono": "^4.12.10",
         "next": "^15.3",
+        "next-axiom": "^1.10.0",
         "postgres": "^3.4.8",
         "react": "^19.1",
         "react-dom": "^19.1"
@@ -4701,6 +4702,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/mysql": {
       "version": "2.15.27",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
@@ -5351,6 +5358,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/functions": {
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-2.2.13.tgz",
+      "integrity": "sha512-14ArBSIIcOBx9nrEgaJb4Bw+en1gl6eSoJWh8qjifLl5G3E4dRXCFOT8HP+w66vb9Wqyd1lAQBrmRhRwOj9X9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-2.0.2.tgz",
+      "integrity": "sha512-59PBFx3T+k5hLTEWa3ggiMpGRz1OVvl9eN8SUai+A43IsqiOuAe7qPBf+cray/Fj6mkgnxm/D7IAtjc8zSHi7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/ms": "2.1.0",
+        "ms": "2.1.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
@@ -6440,6 +6480,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -9182,6 +9231,24 @@
         }
       }
     },
+    "node_modules/next-axiom": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/next-axiom/-/next-axiom-1.10.0.tgz",
+      "integrity": "sha512-PpwmfOqoa2xWKcGmYb3d5t3R4+/J8C2D00IhJsI3Qk0xxv9tNvGzS/hKKOPNOuUwqM4b/etqu6iGW7tkKvltgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vercel/functions": "^2.2.13",
+        "use-deep-compare": "^1.3.0",
+        "whatwg-fetch": "^3.6.20"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": ">=14.0",
+        "react": ">=18.0.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -11652,6 +11719,18 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-deep-compare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-deep-compare/-/use-deep-compare-1.3.0.tgz",
+      "integrity": "sha512-94iG+dEdEP/Sl3WWde+w9StIunlV8Dgj+vkt5wTwMoFQLaijiEZSXXy8KtcStpmEDtIptRJiNeD4ACTtVvnIKA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -11992,6 +12071,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.10",
     "next": "^15.3",
+    "next-axiom": "^1.10.0",
     "postgres": "^3.4.8",
     "react": "^19.1",
     "react-dom": "^19.1"

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,9 +1,21 @@
 import { Hono } from "hono";
+import { log } from "next-axiom";
 import { db } from "./db";
 import { sql } from "drizzle-orm";
 
 const api = new Hono()
   .basePath("/api")
+  .use("*", async (c, next) => {
+    const start = Date.now();
+    await next();
+    const duration = Date.now() - start;
+    log.info("api request", {
+      method: c.req.method,
+      path: c.req.path,
+      status: c.res.status,
+      duration,
+    });
+  })
   .get("/hello", (c) => {
     return c.json({ message: "Hello from Intentional Society API" });
   })

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,1 @@
-{
-  "ignoreCommand": "git diff $VERCEL_GIT_PREVIOUS_SHA HEAD --quiet -- . ':!docs/'"
-}
+{}


### PR DESCRIPTION
## Summary
- Install next-axiom for full-stack observability (Web Vitals, structured logging)
- Add Hono request logging middleware (method, path, status, duration)
- Update doc-vercel with team name and Sentry env vars

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run test:functional` passes
- [x] `npm run lint` clean
- [ ] After merge: verify logs appear in Axiom dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)