### PR TITLE
Record migration-before-build guarantee in devjournal

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-04-14 | James | Drizzle migrations run in Vercel production build
+
+Every production deploy now runs `drizzle-kit migrate` before `next build` (gated on `VERCEL_ENV=production` in `vercel.json`), and a failed migration aborts the deploy with the previous build still serving traffic. Preview deploys skip the migration and continue to hit the prod DB unchanged. See `docs/doc-strategy-committing.md` for the expand-contract verification recipe that builds on this guarantee.
+
 ## 2026-04-07 | James | Observability: Sentry + Axiom
 
 Sentry for error tracking, performance traces, and session replay. Axiom for structured request logs via Vercel Log Drain + next-axiom. Hono middleware logs method, path, status, and duration on every API request.


### PR DESCRIPTION
## Summary
- Single devjournal entry documenting that Drizzle migrations run before `next build` on production deploys (`drizzle-kit migrate && next build`, gated by `VERCEL_ENV`)

## Test plan
- [x] Docs-only change — no code, no tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)