### PR TITLE
Auth plan docs + production Drizzle migration hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ next-env.d.ts
 # IDE
 .vscode/
 .idea/
+*.code-workspace
 
 # OS
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Requires Docker Desktop. `npm run dev` auto-starts a local Supabase stack (Postg
 
 - **ci.yml**: lint + functional tests on every PR (required to pass)
 - **e2e.yml**: Playwright against Vercel preview URL, triggered by `deployment_status` event (not required, but check results before merging)
-- Vercel auto-deploys `main` to production
+- Vercel auto-deploys `main` to production; the build command runs `drizzle-kit migrate` before `next build` on production deploys only (gated by `VERCEL_ENV`)
 
 ## Key docs
 

--- a/docs/doc-strategy-committing.md
+++ b/docs/doc-strategy-committing.md
@@ -22,6 +22,44 @@ When a change touches the database schema or API response shape, deploy it in ph
 
 Each phase is its own PR and deploy. Never combine expand and contract in a single deploy — that's the window where things break.
 
+### When migrations run
+
+Database migrations run as part of Vercel's production build command (`vercel.json`): `drizzle-kit migrate` executes before `next build`, gated by `VERCEL_ENV=production` so preview deploys skip it. This guarantees the database schema is updated before the new code goes live.
+
+Because migrations always run first, the only timing constraint to think about is:
+
+- **The old code must tolerate the new schema** for the brief window between migration and deploy completion. In practice this is the easy direction — additive changes (new tables, new nullable columns) don't break existing queries.
+
+The expand-contract pattern naturally satisfies this: the expand phase adds schema that the old code ignores, and the contract phase only removes schema that the new code no longer references.
+
+### Writing safe migrations
+
+Every migration must be safe to run against a database that is actively serving requests with the *current* production code (i.e., the code from the previous deploy). Concretely:
+
+- **Adding** tables, columns, or indexes is always safe.
+- **Renaming or dropping** a column requires a full expand-contract cycle — don't drop until no deployed code references it.
+- **`NOT NULL` without a default** on an existing table will fail if rows exist. Add the column as nullable (or with a default) first, backfill, then add the constraint in a follow-up migration.
+- **Keep migrations fast.** Long-running locks on a small database are unlikely to cause problems today, but avoid patterns (like rewriting entire tables) that would become a problem at scale.
+
+### Verifying each phase with this stack
+
+Each phase is its own PR, merged and deployed before the next one opens. Here's how each phase gets verified:
+
+**PR #1 (Expand)** — add the new schema to `src/server/schema.ts`, run `drizzle-kit generate` to produce the additive migration. No code changes (or only additive, backward-compatible ones). CI functional tests and the e2e preview both run cleanly because the old code still works against the new schema. On merge, the migration runs against prod and the schema is expanded.
+
+**PR #2 (Migrate)** — update code to read/write the new schema. No schema or migration changes. By the time this PR opens, PR #1 has merged and the prod DB already has the new schema, so the e2e preview (which hits the prod DB) can exercise the new code paths against real data. CI functional tests pass because the tests can rely on the new schema being present locally after `npm run dev:db:reset`.
+
+**PR #3 (Contract)** — this is the interesting one. The preview deploy hits a prod DB that *still has the old schema* (the contract migration hasn't run yet), so the preview can't verify that the drop is safe. Instead we use the TypeScript compiler as the verification mechanism:
+
+1. Remove the old column/table from `src/server/schema.ts`
+2. Run `npx tsc --noEmit` — the compiler lists every stray reference to the removed schema
+3. Fix each reference. (Most should already be gone from PR #2 — this step catches stragglers, including anything in code paths that weren't touched by PR #2.)
+4. Run `npx drizzle-kit generate` to produce the DROP migration
+5. Reset the local DB (`npm run dev:db:reset`) and run `npm test` to confirm the whole suite passes against the contracted schema. This catches raw SQL or dynamic references the type checker can't see.
+6. Merge. On production deploy, the DROP migration runs against a codebase the type checker has already proven doesn't reference the old schema.
+
+This works because Drizzle's schema is TypeScript code, so removing it from the schema turns "prove no code still uses this column" into a compile error — a much stronger signal than runtime monitoring or grep. Other stacks (Rails, SQLAlchemy) achieve similar safety by adding an intermediate deploy that marks the column as hidden from the ORM, but with Drizzle + TS we get it for free at build time.
+
 ## AI-assisted commits
 
 We allow and encourage AI coding support, but you are responsible for the quality of both the code changes and the commit message. Commits made fully by AI assistance include a `Co-Authored-By` trailer for attribution and traceability.

--- a/docs/doc-vercel.md
+++ b/docs/doc-vercel.md
@@ -8,6 +8,7 @@ Current configuration for the Vercel project as deployed. This documents setting
 - **Project name:** `is-app-vercel`
 - **Dashboard:** https://vercel.com/intentional-society-vercel/is-app-vercel
 - **Framework preset:** Next.js (must be set manually — Vercel does not auto-detect from an existing repo)
+- **Build command:** `if [ "$VERCEL_ENV" = "production" ]; then npx drizzle-kit migrate; fi && next build` (set in `vercel.json`). Runs Drizzle migrations before the Next.js build on production deploys only — preview deploys skip migrations. If the production migration fails, the build aborts before `next build` and the previous production deploy keeps serving traffic.
 - **Domain:** `app.intentionalsociety.org` (DNS configured to point to Vercel)
 - **Deployment Protection:** Vercel Authentication disabled on preview deployments, so GitHub Actions can run Playwright e2e tests against preview URLs without hitting a login wall
 - **Integrations:** Axiom (Log Drain — streams all serverless function output to Axiom automatically)

--- a/docs/plan-auth-0.md
+++ b/docs/plan-auth-0.md
@@ -1,0 +1,37 @@
+# Plan: Auth & Members — Shared Decisions
+
+The four-phase effort to add authentication and member accounts:
+
+0. **Shared decisions & non-goals (this document)**
+1. [Plumbing](./plan-auth-1-plumbing.md) — auth wiring, minimal profile, Hono middleware
+2. [Profile schema expansion](./plan-auth-2-profile.md) — rich profile fields, sensitive-field access control
+3. [Invites](./plan-auth-3-invites.md) — member-generated invite codes, signup flow
+4. [Member migration](./plan-auth-4-migration.md) — seed ~40 existing members from Google Sheet
+
+Each phase is self-contained, individually mergeable, and demoable on its own. This document collects the decisions and deliberate non-goals that apply across all four.
+
+---
+
+## Shared decisions (apply to all phases)
+
+- **Auth method:** magic link by default. Members can optionally set a password after first sign-in (via the profile completion flow in Phase 2) and then use email + password to sign in. No password reset flow — magic link serves as password recovery. Signup is always magic link (eliminates the need for a separate email-confirmation step).
+- **Signup model:** invite codes. Any member can generate codes. Single-use. 30-day expiry. Required free-text note on generation. Rate-limited to 10 active (unredeemed, unexpired, unrevoked) invites per member.
+- **Existing members (~40):** migrated via Supabase Admin API (`inviteUserByEmail`), no invite code required. Data source is a Google Sheet exported as CSV.
+- **Entry point:** `/` is the authed landing page. Unauthenticated visitors are redirected to `/login`.
+- **Profile ↔ `auth.users` sync:** app-level in `/auth/callback` (idempotent upsert), not a DB trigger.
+- **Programs:** curated, admin-managed list. Modeled as many-to-many (`programs` + `profilePrograms` tables). Defined in a committed `scripts/programs.seed.json`; no admin UI in this plan.
+- **Access control:** Hono API middleware on all `/api/*` routes per [architecture-appstack.md](./architecture-appstack.md). RLS intentionally not the primary mechanism. Sensitive fields (notably `emergencyContact`, added in Phase 2) are filtered at the API serialization layer.
+- **E2E auth testing:** Playwright session-minting helper using the Supabase Admin API. Bypasses magic-link email entirely. Real magic-link flow is exercised manually during development.
+
+## Deliberate non-goals (across all auth phases)
+
+- Profile edit UI (members cannot change their own data through the app yet — admin hand-edits via DB for now).
+- Member directory page.
+- Admin UI for managing programs (JSON file is the source of truth).
+- Admin UI for mass invite revocation.
+- OAuth providers.
+- Password reset flow (magic link serves as password recovery).
+- Email preferences, notifications, Buttondown integration.
+- Supabase Storage for avatar uploads (`avatarUrl` is a string field).
+- Real magic-link click-through in automated tests (covered by manual QA + the session-minting helper introduced in Phase 3).
+- RLS policies (intentionally not the primary access mechanism per architecture doc).

--- a/docs/plan-auth-1-plumbing.md
+++ b/docs/plan-auth-1-plumbing.md
@@ -1,0 +1,169 @@
+# Plan: Auth Plumbing (Phase 1)
+
+Part of a four-phase effort to add authentication and member accounts:
+
+0. [Shared decisions & non-goals](./plan-auth-0.md)
+1. **Plumbing (this document)** — auth wiring, minimal profile, Hono middleware
+2. [Profile schema expansion](./plan-auth-2-profile.md) — rich profile fields, sensitive-field access control
+3. [Invites](./plan-auth-3-invites.md) — member-generated invite codes, signup flow
+4. [Member migration](./plan-auth-4-migration.md) — seed ~40 existing members from Google Sheet
+
+This phase gets us from zero auth to a signed-in user viewing a minimal profile at `/`. It is deliberately small: just the auth wiring. The full profile schema, invite flow, and migration of existing members are later phases. Mergeable and demoable on its own.
+
+Shared decisions (auth method, access control approach, etc.) and deliberate non-goals are documented in [plan-auth-0.md](./plan-auth-0.md).
+
+---
+
+## Context
+
+The IS app has Supabase auth helpers scaffolded at `src/lib/supabase/{client,server,middleware}.ts` but nothing is wired up end-to-end. The Drizzle schema (`src/server/schema.ts`) is empty, the Hono API (`src/server/api.ts`) has no auth middleware so every endpoint is public, there is no root `src/middleware.ts` to refresh sessions, and there are no auth routes. The current `/` (`src/app/page.tsx`) is a public demo page hitting `/api/hello` and `/api/health`.
+
+Phase 1 does the minimum needed to prove auth works end-to-end: a user can sign in via magic link, land on `/`, and see their own minimal profile (just `displayName`). The full community profile shape — `bio`, `keywords`, `location`, `emergencyContact`, etc. — is intentionally deferred to Phase 2 so the plumbing PR stays focused on auth wiring.
+
+## Schema (`src/server/schema.ts`)
+
+Four tables, Drizzle `pg-core`. The `profiles` table ships minimal; Phase 2 alters it to add the rich fields. The other three tables are defined here to avoid splintering the initial migration — cheaper than three separate migration rounds as Phases 2 and 3 layer in.
+
+### `profiles` (minimal)
+- `id` — `uuid`, PK, references `auth.users(id)` with `onDelete: "cascade"`
+- `displayName` — `text`, not null
+- `createdAt` — `timestamptz`, not null, default `now()`
+
+### `invites` (schema lands in Phase 1; endpoints in Phase 3)
+- `id` — `uuid`, PK, default `gen_random_uuid()`
+- `code` — `text`, unique, not null (12 chars base32, human-readable: `K3JA-9P2F-XQ7M`)
+- `createdBy` — `uuid`, not null, FK to `profiles.id`
+- `note` — `text`, not null (min 10 chars enforced at API layer in Phase 3)
+- `createdAt` — `timestamptz`, not null, default `now()`
+- `expiresAt` — `timestamptz`, not null
+- `redeemedBy` — `uuid`, nullable, FK to `profiles.id`
+- `redeemedAt` — `timestamptz`, nullable
+- `revokedAt` — `timestamptz`, nullable
+
+### `programs`
+- `id` — `uuid`, PK, default `gen_random_uuid()`
+- `slug` — `text`, unique, not null (URL-safe identifier, e.g. `monthly-circle`)
+- `name` — `text`, not null
+- `description` — `text`, nullable
+- `createdAt` — `timestamptz`, not null, default `now()`
+
+### `profilePrograms` (junction)
+- `profileId` — `uuid`, not null, FK to `profiles.id`, `onDelete: "cascade"`
+- `programId` — `uuid`, not null, FK to `programs.id`, `onDelete: "cascade"`
+- `joinedAt` — `timestamptz`, not null, default `now()`
+- Composite PK `(profileId, programId)`
+
+Generate and apply: `npx drizzle-kit generate` → review SQL → commit → `npx drizzle-kit migrate`.
+
+**Note on `profiles.id → auth.users(id)` FK:** Drizzle does not own the `auth.users` table, but the FK can still be declared; generated SQL references `auth.users` directly. Works in both local Supabase and prod.
+
+## Session refresh (`src/middleware.ts` — new, project root)
+
+Thin wrapper that delegates to the existing `src/lib/supabase/middleware.ts` helper. Standard Supabase App Router pattern: refreshes tokens on each request, propagates updated cookies onto the response. Standard `matcher` config excludes `_next/*`, static assets, favicons, and `/api/health`.
+
+## Auth callback (`src/app/auth/callback/route.ts` — new)
+
+GET handler:
+
+1. Read `code` from query string (PKCE).
+2. Call `supabase.auth.exchangeCodeForSession(code)` via the server client.
+3. On success, read the user and idempotently upsert a `profiles` row:
+   - If the row exists → no-op.
+   - If missing → insert with `displayName = user.user_metadata.displayName ?? <email local-part>`.
+   - Uses `ON CONFLICT (id) DO NOTHING`.
+4. Redirect to `/` (or a `next` query param if present and same-origin).
+5. On failure, redirect to `/login?error=<code>`.
+
+The idempotent upsert self-heals the edge case where the callback crashes between auth success and profile insert — the next sign-in just creates the profile.
+
+Phase 3 extends this route to also consume an `invite` query param inside the same transaction.
+
+## Login page (`src/app/login/page.tsx` — new)
+
+Server component shell + client component form. One input (email), submit button. On submit:
+
+```ts
+supabase.auth.signInWithOtp({
+  email,
+  options: { emailRedirectTo: `${origin}/auth/callback` },
+});
+```
+
+Shows a "check your email" state on success. Phase 1 is magic-link-only. Phase 2 extends this page to also accept an optional password (for members who have set one).
+
+## Hono auth middleware (`src/server/api.ts`)
+
+Add middleware that runs on all `/api/*` routes except an explicit public allowlist:
+
+- Extract the Supabase session from request cookies using the server client (same cookie-reading pattern as `src/lib/supabase/server.ts`; Hono reads cookies from `c.req.raw.headers`).
+- No session → `401 { error: "unauthenticated" }`.
+- Session present → `c.set('user', user)`, call `next()`.
+- Public allowlist: `/api/health`.
+- `/api/hello` becomes protected (demo-only, fine to gate).
+
+Introduce `type Variables = { user: SupabaseUser }` and thread through `new Hono<{ Variables: Variables }>()`.
+
+## `/api/me` endpoint
+
+Returns `{ id, email, profile: { id, displayName, createdAt } }`. The `profile` shape is deliberately minimal — Phase 2 expands it to include all community fields along with the sensitive-field access control pattern.
+
+## Protected routing
+
+- **`src/app/page.tsx`** — convert from the existing public client component to a server component that reads the session via the server client.
+  - Unauthenticated → `redirect('/login')`.
+  - Authenticated → render the authed landing page: user email + `displayName` from a direct Drizzle call, a small client component that calls `apiClient.api.me.$get()` to prove the round-trip works, and a sign-out form (server action calling `supabase.auth.signOut()` then `redirect('/login')`).
+
+## apiClient credentials
+
+`src/lib/api.ts` uses Hono RPC. Same-origin browser fetches include cookies by default. Verify during implementation; if the server doesn't see the session cookie, pass `{ credentials: 'include' }` when constructing the client.
+
+## Tests
+
+- **Functional (Vitest):**
+  - Hono auth middleware: unauthenticated → 401; authenticated (mocked server client) → handler runs; `/api/health` reachable without session.
+  - Profile upsert: double-call with same user id → one row, no duplicates, no errors.
+- **E2E (Playwright):**
+  - Unauthenticated visit to `/` → redirects to `/login`.
+  - Unauthenticated `fetch('/api/hello')` → 401.
+  - Full magic-link round-trip test is deferred to Phase 3, which introduces the session-minting helper as part of testing the invite flow.
+
+## Files touched / created
+
+- `src/server/schema.ts` — four tables (profiles minimal)
+- `drizzle/migrations/*` — generated SQL
+- `src/server/profiles.ts` — new: single `upsertProfile(user)` helper
+- `src/middleware.ts` — new
+- `src/app/auth/callback/route.ts` — new
+- `src/app/login/page.tsx` — new
+- `src/app/page.tsx` — converted to authed landing (server component with unauthed redirect)
+- `src/server/api.ts` — auth middleware, `Variables` type, `/api/me`, protect `/api/hello`
+- `tests/functional/auth-middleware.test.ts` — new
+- `tests/functional/profiles.test.ts` — new
+- `tests/e2e/auth-redirect.spec.ts` — new
+- `docs/devjournal.md` — dated entry documenting the phase split and why not RLS
+
+## Verification
+
+1. `npm run dev` (local Supabase + Next.js).
+2. `http://localhost:3000/` → redirects to `/login`.
+3. In Supabase Studio (`http://localhost:54323`), add a user via the auth UI.
+4. "Send magic link" from Studio → email appears in Inbucket (`http://localhost:54324`) → click → lands on `/`.
+5. `/` shows the user's email and freshly-upserted profile (`displayName` = email local-part).
+6. `curl http://localhost:3000/api/hello` (no cookie) → 401.
+7. Same endpoint from the signed-in browser → 200.
+8. `/api/me` returns `{ id, email, profile: { id, displayName, createdAt } }`.
+9. Sign out → back to `/login`.
+10. `npm test` (full suite) green.
+
+## Key files to reference (existing)
+
+- `src/lib/supabase/server.ts:4` — server client factory
+- `src/lib/supabase/client.ts:3` — browser client
+- `src/lib/supabase/middleware.ts:4` — session refresh helper (called by the new root `src/middleware.ts`)
+- `src/server/api.ts:6` — Hono instance (auth middleware goes right after the existing logging middleware at line 8)
+- `src/server/api.ts:19` — existing `/api/hello` (becomes protected)
+- `src/server/api.ts:22` — existing `/api/health` (stays public via allowlist)
+- `src/server/db.ts` — Drizzle connection, unchanged
+- `src/lib/api.ts` — Hono RPC `apiClient`
+- `docs/architecture-appstack.md` — "Supabase — Auth + Managed PostgreSQL" and "Authentication Flow" sections document the contract this plan implements
+- `docs/doc-strategy-committing.md` — expand-contract pattern

--- a/docs/plan-auth-1-plumbing.md
+++ b/docs/plan-auth-1-plumbing.md
@@ -20,6 +20,21 @@ The IS app has Supabase auth helpers scaffolded at `src/lib/supabase/{client,ser
 
 Phase 1 does the minimum needed to prove auth works end-to-end: a user can sign in via magic link, land on `/`, and see their own minimal profile (just `displayName`). The full community profile shape — `bio`, `keywords`, `location`, `emergencyContact`, etc. — is intentionally deferred to Phase 2 so the plumbing PR stays focused on auth wiring.
 
+## Commit plan
+
+This phase lands as a single PR built from six sequential commits. Each commit keeps the app in a working state.
+
+| Commit | Scope | Key changes |
+|--------|-------|-------------|
+| **1a** | Schema + migration | `schema.ts` (4 tables), generated SQL |
+| **1b** | Next.js session-refresh middleware | `src/middleware.ts` (new) |
+| **1c** | Hono auth middleware | `api.ts` middleware, `auth-middleware.test.ts` |
+| **1d** | Auth callback + profile upsert | `auth/callback/route.ts`, `profiles.ts`, `auth-callback.test.ts`, `profiles.test.ts` |
+| **1e** | Login page | `login/page.tsx` |
+| **1f** | Protected home + `/api/me` + E2E | `page.tsx`, `api-me.test.ts`, `auth-redirect.spec.ts` |
+
+Commits 1a–1e are additive; 1f ("tie it all together") depends on all prior commits.
+
 ## Schema (`src/server/schema.ts`)
 
 Four tables, Drizzle `pg-core`. The `profiles` table ships minimal; Phase 2 alters it to add the rich fields. The other three tables are defined here to avoid splintering the initial migration — cheaper than three separate migration rounds as Phases 2 and 3 layer in.
@@ -66,13 +81,16 @@ Thin wrapper that delegates to the existing `src/lib/supabase/middleware.ts` hel
 GET handler:
 
 1. Read `code` from query string (PKCE).
+   - Missing → redirect to `/login?error=missing_code`.
 2. Call `supabase.auth.exchangeCodeForSession(code)` via the server client.
+   - Failure (expired / invalid code) → redirect to `/login?error=exchange_failed`.
 3. On success, read the user and idempotently upsert a `profiles` row:
    - If the row exists → no-op.
-   - If missing → insert with `displayName = user.user_metadata.displayName ?? <email local-part>`.
+   - If missing → insert with `displayName = user.user_metadata.displayName ?? ""`. Phase 3's signup form populates `user_metadata.displayName` via `signInWithOtp({ options: { data: { displayName } } })`; until then, new users get an empty display name.
    - Uses `ON CONFLICT (id) DO NOTHING`.
-4. Redirect to `/` (or a `next` query param if present and same-origin).
-5. On failure, redirect to `/login?error=<code>`.
+   - Database error during upsert → redirect to `/login?error=profile_error`. Session is still valid; next sign-in self-heals via the idempotent upsert.
+4. Redirect to `/`.
+5. All error redirects go to `/login?error=<code>`. The login page renders a human-readable message based on the error code.
 
 The idempotent upsert self-heals the edge case where the callback crashes between auth success and profile insert — the next sign-in just creates the profile.
 
@@ -119,13 +137,34 @@ Returns `{ id, email, profile: { id, displayName, createdAt } }`. The `profile` 
 
 ## Tests
 
-- **Functional (Vitest):**
-  - Hono auth middleware: unauthenticated → 401; authenticated (mocked server client) → handler runs; `/api/health` reachable without session.
-  - Profile upsert: double-call with same user id → one row, no duplicates, no errors.
-- **E2E (Playwright):**
-  - Unauthenticated visit to `/` → redirects to `/login`.
-  - Unauthenticated `fetch('/api/hello')` → 401.
-  - Full magic-link round-trip test is deferred to Phase 3, which introduces the session-minting helper as part of testing the invite flow.
+### Functional (Vitest)
+
+**Commit 1c — `tests/functional/auth-middleware.test.ts`:**
+- Unauthenticated request → 401 `{ error: "unauthenticated" }`.
+- Authenticated request (mocked server client) → handler runs, returns expected response.
+- `/api/health` reachable without session.
+- Allowlist regression guard: explicitly assert that only `/api/health` is public. A new route must not accidentally bypass auth.
+
+**Commit 1d — `tests/functional/auth-callback.test.ts`:**
+- Missing `code` param → redirect to `/login?error=missing_code`.
+- Invalid/expired code (mocked exchange failure) → redirect to `/login?error=exchange_failed`.
+
+**Commit 1d — `tests/functional/profiles.test.ts`:**
+- Profile upsert idempotency: double-call with same user id → one row, no errors.
+
+**Commit 1f — `tests/functional/api-me.test.ts`:**
+- Response shape: validate that `/api/me` returns exactly `{ id, email, profile: { id, displayName, createdAt } }` — no extra fields. Catches accidental field leakage as Phase 2 adds sensitive columns.
+
+### E2E (Playwright)
+
+**Commit 1f — `tests/e2e/auth-redirect.spec.ts`:**
+- Unauthenticated visit to `/` → redirects to `/login`.
+- Unauthenticated `fetch('/api/hello')` → 401.
+- `/api/health` remains accessible without auth (regression guard).
+- Login page renders for unauthenticated users: page loads, email input is visible.
+- Sign-out clears session: after sign-out, `/` redirects to `/login` and `/api/me` returns 401. Uses a lightweight Playwright fixture that mints a session via the Supabase Admin API (pulled forward from the Phase 3 session-minting helper).
+
+Full magic-link round-trip test is deferred to Phase 3, which introduces the full session-minting helper as part of testing the invite flow.
 
 ## Files touched / created
 
@@ -138,7 +177,10 @@ Returns `{ id, email, profile: { id, displayName, createdAt } }`. The `profile` 
 - `src/app/page.tsx` — converted to authed landing (server component with unauthed redirect)
 - `src/server/api.ts` — auth middleware, `Variables` type, `/api/me`, protect `/api/hello`
 - `tests/functional/auth-middleware.test.ts` — new
+- `tests/functional/auth-callback.test.ts` — new
 - `tests/functional/profiles.test.ts` — new
+- `tests/functional/api-me.test.ts` — new
+- `tests/e2e/fixtures/auth.ts` — new: lightweight session-minting fixture (Supabase Admin API)
 - `tests/e2e/auth-redirect.spec.ts` — new
 - `docs/devjournal.md` — dated entry documenting the phase split and why not RLS
 
@@ -148,7 +190,7 @@ Returns `{ id, email, profile: { id, displayName, createdAt } }`. The `profile` 
 2. `http://localhost:3000/` → redirects to `/login`.
 3. In Supabase Studio (`http://localhost:54323`), add a user via the auth UI.
 4. "Send magic link" from Studio → email appears in Inbucket (`http://localhost:54324`) → click → lands on `/`.
-5. `/` shows the user's email and freshly-upserted profile (`displayName` = email local-part).
+5. `/` shows the user's email and freshly-upserted profile (`displayName` = `""` until Phase 3 signup collects it).
 6. `curl http://localhost:3000/api/hello` (no cookie) → 401.
 7. Same endpoint from the signed-in browser → 200.
 8. `/api/me` returns `{ id, email, profile: { id, displayName, createdAt } }`.

--- a/docs/plan-auth-2-profile.md
+++ b/docs/plan-auth-2-profile.md
@@ -1,0 +1,115 @@
+# Plan: Auth Profile Schema Expansion (Phase 2)
+
+Part of a four-phase effort to add authentication and member accounts:
+
+0. [Shared decisions & non-goals](./plan-auth-0.md)
+1. [Plumbing](./plan-auth-1-plumbing.md) — auth wiring, minimal profile, Hono middleware
+2. **Profile schema expansion (this document)** — rich profile fields, sensitive-field access control
+3. [Invites](./plan-auth-3-invites.md) — member-generated invite codes, signup flow
+4. [Member migration](./plan-auth-4-migration.md) — seed ~40 existing members from Google Sheet
+
+Shared decisions (auth method, access control approach, etc.) and deliberate non-goals are documented in [plan-auth-0.md](./plan-auth-0.md).
+
+**Prerequisites:** Phase 1 merged.
+
+---
+
+## Context
+
+Phase 1 created `profiles` with only `id`, `displayName`, and `createdAt` — enough to demo auth end-to-end, not enough to represent a community member. The existing membership is already tracked with a richer shape (pulled from a Google Form): bio, keywords, location, emergency contact, and free-text "live desire," among others. This phase expands the `profiles` table to match, and introduces the serialization-layer access control pattern for sensitive fields.
+
+The underlying table is altered in place (expand step of expand-contract). Columns are added as nullable (or with safe defaults) so existing rows — there will be at most one: yourself, signed in to test Phase 1 — continue to work without backfill.
+
+## Schema changes (`src/server/schema.ts`)
+
+Alter `profiles` to add the following columns. All nullable unless marked otherwise.
+
+- `bio` — `text`, nullable
+- `keywords` — `text[]`, not null, default `{}` (Postgres array; GIN-indexable if search is needed later)
+- `location` — `text`, nullable (approximate free text, not an address — community convention)
+- `supplementaryInfo` — `text`, nullable
+- `referredBy` — `uuid`, nullable, self-FK to `profiles.id` (canonical, populated by invite redemption in Phase 3)
+- `referredByLegacy` — `text`, nullable (free-text "who referred you?" from the existing Google Form; populated for migrated members only, preserves history that is otherwise unrecoverable)
+- `avatarUrl` — `text`, nullable (URL only; image upload UI is out of scope)
+- `emergencyContact` — `text`, nullable (**sensitive PII — see access control note below**)
+- `liveDesire` — `text`, nullable
+- `isAdmin` — `boolean`, not null, default `false`
+
+Generate and apply: `npx drizzle-kit generate` → review the SQL (should be `ALTER TABLE` statements, not `CREATE TABLE`) → commit → `npx drizzle-kit migrate`.
+
+No new tables in this phase — `programs` and `profilePrograms` already exist from Phase 1.
+
+## Sensitive field access control
+
+`emergencyContact` is PII (typically a name and phone number). Since RLS is not the primary mechanism, the Hono API enforces visibility at the serialization layer. Three shapes, all defined in `src/server/profiles.ts`:
+
+- **`getProfileForSelf(userId)`** — includes `emergencyContact`. Used by `/api/me`.
+- **`getProfileForMember(userId)`** — omits `emergencyContact`. Placeholder for a future member-directory endpoint. Not built in this phase.
+- **`getProfileForAdmin(userId)`** — includes `emergencyContact`. Placeholder for future admin tooling. Not built in this phase.
+
+Phase 2 implements only `getProfileForSelf`. The other two shapes are declared with stubs so the access pattern is decided the moment member-directory work starts. The Phase 1 `upsertProfile(user)` helper stays — it still only writes `id` + `displayName`, since no other fields are known at signup time.
+
+## `/api/me` update
+
+Phase 1's `/api/me` returned `{ id, email, profile: { id, displayName, createdAt } }`. Phase 2 swaps the inline shape for `getProfileForSelf(user.id)`, which returns the full profile including `emergencyContact` and a joined list of the member's programs via `profilePrograms` → `programs`.
+
+## `PUT /api/me` endpoint (new)
+
+Authed. Accepts the editable subset of profile fields (`bio`, `keywords`, `location`, `supplementaryInfo`, `avatarUrl`, `emergencyContact`, `liveDesire`). Validates input (e.g. `keywords` is an array of strings) and updates the caller's own profile row. Returns the updated profile via `getProfileForSelf`.
+
+Fields not accepted: `id`, `displayName` (set at signup), `referredBy`, `referredByLegacy`, `isAdmin`, `createdAt`.
+
+## Profile completion flow (`src/app/welcome/page.tsx` — new)
+
+After first sign-in, members land on `/` which detects an incomplete profile (e.g. `bio` is null) and redirects to `/welcome`. This page presents a form to fill in bio, keywords, location, etc. — the same fields accepted by `PUT /api/me`. Submitting saves the profile and redirects to `/`.
+
+The form also includes an **optional password section**: "Set a password for faster sign-in (you can always use magic link instead)." This calls `supabase.auth.updateUser({ password })` client-side — GoTrue handles hashing and storage directly. No new API endpoint needed for password setting.
+
+Members who skip the password section can set one later by signing in via magic link and revisiting `/welcome` (or a future account-settings page).
+
+## Login page update (`src/app/login/page.tsx`)
+
+Phase 1's login page has a single email field and sends a magic link. Phase 2 extends it to dual-mode:
+
+- Email field (always visible).
+- Password field (always visible, but optional). Placeholder text: "Leave blank to use magic link".
+- Single submit button.
+- If password is provided → `supabase.auth.signInWithPassword({ email, password })`. On success → redirect to `/`. On failure (wrong password) → show error, do not fall back to magic link.
+- If password is blank → `supabase.auth.signInWithOtp(...)` → "check your email" state.
+
+No "forgot password?" link. If a member forgets their password, they leave the field blank and sign in via magic link — then set a new password from `/welcome`.
+
+## Tests
+
+- **Functional (Vitest):**
+  - `getProfileForSelf` includes `emergencyContact` (shape guard against accidental omission in future refactors).
+  - `getProfileForMember` does **not** include `emergencyContact` (shape guard for the inverse).
+  - `PUT /api/me` updates only allowed fields; rejects `isAdmin`, `referredBy`.
+  - Existing `upsertProfile` tests still pass — the helper is unchanged.
+- **E2E (Playwright):**
+  - Member with incomplete profile redirected to `/welcome` after sign-in.
+  - Filling out the form and submitting → profile updated, redirected to `/`.
+  - Password field on `/login`: submitting with password → `signInWithPassword` called; submitting without → `signInWithOtp` called.
+
+## Files touched / created
+
+- `src/server/schema.ts` — alter `profiles` (additive column list)
+- `drizzle/migrations/*` — new SQL (expected to be `ALTER TABLE`)
+- `src/server/profiles.ts` — add `getProfileForSelf` + stubs for `getProfileForMember` / `getProfileForAdmin`
+- `src/server/api.ts` — `/api/me` swaps to `getProfileForSelf`; new `PUT /api/me`
+- `src/app/welcome/page.tsx` — new: profile completion + optional password
+- `src/app/login/page.tsx` — extended with optional password field
+- `tests/functional/profiles.test.ts` — extend with access control shape guards + `PUT /api/me` tests
+- `tests/e2e/profile-completion.spec.ts` — new
+
+## Verification
+
+1. `npx drizzle-kit generate` → confirm generated SQL is `ALTER TABLE`, not `CREATE TABLE profiles`.
+2. Apply migration.
+3. Sign in (using the flow from Phase 1).
+4. Redirected to `/welcome` (profile is incomplete).
+5. Fill out the form, set a password, submit → lands on `/`.
+6. `/api/me` now returns the full profile shape with the values just entered.
+7. Sign out. Sign back in with email + password → lands on `/` directly (no `/welcome` redirect — profile is complete).
+8. Sign out. Sign in with email only (blank password) → magic link → click → `/`.
+9. `npm test` green.

--- a/docs/plan-auth-3-invites.md
+++ b/docs/plan-auth-3-invites.md
@@ -1,0 +1,105 @@
+# Plan: Auth Invites (Phase 3)
+
+Part of a four-phase effort to add authentication and member accounts:
+
+0. [Shared decisions & non-goals](./plan-auth-0.md)
+1. [Plumbing](./plan-auth-1-plumbing.md) — auth wiring, minimal profile, Hono middleware
+2. [Profile schema expansion](./plan-auth-2-profile.md) — rich profile fields, sensitive-field access control
+3. **Invites (this document)** — member-generated invite codes, signup flow
+4. [Member migration](./plan-auth-4-migration.md) — seed ~40 existing members from Google Sheet
+
+Shared decisions (auth method, access control approach, etc.) and deliberate non-goals are documented in [plan-auth-0.md](./plan-auth-0.md).
+
+**Prerequisites:** Phases 1 and 2 merged. Phase 2's `profiles.isAdmin` and `profiles.referredBy` columns are required.
+
+---
+
+## Context
+
+Phase 2 ends with a complete profile schema, but the only way to create a user is still manual Studio work. This phase adds the invite-code flow so any signed-in member can bring in new members, and the full profile (`displayName`, `referredBy`) is captured atomically on first sign-in.
+
+Signup is always via magic link — this eliminates the need for a separate email-confirmation step. New members can optionally set a password afterward via the Phase 2 profile completion flow at `/welcome`.
+
+The `invites` table itself already exists from Phase 1 — only the endpoints, UI, and redemption logic are new here.
+
+## Hono endpoints (`src/server/api.ts`)
+
+- **`POST /api/invites`** — authed. Body: `{ note: string }` (min 10 chars). Enforces the 10-active-invite cap for `createdBy`. Generates code, inserts row, `expiresAt = now() + interval '30 days'`. Returns `{ code, expiresAt, note }`.
+- **`GET /api/invites/mine`** — authed. Returns all invites created by the current user (active, redeemed, expired, revoked) so members can see their history.
+- **`POST /api/invites/:code/revoke`** — authed. Allowed if `createdBy === currentUser || currentUser.isAdmin`. Sets `revokedAt`.
+- **`GET /api/invites/:code/check`** — **public** (added to the allowlist). Returns `{ valid: boolean, note?: string }` without consuming the code. Used by `/signup` to give feedback before asking for email.
+
+## Redemption flow — atomic, inside `/auth/callback`
+
+The invite code has to survive the magic-link round-trip. Flow:
+
+1. `/signup`: user enters code → `GET /api/invites/:code/check` validates → user sees the note (context of who/why) → enters email + display name → client calls:
+   ```ts
+   supabase.auth.signInWithOtp({
+     email,
+     options: {
+       emailRedirectTo: `${origin}/auth/callback?invite=${code}`,
+       data: { displayName },
+     },
+   });
+   ```
+2. User clicks the magic link → lands on `/auth/callback?code=<pkce>&invite=<code>`.
+3. Callback exchanges PKCE → gets user → inside `db.transaction`:
+   - Atomic redemption:
+     ```sql
+     UPDATE invites
+     SET redeemed_by = $userId, redeemed_at = now()
+     WHERE code = $code
+       AND redeemed_by IS NULL
+       AND revoked_at IS NULL
+       AND expires_at > now()
+     RETURNING created_by;
+     ```
+   - `rowcount = 0` → code was consumed/revoked/expired between check and click. Sign the user out, redirect to `/login?error=invite_invalid`.
+   - `rowcount = 1` → insert profile with `displayName` from `user_metadata`, `referredBy` from the returned `created_by`.
+   - Both writes in one transaction: either both land or neither does.
+4. No `invite` query param → the existing Phase 1 upsert runs, `referredBy` stays null.
+
+## Signup page (`src/app/signup/page.tsx` — new)
+
+Two-step client form:
+1. Enter code → check → display the inviter's note → continue.
+2. Enter email + display name → send magic link → "check your email".
+
+## `/` additions (authed view)
+
+- **Invite a member** panel: button opens a modal that asks for a note (min 10 chars), submits via `POST /api/invites`, displays the generated code with a copy button.
+- **My invites** table: lists current user's invites with status (active / expired / redeemed / revoked) and a revoke button on active rows.
+
+## Playwright session-minting helper
+
+`tests/e2e/helpers/session.ts` — new. Uses `@supabase/supabase-js` with the local service-role key to:
+1. Create a test user via `supabase.auth.admin.createUser({ email, email_confirm: true })`.
+2. Generate a session directly (or use `generateLink({ type: 'magiclink' })` and consume it server-side).
+3. Set the session cookie on the Playwright browser context so the test starts authenticated.
+
+Teardown deletes the test user. This helper unblocks all subsequent e2e tests that need an authed starting state.
+
+## Tests
+
+- **Functional (Vitest):**
+  - Invite generation: 10-active cap is enforced (11th request → 429).
+  - Invite check: correct `valid` result for each state (active / expired / revoked / redeemed / nonexistent).
+  - Atomic redemption under contention: two concurrent transactions redeeming the same code → exactly one succeeds. Use `Promise.all` over two tx wrappers, assert exactly one returns a row.
+  - Revoke permission: non-admin, non-creator request → 403.
+- **E2E (Playwright):**
+  - Using the session-minting helper: authed member lands on `/`, generates an invite, sees it in "My invites".
+  - Unauthed visitor enters code on `/signup`, sees note, submits email → stubbed `signInWithOtp` succeeds → UI shows "check your email".
+  - Full magic-link click-through is still not e2e-tested; covered by developer sign-in during manual QA.
+
+## Verification
+
+1. Signed in as a member: create an invite with a note. Copy the code.
+2. Sign out. Visit `/signup`. Enter the code — note is displayed.
+3. Enter email + display name → "check your email".
+4. Grab the magic link from Inbucket → click → lands on `/` as the new user.
+5. The new user's profile has `displayName` set and `referredBy` pointing at the inviter.
+6. Try to reuse the same code from another browser → "invite invalid".
+7. Create 10 invites in quick succession → 11th fails with a rate limit error.
+8. Revoke an active invite → it disappears from the active filter and can't be redeemed.
+9. `npm test` green.

--- a/docs/plan-auth-3-invites.md
+++ b/docs/plan-auth-3-invites.md
@@ -56,7 +56,7 @@ The invite code has to survive the magic-link round-trip. Flow:
      RETURNING created_by;
      ```
    - `rowcount = 0` → code was consumed/revoked/expired between check and click. Sign the user out, redirect to `/login?error=invite_invalid`.
-   - `rowcount = 1` → insert profile with `displayName` from `user_metadata`, `referredBy` from the returned `created_by`.
+   - `rowcount = 1` → insert profile with `displayName` from `user_metadata` (set by the signup form via `options.data`), `referredBy` from the returned `created_by`.
    - Both writes in one transaction: either both land or neither does.
 4. No `invite` query param → the existing Phase 1 upsert runs, `referredBy` stays null.
 

--- a/docs/plan-auth-4-migration.md
+++ b/docs/plan-auth-4-migration.md
@@ -1,0 +1,95 @@
+# Plan: Auth Member Migration (Phase 4)
+
+Part of a four-phase effort to add authentication and member accounts:
+
+0. [Shared decisions & non-goals](./plan-auth-0.md)
+1. [Plumbing](./plan-auth-1-plumbing.md) — auth wiring, minimal profile, Hono middleware
+2. [Profile schema expansion](./plan-auth-2-profile.md) — rich profile fields, sensitive-field access control
+3. [Invites](./plan-auth-3-invites.md) — member-generated invite codes, signup flow
+4. **Member migration (this document)** — seed ~40 existing members from Google Sheet
+
+Shared decisions (auth method, access control approach, etc.) and deliberate non-goals are documented in [plan-auth-0.md](./plan-auth-0.md).
+
+**Prerequisites:** Phases 1, 2, and 3 merged. Phase 2's rich profile columns (`bio`, `keywords`, `emergencyContact`, `liveDesire`, etc.) are the target shape for the seed script.
+
+---
+
+## Context
+
+Phase 3 ends with a working invite-driven signup flow for new members. This phase onboards the ~40 members who were previously tracked in a Google Form, using the Supabase Admin API to create their accounts directly (bypassing invite codes) and populating their profiles from the exported sheet.
+
+## Program seed (`scripts/programs.seed.json` — new)
+
+Committed JSON file, the source of truth for the curated program list:
+
+```json
+[
+  { "slug": "monthly-circle", "name": "Monthly Circle", "description": "..." },
+  { "slug": "book-club", "name": "Book Club", "description": "..." }
+]
+```
+
+An idempotent seed function upserts these by `slug`. Run as the first step of the migration, before the member seed. Also safe to run on every deploy if programs are ever added by PR.
+
+## Member seed script (`scripts/seed-members.ts` — new)
+
+Reads `scripts/members.csv` (gitignored — real emails and PII). Expected column headers (final names documented in the runbook once the sheet is exported):
+
+```
+email, name, bio, keywords, location, supplementary_info,
+referred_by, avatar_url, emergency_contact, live_desire, programs
+```
+
+- `keywords` — comma-separated string → `text[]`.
+- `programs` — comma-separated slugs matching `programs.seed.json` → `profilePrograms` rows.
+- `referred_by` — free text from the Google Form → `referredByLegacy`. `referredBy` (uuid FK) stays null for migrated members.
+
+Flow per row:
+1. Check if email already exists in `auth.users` (via `supabase.auth.admin.listUsers`). If yes, skip.
+2. `supabase.auth.admin.inviteUserByEmail(email)` with `SUPABASE_SERVICE_ROLE_KEY`. This creates the `auth.users` row and sends an invitation email containing a magic link.
+3. Insert `profiles` row with all fields from the CSV.
+4. Insert `profilePrograms` rows for each matching program.
+
+Flags:
+- `--dry-run` — prints intent, no writes, no email sends.
+- `--limit N` — only process the first N rows (staged rollout).
+- `--skip-email` — creates `auth.users` + `profiles` rows without sending invitation emails (staging).
+
+Output: `{ created, skipped, failed, errors }`.
+
+## First-admin bootstrap
+
+After the seed runs and you've confirmed sign-in works, one-off SQL:
+
+```sql
+UPDATE profiles SET is_admin = true
+WHERE id = (SELECT id FROM auth.users WHERE email = 'you@example.com');
+```
+
+Documented in `docs/doc-seed-members.md`. Not automated — runs once per environment, and automating it would add config surface (`ADMIN_EMAILS` env var) that is easy to get wrong.
+
+## Environment
+
+New env var: **`SUPABASE_SERVICE_ROLE_KEY`**. Never exposed client-side. Only used by `scripts/*` and any admin-only server code. Added to:
+- `.env.local.example`
+- `npm run setup` (local Supabase prints the key in `supabase status`)
+- `docs/doc-vercel.md` — note that production **does not** need this key; it is only used for one-time migrations from a developer machine
+- `CLAUDE.md` Commands section — `npm run seed:programs`, `npm run seed:members`
+
+## Docs
+
+- `docs/doc-seed-members.md` (new) — operator runbook: exact CSV column names, how to export from Google Sheets, dry-run instructions, interpreting output, how to roll back a bad row (delete from `auth.users` — Supabase cascades).
+- `docs/devjournal.md` — dated entry documenting the migration.
+- `CLAUDE.md` — seeds mentioned in the Commands section.
+
+## Verification
+
+1. Export the Google Sheet to `scripts/members.csv` (local only, gitignored).
+2. `npm run seed:programs` → curated program rows created.
+3. `npm run seed:members -- --dry-run --limit 3` → prints intent for 3 rows.
+4. `npm run seed:members -- --limit 3` → creates 3 `auth.users`, 3 `profiles`, matching `profilePrograms`. Emails appear in Inbucket.
+5. Re-run step 4 → `skipped: 3` (idempotency).
+6. Open one invitation email → click → lands on `/` as that member. Profile fully populated; `emergencyContact` visible on `/api/me`.
+7. `npm run seed:members` (no limit) → all 40 members seeded.
+8. Flag yourself admin via the SQL above. Sign back in. Verify `isAdmin: true` on `/api/me`.
+9. `npm test` green.

--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,3 @@
-{}
+{
+  "buildCommand": "if [ \"$VERCEL_ENV\" = \"production\" ]; then npx drizzle-kit migrate; fi && next build"
+}


### PR DESCRIPTION
## Summary
- Four-phase auth plan docs (Phase 0 shared decisions, Phases 1–4) for team review, plus a 6-commit breakdown for Phase 1 (plumbing) with expanded tests and error paths
- Vercel build command now runs `drizzle-kit migrate` before `next build` on production deploys only (gated by `VERCEL_ENV`), with failure aborting the deploy so the previous build keeps serving traffic
- Committing strategy doc now explains how each expand-contract phase is verified on this stack, including using the TypeScript compiler to catch stray references during the contract phase

## Test plan
- [ ] Review the four-phase auth plan docs and the Phase 1 commit breakdown
- [ ] Confirm `vercel.json` build command matches what's in the Vercel dashboard (clear any conflicting dashboard override)
- [ ] On next production deploy, confirm build logs show `drizzle-kit migrate` running before `next build`
- [ ] On next preview deploy, confirm build logs show migration step is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)