### PR TITLE
Update docs: Axiom, Sentry, README, setup guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,5 +63,7 @@ Requires Docker Desktop. `npm run dev` auto-starts a local Supabase stack (Postg
 - `docs/doc-strategy-committing.md` — commit conventions and expand-contract pattern
 - `docs/doc-vercel.md` — Vercel dashboard settings
 - `docs/doc-github.md` — GitHub settings and CI workflows
+- `docs/doc-sentry.md` — Sentry error tracking and performance monitoring
+- `docs/doc-axiom.md` — Axiom logging and Web Vitals
 - `docs/setup-dev-machine.md` — system prerequisites (Node.js, Docker, etc.)
 - `docs/devjournal.md` — development decision log (most recent first)

--- a/README.md
+++ b/README.md
@@ -4,43 +4,81 @@ Web application for [Intentional Society](https://intentionalsociety.org) — an
 
 Live at **app.intentionalsociety.org**
 
+## How the app works
+
+A Next.js frontend talks to a Hono API backend, both running in the same codebase. Data lives in PostgreSQL (managed by Supabase), accessed via Drizzle ORM. Supabase also handles authentication. For local development, the entire Supabase stack runs in Docker on your machine.
+
 ## Getting started
 
-### Prerequisites
+### 1. Install prerequisites
 
-- Node.js 22+
-- Docker Desktop (for local Supabase stack)
-- See [docs/setup-dev-machine.md](docs/setup-dev-machine.md) for full setup details
+Git, Node.js 22+, and Docker Desktop. See [docs/setup-dev-machine.md](docs/setup-dev-machine.md) for install instructions.
 
-### Run locally
+### 2. Clone and install
 
 ```bash
+git clone https://github.com/Intentional-Society/is-app.git
+cd is-app
 npm install
-cp .env.example .env.local   # then fill in local values (see comments in file)
-npm run dev                   # starts local Supabase + Next.js dev server
 ```
 
-On first run, Docker will pull Supabase images (~2-5 min). After that, startup is near-instant.
+### 3. Set up environment
 
-### Useful commands
+```bash
+cp .env.example .env.local
+```
+
+Edit `.env.local` with your local credentials. See the comments in `.env.example` for local Supabase values.
+
+### 4. Run
+
+```bash
+npm run dev
+```
+
+This starts a local Supabase stack in Docker (Postgres, Auth, Studio), runs any pending database migrations, then launches the Next.js dev server at **http://localhost:3000**.
+
+First run pulls Docker images and takes a few minutes. After that, startup is near-instant.
+
+## Useful commands
 
 | Command | What it does |
 |---------|-------------|
-| `npm run dev` | Start local Supabase (if needed) + Next.js dev server |
+| `npm run dev` | Start Supabase + Next.js dev server |
 | `npm run dev:db:stop` | Stop local Supabase containers |
 | `npm run dev:db:reset` | Wipe local DB and reapply migrations |
 | `npm test` | Run all tests (functional + e2e) |
 | `npm run watch` | Vitest in watch mode |
+| `npm run lint` | ESLint |
+
+## Project structure
+
+```
+src/
+  app/              Next.js pages and layouts
+  app/api/          Catch-all route that delegates to Hono
+  server/api.ts     Hono API routes (the backend)
+  server/schema.ts  Drizzle database schema
+  server/db.ts      Database connection
+  lib/api.ts        Typed API client (apiClient) for frontend use
+  lib/supabase/     Supabase auth helpers (server, client, middleware)
+docs/               Architecture specs, strategy docs, config references
+tests/              Functional and e2e tests
+supabase/           Local Supabase config (config.toml)
+drizzle/            Database migration files
+```
 
 ## Documentation
 
 | Doc | Description |
 |-----|-------------|
+| [architecture-appstack.md](docs/architecture-appstack.md) | Production stack and architecture decisions |
+| [architecture-devstack.md](docs/architecture-devstack.md) | Dev/test tooling |
 | [setup-dev-machine.md](docs/setup-dev-machine.md) | System prerequisites for new developers |
-| [architecture-appstack.md](docs/architecture-appstack.md) | Production stack (Next.js, Hono, Drizzle, Supabase) |
-| [architecture-devstack.md](docs/architecture-devstack.md) | Dev/test tooling (Vitest, Playwright, etc.) |
 | [doc-strategy-branching.md](docs/doc-strategy-branching.md) | Branching strategy |
-| [doc-strategy-committing.md](docs/doc-strategy-committing.md) | Commit conventions and expand-contract pattern |
+| [doc-strategy-committing.md](docs/doc-strategy-committing.md) | Commit conventions |
+| [doc-sentry.md](docs/doc-sentry.md) | Sentry error tracking config |
+| [doc-axiom.md](docs/doc-axiom.md) | Axiom logging config |
 | [doc-vercel.md](docs/doc-vercel.md) | Vercel dashboard settings |
 | [doc-github.md](docs/doc-github.md) | GitHub settings and CI workflows |
 | [devjournal.md](docs/devjournal.md) | Development decision log |

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-04-07 | James | Observability: Sentry + Axiom
+
+Sentry for error tracking, performance traces, and session replay. Axiom for structured request logs via Vercel Log Drain + next-axiom. Hono middleware logs method, path, status, and duration on every API request.
+
 ## 2026-04-06 | James | Local dev environment via Supabase CLI + Docker
 
 `npm run dev` now auto-starts a local Supabase stack (Postgres, Auth, Studio) in Docker and runs Drizzle migrations. Each developer gets an isolated database. Drizzle is the sole migration tool — we don't use `supabase/migrations/`. Production still uses the hosted Supabase instance via env vars.

--- a/docs/doc-axiom.md
+++ b/docs/doc-axiom.md
@@ -1,0 +1,27 @@
+# Axiom Configuration
+
+## Account
+
+- **Organization:** intentional-society-axiom
+- **Dashboard:** https://app.axiom.co/intentional-society-axiom-nnvi/
+
+## How It Works
+
+Axiom receives logs through two channels:
+
+- **Vercel Log Drain** — all serverless function stdout/stderr is streamed to Axiom automatically via the Vercel marketplace integration. No SDK or API key needed for this.
+- **next-axiom** — the `next-axiom` package wraps `next.config.ts` and provides:
+  - `log.info()` / `log.warn()` / `log.error()` / `log.debug()` for structured logging from client and server
+  - Automatic Web Vitals reporting
+
+## Request Logging
+
+Every API request is logged by Hono middleware in `src/server/api.ts` with:
+- `method` — HTTP method
+- `path` — request path
+- `status` — response status code
+- `duration` — response time in milliseconds
+
+## Environment Variables
+
+No Axiom-specific env vars are needed in the app. The Vercel Log Drain integration handles authentication automatically. `next-axiom` reads the Vercel-provided `NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT` at build time.

--- a/docs/doc-vercel.md
+++ b/docs/doc-vercel.md
@@ -10,4 +10,5 @@ Current configuration for the Vercel project as deployed. This documents setting
 - **Framework preset:** Next.js (must be set manually — Vercel does not auto-detect from an existing repo)
 - **Domain:** `app.intentionalsociety.org` (DNS configured to point to Vercel)
 - **Deployment Protection:** Vercel Authentication disabled on preview deployments, so GitHub Actions can run Playwright e2e tests against preview URLs without hitting a login wall
+- **Integrations:** Axiom (Log Drain — streams all serverless function output to Axiom automatically)
 - **Environment variables:** `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`, `DATABASE_URL`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` — set in Vercel dashboard (Settings → Environment Variables), not committed to the repo

--- a/docs/setup-dev-machine.md
+++ b/docs/setup-dev-machine.md
@@ -4,9 +4,23 @@ System prerequisites for working on is-app. These are one-time installs.
 
 ---
 
-## Node.js 22+
+## Node.js 22+ (via nvm)
 
-Install from [nodejs.org](https://nodejs.org/) (LTS) or via a version manager like `nvm` or `fnm`.
+We recommend using `nvm` to manage Node.js versions.
+
+**Mac:**
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+nvm install 22
+```
+
+**Windows:**
+
+Install [nvm-windows](https://github.com/coreybutler/nvm-windows/releases) (download and run the latest `nvm-setup.exe`), then:
+```bash
+nvm install 22
+nvm use 22
+```
 
 After install: `node --version` should show v22.x or later.
 


### PR DESCRIPTION
## Summary
- Add doc-axiom.md with dashboard URL and logging details
- Add Axiom integration to doc-vercel
- Add observability devjournal entry
- Add nvm install instructions (Mac + Windows) to setup guide
- Rewrite README with app overview, project structure, numbered setup steps
- Add Sentry and Axiom to CLAUDE.md key docs

## Test plan
- [x] `npm run test:functional` passes
- [x] `npm run lint` clean
- Docs-only changes (except CLAUDE.md), no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)