### PR TITLE
Add root session-refresh middleware (auth phase 1b)

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -29,3 +29,9 @@ export const createClient = (request: NextRequest) => {
 
   return { supabase, response: supabaseResponse };
 };
+
+export const updateSession = async (request: NextRequest) => {
+  const { supabase, response } = createClient(request);
+  await supabase.auth.getUser();
+  return response;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from "next/server";
+
+import { updateSession } from "@/lib/supabase/middleware";
+
+export async function middleware(request: NextRequest) {
+  return await updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|api/health|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary
- New `src/middleware.ts` (project root) — thin wrapper that calls `updateSession` on every matched request so Supabase auth cookies stay fresh
- `src/lib/supabase/middleware.ts` gains an `updateSession` export (6 lines) that calls `createClient` + `auth.getUser()` + returns response; the existing `createClient` export previously only built a cookie-aware client without actually triggering refresh
- Matcher excludes `_next/static`, `_next/image`, `favicon.ico`, `api/health`, and common image extensions — standard Supabase App Router pattern plus the `api/health` carve-out so the public healthcheck stays middleware-free

## Why the helper expansion
The plan text ("thin wrapper that delegates to the existing helper") implied the helper already did the refresh work, but it only wired up cookie callbacks — `auth.getUser()` is what actually triggers Supabase to write fresh cookies through `setAll`. Adding `updateSession` to the helper keeps the root middleware a one-liner and matches Supabase's own App Router examples.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` green (existing home-page E2E now flows through the new middleware and still passes)
- [ ] Manual smoke on Vercel preview: `/api/health` reachable, `/` loads, and unauthenticated `/` behavior unchanged (auth redirects come in 1f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)