### PR TITLE
Add auth callback route and profile upsert (auth phase 1d)

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { createClient } from "@/lib/supabase/server";
+import { upsertProfile } from "@/server/profiles";
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get("code");
+  if (!code) {
+    return NextResponse.redirect(
+      new URL("/login?error=missing_code", request.url),
+    );
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+  if (error || !data.user) {
+    return NextResponse.redirect(
+      new URL("/login?error=exchange_failed", request.url),
+    );
+  }
+
+  try {
+    await upsertProfile(data.user);
+  } catch {
+    // Session is still valid; next sign-in self-heals via the
+    // idempotent upsert.
+    return NextResponse.redirect(
+      new URL("/login?error=profile_error", request.url),
+    );
+  }
+
+  return NextResponse.redirect(new URL("/", request.url));
+}

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -1,0 +1,14 @@
+import type { User } from "@supabase/supabase-js";
+
+import { db } from "./db";
+import { profiles } from "./schema";
+
+export const upsertProfile = async (user: User) => {
+  const displayName =
+    (user.user_metadata?.displayName as string | undefined) ?? null;
+
+  await db
+    .insert(profiles)
+    .values({ id: user.id, displayName })
+    .onConflictDoNothing({ target: profiles.id });
+};

--- a/tests/functional/auth-callback.test.ts
+++ b/tests/functional/auth-callback.test.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@/server/profiles", () => ({
+  upsertProfile: vi.fn(),
+}));
+
+import { GET } from "@/app/auth/callback/route";
+import { createClient } from "@/lib/supabase/server";
+
+const mockCreateClient = vi.mocked(createClient);
+
+const makeRequest = (path: string) =>
+  new NextRequest(new URL(path, "http://testfake.local"));
+
+describe("GET /auth/callback", () => {
+  beforeEach(() => {
+    mockCreateClient.mockReset();
+  });
+
+  it("redirects to /login?error=missing_code when the code query param is absent", async () => {
+    const res = await GET(makeRequest("/auth/callback"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "http://testfake.local/login?error=missing_code",
+    );
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /login?error=exchange_failed when exchangeCodeForSession errors", async () => {
+    mockCreateClient.mockResolvedValue({
+      auth: {
+        exchangeCodeForSession: vi.fn().mockResolvedValue({
+          data: { user: null, session: null },
+          error: { message: "expired", status: 400 },
+        }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const res = await GET(makeRequest("/auth/callback?code=bad-code"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "http://testfake.local/login?error=exchange_failed",
+    );
+  });
+});

--- a/tests/functional/auth-middleware.test.ts
+++ b/tests/functional/auth-middleware.test.ts
@@ -5,12 +5,6 @@ vi.mock("@supabase/ssr", () => ({
   createServerClient: vi.fn(),
 }));
 
-vi.mock("@/server/db", () => ({
-  db: {
-    execute: vi.fn().mockResolvedValue([{ server_time: "2026-01-01T00:00:00Z" }]),
-  },
-}));
-
 import { createServerClient } from "@supabase/ssr";
 
 import app from "@/server/api";

--- a/tests/functional/profiles.test.ts
+++ b/tests/functional/profiles.test.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from "node:crypto";
+
+import type { User } from "@supabase/supabase-js";
+import { eq, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { db } from "@/server/db";
+import { upsertProfile } from "@/server/profiles";
+import { profiles } from "@/server/schema";
+
+describe("upsertProfile", () => {
+  let testUserId: string;
+
+  beforeEach(async () => {
+    testUserId = randomUUID();
+    // auth.users owns the FK target; insert a minimal row so the
+    // profiles FK constraint is satisfied. is_sso_user / is_anonymous
+    // are NOT NULL in Supabase's schema even though they have defaults.
+    await db.execute(
+      sql`INSERT INTO auth.users (id, is_sso_user, is_anonymous) VALUES (${testUserId}::uuid, false, false)`,
+    );
+  });
+
+  afterEach(async () => {
+    await db.delete(profiles).where(eq(profiles.id, testUserId));
+    await db.execute(
+      sql`DELETE FROM auth.users WHERE id = ${testUserId}::uuid`,
+    );
+  });
+
+  it("is idempotent across repeated calls for the same user", async () => {
+    const user = {
+      id: testUserId,
+      user_metadata: { displayName: "Test User" },
+      app_metadata: {},
+      aud: "authenticated",
+      created_at: "2026-01-01T00:00:00Z",
+    } as User;
+
+    await upsertProfile(user);
+    await upsertProfile(user);
+
+    const rows = await db
+      .select()
+      .from(profiles)
+      .where(eq(profiles.id, testUserId));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.displayName).toBe("Test User");
+  });
+
+  it("stores a null displayName when user_metadata is empty", async () => {
+    const user = {
+      id: testUserId,
+      user_metadata: {},
+      app_metadata: {},
+      aud: "authenticated",
+      created_at: "2026-01-01T00:00:00Z",
+    } as User;
+
+    await upsertProfile(user);
+
+    const rows = await db
+      .select()
+      .from(profiles)
+      .where(eq(profiles.id, testUserId));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.displayName).toBeNull();
+  });
+});

--- a/tests/functional/setup.ts
+++ b/tests/functional/setup.ts
@@ -1,0 +1,3 @@
+import { config } from "dotenv";
+
+config({ path: ".env.local" });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     root: ".",
     exclude: ["tests/e2e/**", "node_modules/**"],
+    setupFiles: ["tests/functional/setup.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- `src/app/auth/callback/route.ts` — new PKCE callback handler (read `code` → `exchangeCodeForSession` → `upsertProfile` → `/`)
- `src/server/profiles.ts` — new `upsertProfile(user)` helper using `ON CONFLICT (id) DO NOTHING`
- `tests/functional/profiles.test.ts` — first real-DB test; inserts minimal `auth.users` row via raw SQL, runs the upsert twice, asserts one row, cleans up
- `tests/functional/auth-callback.test.ts` — mocked client; missing `code` and exchange-failure redirects
- `tests/functional/setup.ts` + `vitest.config.ts` — loads `.env.local` so real-DB tests work
- `tests/functional/auth-middleware.test.ts` — drops the `@/server/db` mock added in 1c; `/api/health` now exercises real Drizzle

## Notable decisions
- **Error redirects land at `/login?error=<code>`** even though the login page (1e) doesn't exist yet — those paths 404 until 1e merges. Consistent with the plan's "1a–1e are additive" framing.
- **Idempotency self-heals the split-brain case:** if the callback crashes between auth success and profile insert, the next sign-in just creates the profile. No partial-state recovery path needed.
- **Real DB over mocks for `profiles.test.ts`:** the point of the test is the `ON CONFLICT` behavior, and mocking Drizzle would only verify we called the right API — much weaker. Inserts a minimal `auth.users` row directly via raw SQL (`INSERT INTO auth.users (id, is_sso_user, is_anonymous) VALUES (..., false, false)`) to satisfy the FK. Avoids pulling in the service-role key / Supabase admin client at this layer — that's 1f's concern for session-minting.
- **Synthetic origin `http://testfake.local`** in `auth-callback.test.ts` to make clear the test is in-process; no port, no server, no confusion with the dev-server 3000 / e2e 3093 conventions.
- **Dotenv wiring is a one-time investment** — every later DB-touching test now Just Works without per-test boilerplate.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test:functional` — 8/8 (4 auth-middleware + 2 auth-callback + 2 profiles real-DB)
- [x] `npm run test:e2e` — home page still passes
- [ ] Vercel preview: visit `/auth/callback` without a code → redirects to `/login?error=missing_code` (login page 404s, as expected until 1e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)