### PR TITLE
Add profiles and invites schema (auth phase 1a)

### DIFF
--- a/docs/plan-auth-1-plumbing.md
+++ b/docs/plan-auth-1-plumbing.md
@@ -26,7 +26,7 @@ This phase lands as a single PR built from six sequential commits. Each commit k
 
 | Commit | Scope | Key changes |
 |--------|-------|-------------|
-| **1a** | Schema + migration | `schema.ts` (4 tables), generated SQL |
+| **1a** | Schema + migration | `schema.ts` (2 tables), generated SQL |
 | **1b** | Next.js session-refresh middleware | `src/middleware.ts` (new) |
 | **1c** | Hono auth middleware | `api.ts` middleware, `auth-middleware.test.ts` |
 | **1d** | Auth callback + profile upsert | `auth/callback/route.ts`, `profiles.ts`, `auth-callback.test.ts`, `profiles.test.ts` |
@@ -37,36 +37,26 @@ Commits 1a–1e are additive; 1f ("tie it all together") depends on all prior co
 
 ## Schema (`src/server/schema.ts`)
 
-Four tables, Drizzle `pg-core`. The `profiles` table ships minimal; Phase 2 alters it to add the rich fields. The other three tables are defined here to avoid splintering the initial migration — cheaper than three separate migration rounds as Phases 2 and 3 layer in.
+Two tables, Drizzle `pg-core`. The `profiles` table ships minimal; Phase 2 alters it to add the rich fields. `invites` lands here too (endpoints in Phase 3) to keep the initial migration coherent. `programs` and `profilePrograms` are deferred to a dedicated micro-PR when a later phase actually needs them.
 
 ### `profiles` (minimal)
-- `id` — `uuid`, PK, references `auth.users(id)` with `onDelete: "cascade"`
-- `displayName` — `text`, not null
+- `id` — `uuid`, PK, references `auth.users(id)` (no cascade: members leave relational traces, so profile rows persist after a Supabase user is deleted; GDPR "forget me" is handled later via anonymization)
+- `displayName` — `text`, nullable (explicit "not yet collected" state until Phase 3 signup collects it)
 - `createdAt` — `timestamptz`, not null, default `now()`
+- `updatedAt` — `timestamptz`, not null, default `now()`, auto-updated via Drizzle `.$onUpdate(() => new Date())`
 
 ### `invites` (schema lands in Phase 1; endpoints in Phase 3)
 - `id` — `uuid`, PK, default `gen_random_uuid()`
 - `code` — `text`, unique, not null (12 chars base32, human-readable: `K3JA-9P2F-XQ7M`)
-- `createdBy` — `uuid`, not null, FK to `profiles.id`
+- `createdBy` — `uuid`, nullable, FK to `profiles.id`, `onDelete: "set null"` (preserves invite audit history after member deletion)
 - `note` — `text`, not null (min 10 chars enforced at API layer in Phase 3)
 - `createdAt` — `timestamptz`, not null, default `now()`
 - `expiresAt` — `timestamptz`, not null
-- `redeemedBy` — `uuid`, nullable, FK to `profiles.id`
+- `redeemedBy` — `uuid`, nullable, FK to `profiles.id`, `onDelete: "set null"`
 - `redeemedAt` — `timestamptz`, nullable
 - `revokedAt` — `timestamptz`, nullable
-
-### `programs`
-- `id` — `uuid`, PK, default `gen_random_uuid()`
-- `slug` — `text`, unique, not null (URL-safe identifier, e.g. `monthly-circle`)
-- `name` — `text`, not null
-- `description` — `text`, nullable
-- `createdAt` — `timestamptz`, not null, default `now()`
-
-### `profilePrograms` (junction)
-- `profileId` — `uuid`, not null, FK to `profiles.id`, `onDelete: "cascade"`
-- `programId` — `uuid`, not null, FK to `programs.id`, `onDelete: "cascade"`
-- `joinedAt` — `timestamptz`, not null, default `now()`
-- Composite PK `(profileId, programId)`
+- CHECK constraint: `(redeemed_by IS NULL) = (redeemed_at IS NULL)` — prevents half-redeemed states from API-layer bugs
+- CHECK constraint: `expires_at > created_at` — catches bad writes at the DB boundary
 
 Generate and apply: `npx drizzle-kit generate` → review SQL → commit → `npx drizzle-kit migrate`.
 
