### PR TITLE
Commit empty Drizzle migration journal

### DIFF
--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,1 @@
+{"version":"7","dialect":"postgresql","entries":[]}


### PR DESCRIPTION
## Summary
- `drizzle-kit migrate` exits 1 with no error output when `drizzle/meta/_journal.json` is missing, which broke the first production deploy that tried to run it after PR #13 landed
- Committing the empty journal (generated by `drizzle-kit generate` with no schema) turns the migrate step back into a clean no-op
- Production was never actually broken — the failed build aborted before `next build` and the previous deploy kept serving traffic, which is the safety property we added in PR #13 working as designed

## Test plan
- [ ] Reproduced locally: `npx drizzle-kit migrate` exit 1 without the journal, exit 0 with it
- [ ] On merge, confirm the production deploy build log shows `migrations applied successfully!` and `next build` runs
- [ ] Confirm production is serving the new build after the deploy completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)