### PR TITLE
Protect home route and add /api/me (auth phase 1f)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,5 @@ jobs:
       - run: supabase start
       - run: npm install
       - run: npm run lint
-      - run: npx drizzle-kit migrate
+      - run: node scripts/migrate.mjs
       - run: npm run test:functional

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ Requires Docker Desktop. `npm run dev` auto-starts a local Supabase stack (Postg
 - `docs/doc-strategy-branching.md` — branching strategy and rationale
 - `docs/doc-strategy-committing.md` — commit conventions and expand-contract pattern
 - `docs/doc-vercel.md` — Vercel dashboard settings
+- `docs/doc-supabase.md` — Supabase dashboard settings (auth URLs, API keys)
 - `docs/doc-github.md` — GitHub settings and CI workflows
 - `docs/doc-sentry.md` — Sentry error tracking and performance monitoring
 - `docs/doc-axiom.md` — Axiom logging and Web Vitals

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-04-18 | James | Auth Phase 1 (plumbing) complete
+
+End-to-end magic-link auth is wired. `/` is now a protected server component (unauthed → `/login`), the Hono API gates every route except `/api/health`, and `/api/me` returns a strict `{ id, email, profile }` shape that the functional test locks down so Phase 2's sensitive-field additions can't silently leak.
+
 ## 2026-04-14 | James | Drizzle migrations run in Vercel production build
 
 Every production deploy now runs `drizzle-kit migrate` before `next build` (gated on `VERCEL_ENV=production` in `vercel.json`), and a failed migration aborts the deploy with the previous build still serving traffic. Preview deploys skip the migration and continue to hit the prod DB unchanged. See `docs/doc-strategy-committing.md` for the expand-contract verification recipe that builds on this guarantee.

--- a/docs/doc-supabase.md
+++ b/docs/doc-supabase.md
@@ -1,0 +1,33 @@
+# Supabase — Configuration Reference
+
+Current configuration for the Supabase project as deployed. This documents settings made in the Supabase dashboard that are not captured in code.
+
+---
+
+- **Project ref:** `oyuzjowguujwhqyhijzx`
+- **Dashboard:** https://supabase.com/dashboard/project/oyuzjowguujwhqyhijzx
+- **Region:** (whichever was selected at project creation — see dashboard)
+- **Database:** Postgres managed by Supabase. Drizzle is the sole migration tool — `supabase/migrations/` is unused.
+
+## Authentication → URL Configuration
+
+These settings control where Supabase redirects users after magic-link sign-in. If `emailRedirectTo` passed from the client is not on the **Redirect URLs** allowlist, Supabase silently falls back to **Site URL** — so both must be kept in sync with the deployment topology.
+
+- **Site URL:** `https://app.intentionalsociety.org`
+- **Redirect URLs** (allowlist):
+  - `https://app.intentionalsociety.org/auth/callback` — production
+  - `https://is-app-vercel-*-intentional-society-vercel.vercel.app/auth/callback` — Vercel preview deploys (wildcard)
+  - `http://localhost:3000/auth/callback` — local dev
+
+The client passes `emailRedirectTo: \`${window.location.origin}/auth/callback\`` from `src/app/login/login-form.tsx`, so adding a new deploy target only requires adding its `/auth/callback` URL to the allowlist above.
+
+## Auth providers
+
+- **Email (magic link):** enabled. No password-based sign-in.
+
+## API keys
+
+- **Publishable default key:** exposed to the browser as `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`
+- **Service role key:** not currently used by the app; keep secret if ever needed
+
+Both are set as Vercel environment variables (see `docs/doc-vercel.md`), not committed to the repo.

--- a/docs/doc-supabase.md
+++ b/docs/doc-supabase.md
@@ -1,15 +1,17 @@
 # Supabase — Configuration Reference
 
-Current configuration for the Supabase project as deployed. This documents settings made in the Supabase dashboard that are not captured in code.
+Covers both the hosted production project (configured via the Supabase dashboard) and the local development stack (configured via `supabase/config.toml`).
 
 ---
+
+## Production (hosted)
 
 - **Project ref:** `oyuzjowguujwhqyhijzx`
 - **Dashboard:** https://supabase.com/dashboard/project/oyuzjowguujwhqyhijzx
 - **Region:** (whichever was selected at project creation — see dashboard)
 - **Database:** Postgres managed by Supabase. Drizzle is the sole migration tool — `supabase/migrations/` is unused.
 
-## Authentication → URL Configuration
+### Authentication → URL Configuration
 
 These settings control where Supabase redirects users after magic-link sign-in. If `emailRedirectTo` passed from the client is not on the **Redirect URLs** allowlist, Supabase silently falls back to **Site URL** — so both must be kept in sync with the deployment topology.
 
@@ -21,13 +23,38 @@ These settings control where Supabase redirects users after magic-link sign-in. 
 
 The client passes `emailRedirectTo: \`${window.location.origin}/auth/callback\`` from `src/app/login/login-form.tsx`, so adding a new deploy target only requires adding its `/auth/callback` URL to the allowlist above.
 
-## Auth providers
+### Auth providers
 
 - **Email (magic link):** enabled. No password-based sign-in.
 
-## API keys
+### API keys
 
 - **Publishable default key:** exposed to the browser as `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`
 - **Service role key:** not currently used by the app; keep secret if ever needed
 
 Both are set as Vercel environment variables (see `docs/doc-vercel.md`), not committed to the repo.
+
+---
+
+## Local stack
+
+The local Supabase stack (spun up by `supabase start`, wrapped by `npm run dev:db`) is configured in `supabase/config.toml`. Any change there requires `npx supabase stop && npx supabase start` — the CLI doesn't hot-reload config.
+
+### `[auth]` — URL Configuration
+
+Same silent-fallback semantics as prod: if `emailRedirectTo` from the client isn't in the allowlist, Supabase falls back to `site_url`.
+
+- **`site_url`** — `http://127.0.0.1:3000`
+- **`additional_redirect_urls`** — must include `/auth/callback` for both `127.0.0.1:3000` and `localhost:3000`, because `window.location.origin` depends on which host the dev server was opened with.
+
+### Inbucket (local email catcher)
+
+`supabase start` also spins up Inbucket at **http://localhost:54324**. All outbound email — magic links, invites, any future notifications — lands there instead of real inboxes. Open the URL, click the mailbox matching your email's local-part, open the most recent message, click the link. No external SMTP is configured for local dev.
+
+### API keys
+
+The CLI-generated local keys are written to `.env.local` by `npm run setup`. They mirror the prod env var names (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`) but point at `http://127.0.0.1:54321`.
+
+### Studio
+
+The local Supabase dashboard equivalent runs at **http://localhost:54323** (DB browser, auth user management, SQL editor).

--- a/docs/plan-auth-1-plumbing.md
+++ b/docs/plan-auth-1-plumbing.md
@@ -147,14 +147,12 @@ Returns `{ id, email, profile: { id, displayName, createdAt } }`. The `profile` 
 
 ### E2E (Playwright)
 
-**Commit 1f — `tests/e2e/auth-redirect.spec.ts`:**
-- Unauthenticated visit to `/` → redirects to `/login`.
+**Commit 1f — `tests/e2e/auth.spec.ts`:**
+- Unauthenticated visit to `/` → redirects to `/login` (login page renders with email input visible).
 - Unauthenticated `fetch('/api/hello')` → 401.
 - `/api/health` remains accessible without auth (regression guard).
-- Login page renders for unauthenticated users: page loads, email input is visible.
-- Sign-out clears session: after sign-out, `/` redirects to `/login` and `/api/me` returns 401. Uses a lightweight Playwright fixture that mints a session via the Supabase Admin API (pulled forward from the Phase 3 session-minting helper).
 
-Full magic-link round-trip test is deferred to Phase 3, which introduces the full session-minting helper as part of testing the invite flow.
+Signed-in coverage (sign-out clears session, authed `/api/me` shape in the browser, full magic-link round-trip) is deferred to Phase 3, which introduces the Playwright session-minting helper built on the Supabase Admin API. Phase 1 sign-out behavior is verified manually in the Verification checklist below. Avoids pulling service-role key management and cookie-injection plumbing into this phase for a single test case.
 
 ## Files touched / created
 
@@ -169,9 +167,8 @@ Full magic-link round-trip test is deferred to Phase 3, which introduces the ful
 - `tests/functional/auth-middleware.test.ts` — new
 - `tests/functional/auth-callback.test.ts` — new
 - `tests/functional/profiles.test.ts` — new
-- `tests/functional/api-me.test.ts` — new
-- `tests/e2e/fixtures/auth.ts` — new: lightweight session-minting fixture (Supabase Admin API)
-- `tests/e2e/auth-redirect.spec.ts` — new
+- `tests/functional/api-me.test.ts` — new (strict response-shape guard, real local DB)
+- `tests/e2e/auth.spec.ts` — new (unauth redirect + public/private API coverage; signed-in cases deferred to Phase 3's session fixture)
 - `docs/devjournal.md` — dated entry documenting the phase split and why not RLS
 
 ## Verification

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "setup": "node scripts/setup.mjs",
     "dev": "npm run dev:db && next dev",
-    "dev:db": "node scripts/ensure-docker.mjs && node scripts/ensure-supabase.mjs && npx drizzle-kit migrate",
+    "dev:db": "node scripts/ensure-docker.mjs && node scripts/ensure-supabase.mjs && node scripts/migrate.mjs",
     "dev:db:stop": "npx supabase stop",
     "dev:db:reset": "npx supabase db reset && npx drizzle-kit migrate",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -5,16 +5,16 @@
   "scripts": {
     "setup": "node scripts/setup.mjs",
     "dev": "npm run dev:db && next dev",
-    "dev:db": "npx supabase status || npx supabase start && (npx drizzle-kit migrate || true)",
+    "dev:db": "node scripts/ensure-docker.mjs && node scripts/ensure-supabase.mjs && npx drizzle-kit migrate",
     "dev:db:stop": "npx supabase stop",
     "dev:db:reset": "npx supabase db reset && npx drizzle-kit migrate",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "test": "vitest run && playwright test",
-    "test:functional": "vitest run",
-    "watch": "vitest",
-    "test:e2e": "playwright test"
+    "test": "npm run dev:db && vitest run && playwright test",
+    "test:functional": "npm run dev:db && vitest run",
+    "watch": "npm run dev:db && vitest",
+    "test:e2e": "npm run dev:db && playwright test"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.12",

--- a/scripts/ensure-docker.mjs
+++ b/scripts/ensure-docker.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Ensure the Docker daemon is reachable. If it isn't, launch Docker
+// Desktop (cross-platform) and poll until the daemon comes up.
+//
+// Used by `npm run dev:db` so developers never have to manually start
+// Docker Desktop before `npm run dev` or `npm test`.
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { platform } from "node:process";
+
+const DAEMON_READY_TIMEOUT_MS = 120_000;
+const POLL_INTERVAL_MS = 2_000;
+
+const pingDaemon = () =>
+  spawnSync("docker", ["info"], { stdio: "ignore" }).status === 0;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const launchDockerDesktop = () => {
+  // Prefer Docker's own CLI verb when available (Docker Desktop 4.37+).
+  const cli = spawnSync("docker", ["desktop", "start"], { stdio: "ignore" });
+  if (cli.status === 0) return true;
+
+  if (platform === "darwin") {
+    return spawnSync("open", ["-a", "Docker"], { stdio: "ignore" }).status === 0;
+  }
+
+  if (platform === "win32") {
+    const candidates = [
+      "C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe",
+      "C:\\Program Files (x86)\\Docker\\Docker\\Docker Desktop.exe",
+    ];
+    for (const path of candidates) {
+      if (existsSync(path)) {
+        spawn(path, [], { detached: true, stdio: "ignore" }).unref();
+        return true;
+      }
+    }
+    return false;
+  }
+
+  if (platform === "linux") {
+    return (
+      spawnSync("systemctl", ["--user", "start", "docker-desktop"], {
+        stdio: "ignore",
+      }).status === 0
+    );
+  }
+
+  return false;
+};
+
+const main = async () => {
+  if (pingDaemon()) return;
+
+  process.stdout.write("Docker daemon not reachable — starting Docker Desktop…\n");
+
+  if (!launchDockerDesktop()) {
+    process.stderr.write(
+      `Couldn't start Docker Desktop automatically on platform '${platform}'.\n` +
+        "Please start it manually, or install it from https://docs.docker.com/desktop.\n",
+    );
+    process.exit(1);
+  }
+
+  const deadline = Date.now() + DAEMON_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+    if (pingDaemon()) {
+      process.stdout.write("Docker daemon ready.\n");
+      return;
+    }
+  }
+
+  process.stderr.write(
+    `Timed out waiting for Docker daemon after ${DAEMON_READY_TIMEOUT_MS / 1000}s. ` +
+      "Please check Docker Desktop.\n",
+  );
+  process.exit(1);
+};
+
+main();

--- a/scripts/ensure-supabase.mjs
+++ b/scripts/ensure-supabase.mjs
@@ -6,9 +6,16 @@
 // "container is not ready: starting" and `supabase start` refuses
 // because a boot is already in progress. This script polls through
 // that window before deciding whether to issue its own `supabase start`.
+//
+// Also auto-recovers from dangling-container conflicts: if a prior
+// `supabase stop` left orphaned `supabase_*_<project>` containers,
+// `supabase start` fails with "container name already in use". We detect
+// that, force-remove the offenders, and retry once.
 
 import { spawnSync } from "node:child_process";
+import path from "node:path";
 
+const PROJECT_ID = path.basename(process.cwd());
 const GRACE_POLL_MS = 30_000; // wait for auto-starting containers first
 const POST_START_POLL_MS = 90_000; // wait after issuing our own start
 const POLL_INTERVAL_MS = 3_000;
@@ -30,6 +37,36 @@ const pollUntilReady = async (budgetMs) => {
   return false;
 };
 
+const runSupabaseStart = () => {
+  // Capture stderr so we can detect the "container name already in use"
+  // conflict, but also echo live output for the developer.
+  const result = spawnSync("npx", ["supabase", "start"], {
+    shell: true,
+    encoding: "utf8",
+  });
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  return result;
+};
+
+const clearDanglingSupabaseContainers = () => {
+  const list = spawnSync(
+    "docker",
+    ["ps", "-aq", "--filter", `name=supabase_.*_${PROJECT_ID}$`],
+    { shell: true, encoding: "utf8" },
+  );
+  const ids = (list.stdout ?? "").split(/\s+/).filter(Boolean);
+  if (ids.length === 0) return false;
+  process.stdout.write(
+    `Removing ${ids.length} dangling Supabase container(s)…\n`,
+  );
+  spawnSync("docker", ["rm", "-f", ...ids], {
+    stdio: "inherit",
+    shell: true,
+  });
+  return true;
+};
+
 const main = async () => {
   if (statusOk()) return;
 
@@ -42,11 +79,17 @@ const main = async () => {
   // Not coming up on its own — issue a start. `supabase start` blocks
   // until the stack is ready on the happy path.
   process.stdout.write("Starting Supabase stack…\n");
-  const start = spawnSync("npx", ["supabase", "start"], {
-    stdio: "inherit",
-    shell: true,
-  });
+  let start = runSupabaseStart();
   if (start.status === 0) return;
+
+  const stderr = start.stderr ?? "";
+  if (/container name .* is already in use/i.test(stderr)) {
+    if (clearDanglingSupabaseContainers()) {
+      process.stdout.write("Retrying Supabase start…\n");
+      start = runSupabaseStart();
+      if (start.status === 0) return;
+    }
+  }
 
   // `supabase start` can report "already running" if it races a
   // concurrent boot. Give the stack another window to settle.

--- a/scripts/ensure-supabase.mjs
+++ b/scripts/ensure-supabase.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Ensure the local Supabase stack is running and ready.
+//
+// Handles a subtle race: when Docker Desktop cold-starts, it auto-boots
+// persisted containers. `supabase status` during that window reports
+// "container is not ready: starting" and `supabase start` refuses
+// because a boot is already in progress. This script polls through
+// that window before deciding whether to issue its own `supabase start`.
+
+import { spawnSync } from "node:child_process";
+
+const GRACE_POLL_MS = 30_000; // wait for auto-starting containers first
+const POST_START_POLL_MS = 90_000; // wait after issuing our own start
+const POLL_INTERVAL_MS = 3_000;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const statusOk = () =>
+  spawnSync("npx", ["supabase", "status"], {
+    stdio: "ignore",
+    shell: true,
+  }).status === 0;
+
+const pollUntilReady = async (budgetMs) => {
+  const deadline = Date.now() + budgetMs;
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+    if (statusOk()) return true;
+  }
+  return false;
+};
+
+const main = async () => {
+  if (statusOk()) return;
+
+  process.stdout.write("Supabase stack not ready — waiting for containers…\n");
+  if (await pollUntilReady(GRACE_POLL_MS)) {
+    process.stdout.write("Supabase stack ready.\n");
+    return;
+  }
+
+  // Not coming up on its own — issue a start. `supabase start` blocks
+  // until the stack is ready on the happy path.
+  process.stdout.write("Starting Supabase stack…\n");
+  const start = spawnSync("npx", ["supabase", "start"], {
+    stdio: "inherit",
+    shell: true,
+  });
+  if (start.status === 0) return;
+
+  // `supabase start` can report "already running" if it races a
+  // concurrent boot. Give the stack another window to settle.
+  if (await pollUntilReady(POST_START_POLL_MS)) {
+    process.stdout.write("Supabase stack ready.\n");
+    return;
+  }
+
+  process.stderr.write(
+    "Supabase stack failed to become ready. " +
+      "Try: npx supabase stop && npx supabase start\n",
+  );
+  process.exit(1);
+};
+
+main();

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// Run Drizzle migrations quietly. Replaces `npx drizzle-kit migrate` on
+// local dev paths. drizzle-kit prints config/driver chatter plus raw
+// postgres NOTICEs (e.g. "schema already exists, skipping") on every
+// warm run; here we use drizzle-orm's programmatic migrator with
+// postgres' `onnotice` hook silenced so `npm run dev` stays quiet.
+
+import { config } from "dotenv";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import postgres from "postgres";
+
+config({ path: ".env.local", quiet: true });
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  process.stderr.write(
+    "DATABASE_URL is not set. Did you run `npm run setup`?\n",
+  );
+  process.exit(1);
+}
+
+const client = postgres(connectionString, {
+  max: 1,
+  onnotice: () => {},
+});
+
+try {
+  await migrate(drizzle(client), { migrationsFolder: "./drizzle" });
+} finally {
+  await client.end();
+}

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -59,7 +59,7 @@ export function LoginForm() {
         value={email}
         onChange={(event) => setEmail(event.target.value)}
         disabled={state.status === "submitting"}
-        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-100 focus:border-gray-300 focus:outline-none"
+        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-gray-300 focus:outline-none"
       />
       <button
         type="submit"

--- a/src/app/me-smoke.tsx
+++ b/src/app/me-smoke.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { apiClient } from "@/lib/api";
+
+// Phase 1 smoke widget: proves the authed RPC wire works from the
+// browser end-to-end. Remove in Phase 2 when real widgets replace it.
+export function MeSmokeWidget() {
+  const [status, setStatus] = useState("authed RPC: checking…");
+
+  useEffect(() => {
+    apiClient.api.me
+      .$get()
+      .then(async (res) => {
+        if (!res.ok) {
+          setStatus(`authed RPC: failed (${res.status})`);
+          return;
+        }
+        const data = await res.json();
+        setStatus(`authed RPC: ok (${String(data.id).slice(0, 8)}…)`);
+      })
+      .catch(() => setStatus("authed RPC: failed"));
+  }, []);
+
+  return <p className="text-xs text-gray-400">{status}</p>;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,25 +1,53 @@
-"use client";
+import { eq } from "drizzle-orm";
+import { redirect } from "next/navigation";
 
-import { useEffect, useState } from "react";
-import { apiClient } from "@/lib/api";
+import { createClient } from "@/lib/supabase/server";
+import { db } from "@/server/db";
+import { upsertProfile } from "@/server/profiles";
+import { profiles } from "@/server/schema";
 
-export default function Home() {
-  const [serverTime, setServerTime] = useState("");
+import { MeSmokeWidget } from "./me-smoke";
 
-  useEffect(() => {
-    apiClient.api.health
-      .$get()
-      .then((res) => res.json())
-      .then((data) => setServerTime(String(data.database.serverTime)))
-      .catch(() => setServerTime("Failed to connect to database"));
-  }, []);
+async function signOut() {
+  "use server";
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  redirect("/login");
+}
+
+export default async function Home() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/login");
+  }
+
+  const readProfile = () =>
+    db.select().from(profiles).where(eq(profiles.id, user.id));
+
+  let [profile] = await readProfile();
+  if (!profile) {
+    // Self-heal in case 1d's callback upsert failed.
+    await upsertProfile(user);
+    [profile] = await readProfile();
+  }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8">
       <h1 className="text-4xl font-bold">Intentional Society</h1>
-      {serverTime && (
-        <p className="text-sm text-gray-400">Database time: {serverTime}</p>
-      )}
+      <p className="text-sm">Signed in as {user.email}</p>
+      <p className="text-sm">Display name: {profile?.displayName ?? "—"}</p>
+      <form action={signOut}>
+        <button
+          type="submit"
+          className="rounded border border-gray-600 px-3 py-2 text-sm"
+        >
+          Sign out
+        </button>
+      </form>
+      <MeSmokeWidget />
     </main>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,8 @@
 import { hc } from "hono/client";
+
 import type { ApiRoutes } from "@/server/api";
 
-export const apiClient = hc<ApiRoutes>("/");
+export const apiClient = hc<ApiRoutes>("/", {
+  fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+    fetch(input, { ...init, credentials: "include" }),
+});

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,9 +1,11 @@
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { log } from "next-axiom";
 
 import { type ApiVariables, requireAuth } from "./auth-middleware";
 import { db } from "./db";
+import { upsertProfile } from "./profiles";
+import { profiles } from "./schema";
 
 const api = new Hono<{ Variables: ApiVariables }>()
   .basePath("/api")
@@ -21,6 +23,29 @@ const api = new Hono<{ Variables: ApiVariables }>()
   .use("*", requireAuth)
   .get("/hello", (c) => {
     return c.json({ message: "Hello from Intentional Society API" });
+  })
+  .get("/me", async (c) => {
+    const user = c.get("user");
+
+    const selectProfile = () =>
+      db
+        .select({
+          id: profiles.id,
+          displayName: profiles.displayName,
+          createdAt: profiles.createdAt,
+        })
+        .from(profiles)
+        .where(eq(profiles.id, user.id));
+
+    let [profile] = await selectProfile();
+    if (!profile) {
+      // Self-heal: 1d's callback can leave a session without a profile
+      // row if the upsert failed there. The next authed request repairs.
+      await upsertProfile(user);
+      [profile] = await selectProfile();
+    }
+
+    return c.json({ id: user.id, email: user.email, profile });
   })
   .get("/health", async (c) => {
     const result = await db.execute(sql`SELECT now() AS server_time`);

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -153,7 +153,12 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+# Must include the /auth/callback path for magic-link sign-in; cover both 127.0.0.1 and localhost
+# because window.location.origin on the client depends on which host the dev server was opened on.
+additional_redirect_urls = [
+  "http://127.0.0.1:3000/auth/callback",
+  "http://localhost:3000/auth/callback",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+
+test("unauthenticated visit to / redirects to /login", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForURL("**/login");
+
+  await expect(
+    page.getByRole("heading", { name: "Intentional Society" }),
+  ).toBeVisible();
+  await expect(page.getByLabel("Email")).toBeVisible();
+});
+
+test("unauthenticated /api/hello returns 401", async ({ request }) => {
+  const res = await request.get("/api/hello");
+  expect(res.status()).toBe(401);
+  expect(await res.json()).toEqual({ error: "unauthenticated" });
+});
+
+test("unauthenticated /api/health returns 200", async ({ request }) => {
+  const res = await request.get("/api/health");
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  expect(body.status).toBe("ok");
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,9 +1,0 @@
-import { test, expect } from "@playwright/test";
-
-test("home page loads and displays database time", async ({ page }) => {
-  await page.goto("/");
-  await page.waitForLoadState("domcontentloaded");
-
-  await expect(page.getByRole("heading", { name: "Intentional Society" })).toBeVisible();
-  await expect(page.getByText("Database time:")).toBeVisible();
-});

--- a/tests/functional/api-me.test.ts
+++ b/tests/functional/api-me.test.ts
@@ -1,0 +1,83 @@
+import { randomUUID } from "node:crypto";
+
+import type { User } from "@supabase/supabase-js";
+import { eq, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+import { createServerClient } from "@supabase/ssr";
+
+import app from "@/server/api";
+import { db } from "@/server/db";
+import { profiles } from "@/server/schema";
+
+const mockCreateServerClient = vi.mocked(createServerClient);
+
+const makeUser = (id: string, email: string): User =>
+  ({
+    id,
+    email,
+    user_metadata: { displayName: "Test User" },
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+  }) as User;
+
+describe("GET /api/me", () => {
+  let testUserId: string;
+
+  beforeEach(async () => {
+    testUserId = randomUUID();
+    await db.execute(
+      sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${testUserId}::uuid, 'me-test@testfake.local', false, false)`,
+    );
+
+    mockCreateServerClient.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: makeUser(testUserId, "me-test@testfake.local") },
+          error: null,
+        }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await db.delete(profiles).where(eq(profiles.id, testUserId));
+    await db.execute(
+      sql`DELETE FROM auth.users WHERE id = ${testUserId}::uuid`,
+    );
+  });
+
+  it("returns the strict shape and self-heals a missing profile row", async () => {
+    // No profile pre-inserted — handler must upsert on first call.
+    const res = await app.request("/api/me");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Strict equality: any accidental field leakage (e.g. Phase 2's
+    // emergencyContact) will fail this assertion loudly.
+    expect(body).toEqual({
+      id: testUserId,
+      email: "me-test@testfake.local",
+      profile: {
+        id: testUserId,
+        displayName: "Test User",
+        createdAt: expect.any(String),
+      },
+    });
+
+    // Confirm the self-heal actually wrote a row.
+    const rows = await db
+      .select()
+      .from(profiles)
+      .where(eq(profiles.id, testUserId));
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "buildCommand": "if [ \"$VERCEL_ENV\" = \"production\" ]; then npx drizzle-kit migrate; fi && next build"
+  "buildCommand": "if [ \"$VERCEL_ENV\" = \"production\" ]; then node scripts/migrate.mjs; fi && next build"
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,9 @@ import path from "path";
 export default defineConfig({
   test: {
     root: ".",
-    exclude: ["tests/e2e/**", "node_modules/**"],
+    // .claude/** is excluded because agent worktrees land there; without
+    // this, Vitest double-collects the same tests from the worktree copy.
+    exclude: ["tests/e2e/**", "node_modules/**", ".claude/**"],
     setupFiles: ["tests/functional/setup.ts"],
   },
   resolve: {


### PR DESCRIPTION
## Summary
- Closes out auth Phase 1 (plumbing): `/` is now a protected server component, unauthed visitors redirect to `/login`, and `GET /api/me` returns a strict `{ id, email, profile }` shape with a regression test to prevent Phase 2 from silently leaking new fields.
- Cleans up dev infra along the way: cross-platform Docker auto-start, race-safe Supabase wait/start with auto-recovery from dangling-container conflicts, quiet Drizzle migrations, and a fixed local `supabase/config.toml` allowlist so magic-link redirects actually land on `/auth/callback`.
- Defers Playwright session-minting fixture to Phase 3; e2e coverage here is the three unauthenticated cases (`/` → `/login`, `/api/hello` 401, `/api/health` 200).

## Test plan
- [x] `npm test` — 9 functional + 3 e2e, all green
- [x] Manual: magic-link happy path (login → Inbucket → callback → `/`) works end-to-end
- [x] Manual: unauthed visit to `/` redirects to `/login`
- [x] Reviewer: confirm `/api/me` regression test locks the exact response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)