@@ -86,7 +76,7 @@ GET handler:
    - Failure (expired / invalid code) → redirect to `/login?error=exchange_failed`.
 3. On success, read the user and idempotently upsert a `profiles` row:
    - If the row exists → no-op.
-   - If missing → insert with `displayName = user.user_metadata.displayName ?? ""`. Phase 3's signup form populates `user_metadata.displayName` via `signInWithOtp({ options: { data: { displayName } } })`; until then, new users get an empty display name.
+   - If missing → insert with `displayName = user.user_metadata.displayName ?? null`. Phase 3's signup form populates `user_metadata.displayName` via `signInWithOtp({ options: { data: { displayName } } })`; until then, new users get a null display name.
    - Uses `ON CONFLICT (id) DO NOTHING`.
    - Database error during upsert → redirect to `/login?error=profile_error`. Session is still valid; next sign-in self-heals via the idempotent upsert.
 4. Redirect to `/`.
@@ -168,7 +158,7 @@ Full magic-link round-trip test is deferred to Phase 3, which introduces the ful
 
 ## Files touched / created
 
-- `src/server/schema.ts` — four tables (profiles minimal)
+- `src/server/schema.ts` — two tables (profiles minimal + invites)
 - `drizzle/migrations/*` — generated SQL
 - `src/server/profiles.ts` — new: single `upsertProfile(user)` helper
 - `src/middleware.ts` — new
@@ -190,7 +180,7 @@ Full magic-link round-trip test is deferred to Phase 3, which introduces the ful
 2. `http://localhost:3000/` → redirects to `/login`.
 3. In Supabase Studio (`http://localhost:54323`), add a user via the auth UI.
 4. "Send magic link" from Studio → email appears in Inbucket (`http://localhost:54324`) → click → lands on `/`.
-5. `/` shows the user's email and freshly-upserted profile (`displayName` = `""` until Phase 3 signup collects it).
+5. `/` shows the user's email and freshly-upserted profile (`displayName` = `null` until Phase 3 signup collects it).
 6. `curl http://localhost:3000/api/hello` (no cookie) → 401.
 7. Same endpoint from the signed-in browser → 200.
 8. `/api/me` returns `{ id, email, profile: { id, displayName, createdAt } }`.

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   schema: "./src/server/schema.ts",
   out: "./drizzle",
   dialect: "postgresql",
+  schemaFilter: ["public"],
   dbCredentials: {
     url: process.env.DATABASE_URL!,
   },

