### PR TITLE
Add magic-link login page (auth phase 1e)

### DIFF
--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+
+type FormState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | { status: "sent"; email: string }
+  | { status: "error"; message: string };
+
+export function LoginForm() {
+  const [email, setEmail] = useState("");
+  const [state, setState] = useState<FormState>({ status: "idle" });
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setState({ status: "submitting" });
+
+    const supabase = createClient();
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+
+    if (error) {
+      setState({ status: "error", message: error.message });
+      return;
+    }
+
+    setState({ status: "sent", email });
+  };
+
+  if (state.status === "sent") {
+    return (
+      <p className="max-w-sm text-center text-sm text-gray-300">
+        Check <span className="font-semibold">{state.email}</span> for a
+        sign-in link.
+      </p>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex w-full max-w-sm flex-col gap-3"
+    >
+      <label htmlFor="email" className="text-sm text-gray-300">
+        Email
+      </label>
+      <input
+        id="email"
+        type="email"
+        required
+        autoComplete="email"
+        value={email}
+        onChange={(event) => setEmail(event.target.value)}
+        disabled={state.status === "submitting"}
+        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-100 focus:border-gray-300 focus:outline-none"
+      />
+      <button
+        type="submit"
+        disabled={state.status === "submitting"}
+        className="rounded bg-gray-100 px-3 py-2 text-sm font-medium text-gray-900 disabled:opacity-50"
+      >
+        {state.status === "submitting" ? "Sending…" : "Send sign-in link"}
+      </button>
+      {state.status === "error" && (
+        <p role="alert" className="text-sm text-red-300">
+          {state.message}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,48 @@
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/lib/supabase/server";
+
+import { LoginForm } from "./login-form";
+
+const ERROR_MESSAGES: Record<string, string> = {
+  missing_code: "That sign-in link was incomplete. Please request a new one.",
+  exchange_failed:
+    "That sign-in link is invalid or has expired. Please request a new one.",
+  profile_error:
+    "We signed you in but couldn't finish setting up your profile. Please try again.",
+};
+
+type LoginPageProps = {
+  searchParams: Promise<{ error?: string }>;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (user) {
+    redirect("/");
+  }
+
+  const { error } = await searchParams;
+  const errorMessage = error ? ERROR_MESSAGES[error] : undefined;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
+      <h1 className="text-4xl font-bold">Intentional Society</h1>
+      <p className="text-sm text-gray-400">
+        Enter your email to receive a sign-in link.
+      </p>
+      {errorMessage && (
+        <p
+          role="alert"
+          className="max-w-sm rounded border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-300"
+        >
+          {errorMessage}
+        </p>
+      )}
+      <LoginForm />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/login` route: server shell checks for an existing session and redirects authenticated users to `/`, maps 1d's callback error codes (`missing_code`, `exchange_failed`, `profile_error`) to human-readable messages, and renders a client form.
- Client form calls `supabase.auth.signInWithOtp` with `emailRedirectTo` pointing at `/auth/callback` and swaps to a "check your email" confirmation on success.
- No new tests — 1f's e2e will cover "login page renders"; the existing auth-middleware and callback tests already cover the pieces this page sits on top of.

## Test plan
- [x] `npm run lint`
- [x] `npm test` (8 functional + 1 e2e pass)
- [x] Manual smoke on the Vercel preview: `/login` renders, submitting an email shows the confirmation state, magic-link email arrives and `/auth/callback` lands on `/`
- [ ] Visiting `/login` while already signed in redirects to `/`
- [x] `/login?error=exchange_failed` shows the mapped error copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)