### PR TITLE
Migrate lint from next lint to eslint CLI

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,9 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
-const eslintConfig = [...compat.extends("next/core-web-vitals", "next/typescript")];
+const eslintConfig = [
+  { ignores: [".next/", "next-env.d.ts"] },
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:db:reset": "npx supabase db reset && npx drizzle-kit migrate",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "test": "vitest run && playwright test",
     "test:functional": "vitest run",
     "watch": "vitest",


### PR DESCRIPTION
## Summary
- Replace deprecated `next lint` with `eslint .` in package.json
- Add ignores for `.next/` build output and `next-env.d.ts` in eslint config
- Prepares for Next.js 16 which removes `next lint`

## Test plan
- [x] `npm run lint` passes with no warnings or errors
- [x] `npm run test:functional` passes
- [x] No deprecation warning in lint output

🤖 Generated with [Claude Code](https://claude.com/claude-code)