### PR TITLE
Document PKCE same-browser requirement and improve exchange_failed copy

### DIFF
--- a/docs/doc-supabase.md
+++ b/docs/doc-supabase.md
@@ -4,6 +4,14 @@ Covers both the hosted production project (configured via the Supabase dashboard
 
 ---
 
+## Magic-link flow (PKCE)
+
+The magic-link sign-in flow uses PKCE. When a user requests a link, the client stores a `code_verifier` secret in a browser cookie (`sb-<ref>-auth-token-code-verifier`). The `/auth/callback` handler needs that cookie to exchange the `code` for a session.
+
+Consequence: **the magic link must be opened in the same browser that requested it.** Clicking the link from a phone when the request came from a desktop, or opening it in an incognito window, fails with "exchange failed". Applies equally to the hosted and local stacks.
+
+---
+
 ## Production (hosted)
 
 - **Project ref:** `oyuzjowguujwhqyhijzx`

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,7 +7,7 @@ import { LoginForm } from "./login-form";
 const ERROR_MESSAGES: Record<string, string> = {
   missing_code: "That sign-in link was incomplete. Please request a new one.",
   exchange_failed:
-    "That sign-in link is invalid or has expired. Please request a new one.",
+    "That sign-in link couldn't be verified. It must be opened in the same browser where you requested it, and before it expires. Please request a new one.",
   profile_error:
     "We signed you in but couldn't finish setting up your profile. Please try again.",
 };


### PR DESCRIPTION
## Summary
- Document in `docs/doc-supabase.md` that magic links must be opened in the same browser that requested them (PKCE `code_verifier` cookie constraint). Applies to both hosted and local stacks.
- Rewrite the `exchange_failed` error copy on `/login` to name same-browser and expiry as the two likely causes, instead of the vaguer "invalid or expired".

## Test plan
- [x] `npm test` — 9 functional + 3 e2e, all green
- [ ] Reviewer: confirm doc phrasing is clear; error-message copy reads naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)