--- a/drizzle/0000_known_sage.sql
+++ b/drizzle/0000_known_sage.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "invites" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"code" text NOT NULL,
+	"created_by" uuid,
+	"note" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"redeemed_by" uuid,
+	"redeemed_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	CONSTRAINT "invites_code_unique" UNIQUE("code"),
+	CONSTRAINT "invites_redemption_pair" CHECK (("invites"."redeemed_by" IS NULL) = ("invites"."redeemed_at" IS NULL)),
+	CONSTRAINT "invites_expires_after_created" CHECK ("invites"."expires_at" > "invites"."created_at")
+);
+--> statement-breakpoint
+CREATE TABLE "profiles" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"display_name" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "invites" ADD CONSTRAINT "invites_created_by_profiles_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."profiles"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invites" ADD CONSTRAINT "invites_redeemed_by_profiles_id_fk" FOREIGN KEY ("redeemed_by") REFERENCES "public"."profiles"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "profiles" ADD CONSTRAINT "profiles_id_users_id_fk" FOREIGN KEY ("id") REFERENCES "auth"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,186 @@
+{
+  "id": "0f8ae865-dc57-4181-83ca-02e49e3b388a",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by": {
+          "name": "redeemed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_profiles_id_fk": {
+          "name": "invites_created_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_profiles_id_fk": {
+          "name": "invites_redeemed_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "redeemed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_redemption_pair": {
+          "name": "invites_redemption_pair",
+          "value": "(\"invites\".\"redeemed_by\" IS NULL) = (\"invites\".\"redeemed_at\" IS NULL)"
+        },
+        "invites_expires_after_created": {
+          "name": "invites_expires_after_created",
+          "value": "\"invites\".\"expires_at\" > \"invites\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,1 +1,13 @@
-{"version":"7","dialect":"postgresql","entries":[]}
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1776217861222,
+      "tag": "0000_known_sage",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -1,3 +1,62 @@
-// Drizzle schema definitions go here.
-// Example:
-// import { pgTable, text, uuid, timestamp } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import {
+  check,
+  pgSchema,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+// Supabase's auth.users table — referenced for FK purposes only.
+// drizzle-kit is configured with schemaFilter: ["public"] so it will
+// not attempt to create or alter this table.
+const authSchema = pgSchema("auth");
+const authUsers = authSchema.table("users", {
+  id: uuid("id").primaryKey(),
+});
+
+export const profiles = pgTable("profiles", {
+  id: uuid("id")
+    .primaryKey()
+    .references(() => authUsers.id),
+  displayName: text("display_name"),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+});
+
+export const invites = pgTable(
+  "invites",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    code: text("code").notNull().unique(),
+    createdBy: uuid("created_by").references(() => profiles.id, {
+      onDelete: "set null",
+    }),
+    note: text("note").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    redeemedBy: uuid("redeemed_by").references(() => profiles.id, {
+      onDelete: "set null",
+    }),
+    redeemedAt: timestamp("redeemed_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+  },
+  (table) => [
+    check(
+      "invites_redemption_pair",
+      sql`(${table.redeemedBy} IS NULL) = (${table.redeemedAt} IS NULL)`,
+    ),
+    check(
+      "invites_expires_after_created",
+      sql`${table.expiresAt} > ${table.createdAt}`,
+    ),
+  ],
+);


### PR DESCRIPTION
## Summary
- First real Drizzle migration — two tables (`profiles`, `invites`) supporting the phase 1 auth plumbing
- Plan doc refinements that this schema implements (nullable displayName, no cascade on auth.users FK, updatedAt up front, set-null invite FKs, CHECK constraints, deferred programs)
- `drizzle.config.ts` gets `schemaFilter: ["public"]` so drizzle-kit ignores Supabase's `auth` schema

## Notable decisions
- **`profiles.id → auth.users(id)`** uses no-action (not cascade). Members leave relational traces, so profile rows persist after a Supabase user is deleted; GDPR erasure will be handled later via anonymization.
- **`profiles.displayName` is nullable.** Explicit "not yet collected" state, avoiding an empty-string sentinel until phase 3 signup collects it.
- **`profiles.updatedAt` added now** (auto-updated via Drizzle `$onUpdate`) to avoid a backfill when phase 2 expands the profile schema.
- **`invites.createdBy` / `redeemedBy`** both use `ON DELETE SET NULL` to preserve audit history after member deletion.
- **Two CHECK constraints on `invites`**: `(redeemed_by IS NULL) = (redeemed_at IS NULL)` prevents half-redeemed states; `expires_at > created_at` catches bad writes.
- **`programs` / `profilePrograms` deferred** to a micro-PR when a later phase actually needs them, keeping 1a focused.

## Test plan
- [x] `npx drizzle-kit generate` produces expected SQL (2 tables, 2 FKs with SET NULL, 2 CHECKs, `auth.users` FK as no-action)
- [x] `npx drizzle-kit migrate` applies cleanly against local Supabase
- [x] `docker exec ... psql \d` confirms table shapes, FK actions, CHECK constraints, and defaults match the plan
- [x] `npm run lint` clean
- [x] `npm test` green (vitest + playwright)
- [x] Vercel preview deploy succeeds (migration runs during production build only — preview build should still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)