### PR TITLE
Auth Phase 2: profile schema expansion + welcome flow

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,7 +4,19 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
-## 2026-04-18 | James | Auth Phase 1 (plumbing) complete
+## 2026-04-19 | James | Auth Phase 2 (profile expansion) complete
+
+`profiles` grew from three columns to the full community shape (bio, keywords, location, supplementaryInfo, referredBy, referredByLegacy, avatarUrl, emergencyContact, liveDesire, isAdmin) via additive `ALTER TABLE` statements — no backfill needed because the only existing row was a test account. `programs` and `profilePrograms` also landed as empty structural tables; they were deferred from Phase 1 and explicitly **not** joined into any profile shape, because program membership is a separate concern that will get its own endpoint.
+
+Introduced the serialization-layer access control pattern: `getProfileForSelf` returns the full self view (including `emergencyContact` and `isAdmin`), and `getProfileForMember` / `getProfileForAdmin` are `NotImplemented` stubs. The stubs exist deliberately so the next person to build a member-directory or admin tool is forced to decide the visible shape rather than silently reusing self.
+
+`PUT /api/me` accepts only the editable subset (bio, keywords, location, supplementaryInfo, avatarUrl, emergencyContact, liveDesire). Unknown keys and non-editable fields (`isAdmin`, `referredBy`, `displayName`, `id`, `createdAt`) are rejected with 400 by a compact allowlist parser — no new validation dependency.
+
+`/welcome` was added as the first-sign-in completion flow: `/` redirects there when `profile.bio IS NULL`, and the form saves via `PUT /api/me` plus an optional client-side `supabase.auth.updateUser({ password })`. Login page grew an optional password field; blank password still sends a magic link. No "forgot password" link — magic link is the recovery path.
+
+Signed-in e2e coverage for the welcome flow is deliberately deferred to Phase 3, which owns the Playwright session-minting helper. The login-page password-vs-OTP e2e uses route interception on `/auth/v1/token` and `/auth/v1/otp` — no session needed because `/login` is public.
+
+
 
 End-to-end magic-link auth is wired. `/` is now a protected server component (unauthed → `/login`), the Hono API gates every route except `/api/health`, and `/api/me` returns a strict `{ id, email, profile }` shape that the functional test locks down so Phase 2's sensitive-field additions can't silently leak.
 

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -6,17 +6,13 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ## 2026-04-19 | James | Auth Phase 2 (profile expansion) complete
 
-`profiles` grew from three columns to the full community shape (bio, keywords, location, supplementaryInfo, referredBy, referredByLegacy, avatarUrl, emergencyContact, liveDesire, isAdmin) via additive `ALTER TABLE` statements — no backfill needed because the only existing row was a test account. `programs` and `profilePrograms` also landed as empty structural tables; they were deferred from Phase 1 and explicitly **not** joined into any profile shape, because program membership is a separate concern that will get its own endpoint.
+`profiles` grew from three columns to the full community shape (bio, keywords, location, supplementaryInfo, referred-by, avatar, emergency contact, live desire, isAdmin) via additive `ALTER TABLE`s. `programs` and `profilePrograms` landed as empty structural tables — deliberately **not** joined into any profile shape; program membership will get its own endpoint.
 
-Introduced the serialization-layer access control pattern: `getProfileForSelf` returns the full self view (including `emergencyContact` and `isAdmin`), and `getProfileForMember` / `getProfileForAdmin` are `NotImplemented` stubs. The stubs exist deliberately so the next person to build a member-directory or admin tool is forced to decide the visible shape rather than silently reusing self.
+Introduced serialization-layer access control: `getProfileForSelf` returns the full self view; `getProfileForMember` / `getProfileForAdmin` are `NotImplemented` stubs so the next person adding a directory or admin surface is forced to decide the visible shape rather than silently reusing self. `PUT /api/me` accepts only the editable subset and rejects unknown or privileged keys (`isAdmin`, `referredBy`, etc.) via a compact allowlist parser — no new validation dep.
 
-`PUT /api/me` accepts only the editable subset (bio, keywords, location, supplementaryInfo, avatarUrl, emergencyContact, liveDesire). Unknown keys and non-editable fields (`isAdmin`, `referredBy`, `displayName`, `id`, `createdAt`) are rejected with 400 by a compact allowlist parser — no new validation dependency.
+`/welcome` is the first-sign-in completion flow: `/` redirects there when `bio IS NULL`, and the form saves via `PUT /api/me` plus an optional client-side `supabase.auth.updateUser({ password })`. Login grew an optional password field; blank still sends a magic link, which is also the recovery path (no "forgot password" link). Signed-in e2e coverage is deferred to Phase 3, which owns the Playwright session-minting helper.
 
-`/welcome` was added as the first-sign-in completion flow: `/` redirects there when `profile.bio IS NULL`, and the form saves via `PUT /api/me` plus an optional client-side `supabase.auth.updateUser({ password })`. Login page grew an optional password field; blank password still sends a magic link. No "forgot password" link — magic link is the recovery path.
-
-Signed-in e2e coverage for the welcome flow is deliberately deferred to Phase 3, which owns the Playwright session-minting helper. The login-page password-vs-OTP e2e uses route interception on `/auth/v1/token` and `/auth/v1/otp` — no session needed because `/login` is public.
-
-
+## 2026-04-18 | James | Auth Phase 1 (plumbing) complete
 
 End-to-end magic-link auth is wired. `/` is now a protected server component (unauthed → `/login`), the Hono API gates every route except `/api/health`, and `/api/me` returns a strict `{ id, email, profile }` shape that the functional test locks down so Phase 2's sensitive-field additions can't silently leak.
 

--- a/docs/doc-strategy-committing.md
+++ b/docs/doc-strategy-committing.md
@@ -32,6 +32,8 @@ Because migrations always run first, the only timing constraint to think about i
 
 The expand-contract pattern naturally satisfies this: the expand phase adds schema that the old code ignores, and the contract phase only removes schema that the new code no longer references.
 
+**Preview caveat.** Preview deploys skip the migration and share the prod DB, so a PR that both adds columns *and* reads them ships new code against the still-old preview database. Any page that queries the new columns will 500 ("Application error" in production builds — the real `column "X" does not exist` message is hidden). Production itself is unaffected because its build runs the migration before `next build`, but the preview can't exercise the new flow until the PR merges. To keep previews functional end-to-end, land the schema change in its own PR (Expand) before the PR that uses it (Migrate).
+
 ### Writing safe migrations
 
 Every migration must be safe to run against a database that is actively serving requests with the *current* production code (i.e., the code from the previous deploy). Concretely:

--- a/docs/plan-auth-2-profile.md
+++ b/docs/plan-auth-2-profile.md
@@ -74,9 +74,9 @@ Phase 1's `/api/me` returned `{ id, email, profile: { id, displayName, createdAt
 
 ## `PUT /api/me` endpoint (new)
 
-Authed. Accepts the editable subset of profile fields (`bio`, `keywords`, `location`, `supplementaryInfo`, `avatarUrl`, `emergencyContact`, `liveDesire`). Validates input (e.g. `keywords` is an array of strings) and updates the caller's own profile row. Returns the updated profile via `getProfileForSelf`.
+Authed. Accepts the editable subset of profile fields (`displayName`, `bio`, `keywords`, `location`, `supplementaryInfo`, `avatarUrl`, `emergencyContact`, `liveDesire`). Validates input (e.g. `keywords` is an array of strings) and updates the caller's own profile row. Returns the updated profile via `getProfileForSelf`.
 
-Fields not accepted: `id`, `displayName` (set at signup), `referredBy`, `referredByLegacy`, `isAdmin`, `createdAt`.
+Fields not accepted: `id`, `referredBy`, `referredByLegacy`, `isAdmin`, `createdAt`.
 
 ## Profile completion flow (`src/app/welcome/page.tsx` — new)
 
@@ -103,7 +103,7 @@ No "forgot password?" link. If a member forgets their password, they leave the f
 - **Functional (Vitest):**
   - `getProfileForSelf` includes `emergencyContact` and `isAdmin` (shape guard against accidental omission in future refactors).
   - `getProfileForMember` / `getProfileForAdmin` throw `NotImplemented` (lock in the "decide-on-use" contract).
-  - `PUT /api/me` updates only allowed fields; rejects `isAdmin`, `referredBy`, `displayName`, and unknown keys.
+  - `PUT /api/me` updates only allowed fields; rejects `isAdmin`, `referredBy`, and unknown keys.
   - `PUT /api/me` rejects malformed input (e.g. `keywords` not an array of strings) with a 400.
   - Existing `upsertProfile` tests still pass — the helper is unchanged.
 - **E2E (Playwright):**

--- a/docs/plan-auth-2-profile.md
+++ b/docs/plan-auth-2-profile.md
@@ -20,9 +20,23 @@ Phase 1 created `profiles` with only `id`, `displayName`, and `createdAt` — en
 
 The underlying table is altered in place (expand step of expand-contract). Columns are added as nullable (or with safe defaults) so existing rows — there will be at most one: yourself, signed in to test Phase 1 — continue to work without backfill.
 
+Phase 1 deferred the `programs` / `profilePrograms` tables to "a dedicated micro-PR when a later phase actually needs them." Phase 2 is that moment — the tables land here as structure only (no seed data, no endpoints, not joined into any profile shape). Programs are a membership classification, not a profile field, so they are intentionally kept out of `getProfileFor*`.
+
+## Commit plan
+
+This phase lands as a single PR built from five sequential commits. Each commit keeps the app in a working state.
+
+| Commit | Scope | Key changes |
+|--------|-------|-------------|
+| **2a** | Schema expand + migration | `schema.ts` (alter profiles, add programs + profilePrograms), generated SQL |
+| **2b** | Serialization layer + `/api/me` swap | `profiles.ts` (`getProfileForSelf` + stubs), `api.ts` swap, shape-guard tests |
+| **2c** | `PUT /api/me` | `api.ts` endpoint, zod validation, functional tests |
+| **2d** | `/welcome` page + incomplete-profile redirect | `welcome/page.tsx`, `page.tsx` redirect, e2e |
+| **2e** | Login dual-mode (email + optional password) | `login-form.tsx`, e2e |
+
 ## Schema changes (`src/server/schema.ts`)
 
-Alter `profiles` to add the following columns. All nullable unless marked otherwise.
+### Alter `profiles` — add the following columns. All nullable unless marked otherwise.
 
 - `bio` — `text`, nullable
 - `keywords` — `text[]`, not null, default `{}` (Postgres array; GIN-indexable if search is needed later)
@@ -35,23 +49,28 @@ Alter `profiles` to add the following columns. All nullable unless marked otherw
 - `liveDesire` — `text`, nullable
 - `isAdmin` — `boolean`, not null, default `false`
 
-Generate and apply: `npx drizzle-kit generate` → review the SQL (should be `ALTER TABLE` statements, not `CREATE TABLE`) → commit → `npx drizzle-kit migrate`.
+### New tables (structure only, no seed)
 
-No new tables in this phase — `programs` and `profilePrograms` already exist from Phase 1.
+- `programs` — `id` (uuid PK, default `gen_random_uuid()`), `slug` (text, unique, not null), `name` (text, not null), `description` (text, nullable), `createdAt` (timestamptz, not null, default `now()`).
+- `profilePrograms` — `profileId` (uuid, FK to `profiles.id` on delete cascade), `programId` (uuid, FK to `programs.id` on delete cascade), composite PK `(profileId, programId)`, `assignedAt` (timestamptz, not null, default `now()`).
+
+No seed data, no seed script, no endpoints in this phase. A later phase will introduce admin-managed seeding and membership assignment.
+
+Generate and apply: `npx drizzle-kit generate` → review the SQL (expect `ALTER TABLE` for `profiles` and `CREATE TABLE` for the two new tables) → commit → `npx drizzle-kit migrate`.
 
 ## Sensitive field access control
 
 `emergencyContact` is PII (typically a name and phone number). Since RLS is not the primary mechanism, the Hono API enforces visibility at the serialization layer. Three shapes, all defined in `src/server/profiles.ts`:
 
-- **`getProfileForSelf(userId)`** — includes `emergencyContact`. Used by `/api/me`.
-- **`getProfileForMember(userId)`** — omits `emergencyContact`. Placeholder for a future member-directory endpoint. Not built in this phase.
-- **`getProfileForAdmin(userId)`** — includes `emergencyContact`. Placeholder for future admin tooling. Not built in this phase.
+- **`getProfileForSelf(userId)`** — includes `emergencyContact` and `isAdmin`. Used by `/api/me`.
+- **`getProfileForMember(userId)`** — stub that throws `NotImplemented`. Placeholder so the access decision is forced when member-directory work starts. Not built in this phase.
+- **`getProfileForAdmin(userId)`** — stub that throws `NotImplemented`. Placeholder for future admin tooling. Not built in this phase.
 
-Phase 2 implements only `getProfileForSelf`. The other two shapes are declared with stubs so the access pattern is decided the moment member-directory work starts. The Phase 1 `upsertProfile(user)` helper stays — it still only writes `id` + `displayName`, since no other fields are known at signup time.
+None of the shapes include programs — program membership is a separate concern and will get its own endpoint in a later phase. The Phase 1 `upsertProfile(user)` helper stays unchanged — it still only writes `id` + `displayName`, since no other fields are known at signup time.
 
 ## `/api/me` update
 
-Phase 1's `/api/me` returned `{ id, email, profile: { id, displayName, createdAt } }`. Phase 2 swaps the inline shape for `getProfileForSelf(user.id)`, which returns the full profile including `emergencyContact` and a joined list of the member's programs via `profilePrograms` → `programs`.
+Phase 1's `/api/me` returned `{ id, email, profile: { id, displayName, createdAt } }`. Phase 2 swaps the inline shape for `getProfileForSelf(user.id)`, which returns the full profile (all columns including `emergencyContact` and `isAdmin`). Programs are **not** included.
 
 ## `PUT /api/me` endpoint (new)
 
@@ -61,7 +80,7 @@ Fields not accepted: `id`, `displayName` (set at signup), `referredBy`, `referre
 
 ## Profile completion flow (`src/app/welcome/page.tsx` — new)
 
-After first sign-in, members land on `/` which detects an incomplete profile (e.g. `bio` is null) and redirects to `/welcome`. This page presents a form to fill in bio, keywords, location, etc. — the same fields accepted by `PUT /api/me`. Submitting saves the profile and redirects to `/`.
+After first sign-in, members land on `/`. The "incomplete profile" heuristic is `bio IS NULL` — bio is the one field every member must supply, and a new Phase 1 member will have it as null. If incomplete, `/` redirects to `/welcome`. This page presents a form to fill in bio, keywords, location, etc. — the same fields accepted by `PUT /api/me`. Submitting saves the profile and redirects to `/`.
 
 The form also includes an **optional password section**: "Set a password for faster sign-in (you can always use magic link instead)." This calls `supabase.auth.updateUser({ password })` client-side — GoTrue handles hashing and storage directly. No new API endpoint needed for password setting.
 
@@ -82,9 +101,10 @@ No "forgot password?" link. If a member forgets their password, they leave the f
 ## Tests
 
 - **Functional (Vitest):**
-  - `getProfileForSelf` includes `emergencyContact` (shape guard against accidental omission in future refactors).
-  - `getProfileForMember` does **not** include `emergencyContact` (shape guard for the inverse).
-  - `PUT /api/me` updates only allowed fields; rejects `isAdmin`, `referredBy`.
+  - `getProfileForSelf` includes `emergencyContact` and `isAdmin` (shape guard against accidental omission in future refactors).
+  - `getProfileForMember` / `getProfileForAdmin` throw `NotImplemented` (lock in the "decide-on-use" contract).
+  - `PUT /api/me` updates only allowed fields; rejects `isAdmin`, `referredBy`, `displayName`, and unknown keys.
+  - `PUT /api/me` rejects malformed input (e.g. `keywords` not an array of strings) with a 400.
   - Existing `upsertProfile` tests still pass — the helper is unchanged.
 - **E2E (Playwright):**
   - Member with incomplete profile redirected to `/welcome` after sign-in.
@@ -93,14 +113,17 @@ No "forgot password?" link. If a member forgets their password, they leave the f
 
 ## Files touched / created
 
-- `src/server/schema.ts` — alter `profiles` (additive column list)
-- `drizzle/migrations/*` — new SQL (expected to be `ALTER TABLE`)
-- `src/server/profiles.ts` — add `getProfileForSelf` + stubs for `getProfileForMember` / `getProfileForAdmin`
+- `src/server/schema.ts` — alter `profiles` (additive column list); add `programs` + `profilePrograms` tables
+- `drizzle/*.sql` — new generated migration (mixed `ALTER TABLE profiles` + `CREATE TABLE` for the two new tables)
+- `src/server/profiles.ts` — add `getProfileForSelf` + `NotImplemented` stubs for `getProfileForMember` / `getProfileForAdmin`
 - `src/server/api.ts` — `/api/me` swaps to `getProfileForSelf`; new `PUT /api/me`
-- `src/app/welcome/page.tsx` — new: profile completion + optional password
-- `src/app/login/page.tsx` — extended with optional password field
-- `tests/functional/profiles.test.ts` — extend with access control shape guards + `PUT /api/me` tests
-- `tests/e2e/profile-completion.spec.ts` — new
+- `src/app/page.tsx` — redirect to `/welcome` when `profile.bio === null`
+- `src/app/welcome/page.tsx` + `welcome-form.tsx` — new: profile completion + optional password
+- `src/app/login/login-form.tsx` — extended with optional password field
+- `tests/functional/profiles.test.ts` — extend with access control shape guards
+- `tests/functional/api-me.test.ts` — extend (new shape) + add `PUT /api/me` tests
+- `tests/e2e/profile-completion.spec.ts` — new (welcome redirect + form submit)
+- `tests/e2e/login-password.spec.ts` — new (dual-mode login via route interception)
 
 ## Verification
 

--- a/docs/plan-auth-2-profile.md
+++ b/docs/plan-auth-2-profile.md
@@ -107,9 +107,8 @@ No "forgot password?" link. If a member forgets their password, they leave the f
   - `PUT /api/me` rejects malformed input (e.g. `keywords` not an array of strings) with a 400.
   - Existing `upsertProfile` tests still pass — the helper is unchanged.
 - **E2E (Playwright):**
-  - Member with incomplete profile redirected to `/welcome` after sign-in.
-  - Filling out the form and submitting → profile updated, redirected to `/`.
-  - Password field on `/login`: submitting with password → `signInWithPassword` called; submitting without → `signInWithOtp` called.
+  - Password field on `/login`: submitting with password → `signInWithPassword` called; submitting without → `signInWithOtp` called. Uses route interception on the Supabase auth endpoints; `/login` is public so no session needed.
+  - Signed-in e2e coverage for the `/welcome` redirect and form submission is **deferred to Phase 3**, which owns the Playwright session-minting helper. Phase 2 verifies this flow manually (see Verification steps 3–6 below).
 
 ## Files touched / created
 

--- a/docs/plan-secure-password-change.md
+++ b/docs/plan-secure-password-change.md
@@ -1,0 +1,111 @@
+# Plan: Require recent authentication to change a password
+
+## Goal
+
+Close the session-hijack → persistent-account-takeover path on the
+`/welcome` password-set flow by requiring a fresh re-authentication
+nonce before `supabase.auth.updateUser({ password })` is accepted.
+
+## The gap today
+
+Phase 2 landed a welcome form that lets any authenticated user set a
+password with a single client-side call:
+
+```ts
+await supabase.auth.updateUser({ password });
+```
+
+No current-password prompt, no recency check. Any valid session —
+magic-link click, stolen cookie, XSS payload, forgotten laptop — can
+pivot to persistent access by setting a new password. The legitimate
+user rotating their session doesn't evict the attacker, because the
+password is now the attacker's.
+
+Supabase's default configuration allows this. Our `supabase/config.toml`
+currently has:
+
+```toml
+secure_password_change = false
+```
+
+## The fix
+
+Two coordinated changes:
+
+1. **Flip the Supabase setting on.** Both locally and in the hosted
+   project's Auth settings. With it on, GoTrue rejects `updateUser`
+   password changes unless the session has a recent reauth nonce.
+2. **Add a `reauthenticate()` step to the welcome form.** When a
+   password is being set, call `supabase.auth.reauthenticate()` first —
+   this sends a one-time code to the user's email. The form collects
+   the code and passes it to `updateUser({ password, nonce })`.
+
+## Config changes
+
+`supabase/config.toml`:
+
+```diff
+-secure_password_change = false
++secure_password_change = true
+```
+
+Hosted Supabase project: Auth → Providers → Email → toggle "Secure
+password change" on. Document the setting location in `docs/doc-supabase.md`.
+
+## Code changes
+
+`src/app/welcome/welcome-form.tsx`:
+
+- Add a "reauth code" state and input, shown only after the user
+  submits and a reauth email is sent.
+- Flow on submit when password is non-empty:
+  1. Save profile via `PUT /api/me` (unchanged).
+  2. Call `supabase.auth.reauthenticate()`. Show the reauth-code input
+     and a message: "Check <email> for a 6-digit code to confirm the
+     password change."
+  3. User enters the code. Call
+     `supabase.auth.updateUser({ password, nonce: code })`.
+  4. On success → redirect to `/`.
+- If password is empty: skip the reauth dance entirely; flow is
+  unchanged from today.
+- Error messages must distinguish "couldn't send code" from "code
+  invalid or expired" so the user can self-correct.
+
+## UX trade-off
+
+Setting a password now takes a second form submission and an email
+round-trip. That's friction, but it's the same friction Supabase
+recommends for any password-write surface — and the welcome-form case
+is first-sign-in only, so most members hit it once.
+
+Members who skip the password field on `/welcome` are unaffected.
+Future password-change surfaces (settings page) will inherit the same
+flow for free, since the enforcement is server-side.
+
+## Tests
+
+- **Functional:** nothing to add — the enforcement lives in GoTrue,
+  not our code. Our existing `PUT /api/me` tests don't touch passwords.
+- **E2E:** deferred. Verifying the reauth dance end-to-end would need
+  inbox access (we don't mint real sessions in e2e yet — Phase 3 owns
+  the session helper). For now, manual smoke on a staging project is
+  enough.
+
+## Rollout
+
+1. Flip `config.toml` + hosted project setting.
+2. Ship the welcome-form reauth flow in the same PR so no one hits a
+   broken state (config-on + no reauth = silent failure when setting
+   a password).
+3. Devjournal entry documenting the gap and the fix.
+
+## Out of scope
+
+- Current-password confirmation on password change. `reauthenticate()`
+  via email is Supabase's recommended path; adding a "type your current
+  password" field on top is belt-and-braces and not free (requires a
+  `signInWithPassword` round-trip to verify).
+- Password strength policy beyond Supabase defaults. Tracked separately
+  if/when it comes up.
+- Rate-limiting the reauth-code endpoint. GoTrue rate-limits this
+  already.

--- a/docs/plan-use-turbopack.md
+++ b/docs/plan-use-turbopack.md
@@ -1,0 +1,162 @@
+# Plan: Switch dev server to Turbopack
+
+## Goal
+
+Eliminate a recurring Windows-only dev-server crash by swapping `next dev`
+for `next dev --turbopack`. Stop relying on `rm -rf .next` as the workaround.
+
+## What is Turbopack?
+
+Turbopack is Vercel's Rust-based bundler, built as the eventual successor
+to webpack inside Next.js. It's the thing that compiles your TypeScript
+and React into runnable JS, watches files, and serves the HMR updates
+that make the dev server feel live. Same job webpack does — different
+implementation.
+
+Two things make it relevant here:
+
+1. **It's written in Rust** and parallelizes aggressively, so cold starts
+   and incremental rebuilds are noticeably faster.
+2. **Its cache is content-addressed in memory and on disk differently**
+   from webpack's `PackFileCacheStrategy`. No `*.pack.gz_` → `*.pack.gz`
+   rename dance — which is the specific Windows race we're trying to
+   escape.
+
+Status inside Next.js: stable for `next dev` in Next 15, on track to
+become the default in Next 16. Production `next build` is still webpack
+for now; Turbopack build support exists but is beta.
+
+Using it is a one-flag change (`--turbopack`). No new dependencies, no
+config migration, no lockfile churn.
+
+## Pros and cons of switching
+
+**Pros**
+- Fixes the `installChunk` crash we keep hitting on Windows.
+- Faster dev startup and HMR (a few-second-per-change improvement, not
+  life-changing but real).
+- Aligns with Next.js's direction — less work when Next 16 lands.
+
+**Cons**
+- Sentry can't auto-instrument server actions under Turbopack yet. We
+  have one (sign-out); it's trivial.
+- Surfaces noisy `import-in-the-middle` version warnings from Sentry's
+  transitive OTel deps. Non-fatal, just ugly.
+- Teammate who hits a Turbopack-specific bug would need to drop the
+  flag locally until fixed.
+
+## Symptom
+
+After any interrupted dev run (Ctrl+C, VS Code restart, antivirus touch),
+the next `npm run dev` would compile fine on first load but crash on a
+subsequent route with:
+
+```
+TypeError: Cannot read properties of undefined (reading 'length')
+    at installChunk (.next/server/webpack-runtime.js:…)
+```
+
+Most recently reproduced hitting `/auth/callback` during Phase 2 testing.
+Manually deleting `.next/` made the error go away — until the next
+interrupted run recreated a bad pack file.
+
+## Root cause
+
+Webpack's `PackFileCacheStrategy` writes pack files as `*.pack.gz_`
+and renames them to `*.pack.gz` on success. On Windows this rename
+races with antivirus scanning, file-indexing services, and any lingering
+file handles from the previous dev process. A lost race leaves either
+a truncated `.pack.gz` or a leftover `.pack.gz_`. On the next load,
+webpack deserializes the bad pack as `undefined` and its runtime chunk
+loader blows up dereferencing it.
+
+This is a longstanding, still-unresolved Next.js issue on Windows. It
+is not caused by anything in our code.
+
+## Why Turbopack fixes it
+
+Turbopack is Next.js's Rust-based bundler, stable for `next dev` in
+Next 15 and slated to become the default in Next 16. Its cache is
+built differently — there is no `PackFileCacheStrategy`, no rename
+race, and nothing on disk that deserializes to `undefined`. Empirically
+the `installChunk` crash disappears. Functionally it also starts faster
+and incremental-rebuilds faster, but those are bonuses — the motivation
+here is correctness, not speed.
+
+## Compatibility
+
+Our stack already supports Turbopack with zero config changes:
+
+- **Next 15.5.15** — Turbopack is stable for `dev`.
+- **@sentry/nextjs 10.47.0** — full Turbopack support landed in Next
+  15.4.1+. Our `withSentryConfig` call uses none of the webpack-only
+  options (`autoInstrumentServerFunctions`, `autoInstrumentMiddleware`,
+  `excludeServerRoutes`).
+- **Tailwind v4 / PostCSS** — supported.
+- **Production `next build`** — stays on webpack. No change to Vercel
+  deploys, migrations, or bundles.
+
+## Known trade-offs
+
+1. **Server actions lose auto-instrumentation.** Sentry's webpack plugin
+   auto-wraps server actions; Turbopack doesn't yet. We have one simple
+   server action (sign-out); acceptable.
+2. **Noisy warnings.** Turbopack surfaces `import-in-the-middle`
+   version-mismatch warnings from `@fastify/otel` and
+   `@prisma/instrumentation` (both are transitive OTel deps pulled in
+   by Sentry). They are non-fatal, well-known, and expected to quiet
+   in Next 16. We accept the noise.
+
+## Change
+
+One line in `package.json`:
+
+```diff
+-    "dev": "npm run dev:db && next dev",
++    "dev": "npm run dev:db && next dev --turbopack",
+```
+
+## Verification
+
+- `npm test` — all 21 functional + 5 e2e pass (e2e drives `next dev`
+  via Playwright's webServer, which picks up the new flag).
+- Manual smoke: `/login`, `/auth/callback`, `/welcome`, `/` all load
+  under Turbopack with no runtime errors.
+
+## Rollback
+
+If Turbopack misbehaves on a teammate's machine, `next dev` (webpack)
+still works — just drop the `--turbopack` flag locally. Production is
+unaffected either way.
+
+## Devjournal entry to post on commit
+
+```
+## 2026-04-19 | James | Switched dev server to Turbopack
+
+`npm run dev` now runs `next dev --turbopack`. The motivation was a
+recurring Windows-only crash: `TypeError: Cannot read properties of
+undefined (reading 'length')` at `installChunk` in
+`.next/server/webpack-runtime.js`, reliably reproducible after any
+interrupted dev run. Root cause is webpack's `PackFileCacheStrategy`
+rename race on Windows — it writes `*.pack.gz_` and renames to
+`*.pack.gz`, and the rename loses to antivirus / file-lock interference,
+leaving a half-written pack that later deserializes as `undefined`.
+This is a longstanding unresolved Next.js issue, and the only reliable
+mitigation under webpack was `rm -rf .next` — not a long-term answer.
+
+Turbopack has its own cache architecture and sidesteps the race
+entirely. Our stack already supports it: Next 15.5.15 ships Turbopack
+as stable for `dev`, and `@sentry/nextjs` 10.47.0 has full Turbopack
+support on Next 15.4.1+. Our Sentry config uses none of the webpack-only
+options (`autoInstrumentServerFunctions`, `autoInstrumentMiddleware`,
+`excludeServerRoutes`), so no config changes were required. The one
+known trade-off — server actions lose auto-instrumentation — is
+negligible for us (one simple sign-out action). Production `next build`
+is unaffected; still webpack, still migrated on deploy.
+
+Turbopack surfaces noisy `import-in-the-middle` version-mismatch
+warnings from `@fastify/otel` and `@prisma/instrumentation` (transitive
+OTel deps via Sentry). They're non-fatal and well-known; Next 16 is
+expected to quiet them.
+```

--- a/drizzle/0001_peaceful_madripoor.sql
+++ b/drizzle/0001_peaceful_madripoor.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "profile_programs" (
+	"profile_id" uuid NOT NULL,
+	"program_id" uuid NOT NULL,
+	"assigned_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "profile_programs_profile_id_program_id_pk" PRIMARY KEY("profile_id","program_id")
+);
+--> statement-breakpoint
+CREATE TABLE "programs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"slug" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "programs_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "bio" text;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "keywords" text[] DEFAULT '{}'::text[] NOT NULL;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "location" text;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "supplementary_info" text;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "referred_by" uuid;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "referred_by_legacy" text;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "avatar_url" text;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "emergency_contact" text;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "live_desire" text;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "is_admin" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "profile_programs" ADD CONSTRAINT "profile_programs_profile_id_profiles_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "profile_programs" ADD CONSTRAINT "profile_programs_program_id_programs_id_fk" FOREIGN KEY ("program_id") REFERENCES "public"."programs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "profiles" ADD CONSTRAINT "profiles_referred_by_profiles_id_fk" FOREIGN KEY ("referred_by") REFERENCES "public"."profiles"("id") ON DELETE set null ON UPDATE no action;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,381 @@
+{
+  "id": "45940aaa-1b92-4bfa-86fe-10119d302bd4",
+  "prevId": "0f8ae865-dc57-4181-83ca-02e49e3b388a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by": {
+          "name": "redeemed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_profiles_id_fk": {
+          "name": "invites_created_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_profiles_id_fk": {
+          "name": "invites_redeemed_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "redeemed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_redemption_pair": {
+          "name": "invites_redemption_pair",
+          "value": "(\"invites\".\"redeemed_by\" IS NULL) = (\"invites\".\"redeemed_at\" IS NULL)"
+        },
+        "invites_expires_after_created": {
+          "name": "invites_expires_after_created",
+          "value": "\"invites\".\"expires_at\" > \"invites\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_programs": {
+      "name": "profile_programs",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_programs_profile_id_profiles_id_fk": {
+          "name": "profile_programs_profile_id_profiles_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_programs_program_id_programs_id_fk": {
+          "name": "profile_programs_program_id_programs_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_programs_profile_id_program_id_pk": {
+          "name": "profile_programs_profile_id_program_id_pk",
+          "columns": [
+            "profile_id",
+            "program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplementary_info": {
+          "name": "supplementary_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by": {
+          "name": "referred_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by_legacy": {
+          "name": "referred_by_legacy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_desire": {
+          "name": "live_desire",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profiles_referred_by_profiles_id_fk": {
+          "name": "profiles_referred_by_profiles_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "referred_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_slug_unique": {
+          "name": "programs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776217861222,
       "tag": "0000_known_sage",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776622910925,
+      "tag": "0001_peaceful_madripoor",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/ensure-supabase.mjs
+++ b/scripts/ensure-supabase.mjs
@@ -38,8 +38,10 @@ const pollUntilReady = async (budgetMs) => {
 };
 
 const runSupabaseStart = () => {
-  // Capture stderr so we can detect the "container name already in use"
-  // conflict, but also echo live output for the developer.
+  // Capture both streams so the caller can scan either for the
+  // "container name already in use" conflict — the CLI is inconsistent
+  // about which stream it picks (Windows shell: true makes it fuzzier).
+  // Output is echoed live to the developer on the way out.
   const result = spawnSync("npx", ["supabase", "start"], {
     shell: true,
     encoding: "utf8",
@@ -55,6 +57,14 @@ const clearDanglingSupabaseContainers = () => {
     ["ps", "-aq", "--filter", `name=supabase_.*_${PROJECT_ID}$`],
     { shell: true, encoding: "utf8" },
   );
+  if (list.status !== 0) {
+    // docker itself failed — don't swallow it, caller has no other way
+    // to know we gave up.
+    process.stderr.write(
+      `docker ps failed (exit ${list.status}):\n${list.stderr ?? ""}\n`,
+    );
+    return false;
+  }
   const ids = (list.stdout ?? "").split(/\s+/).filter(Boolean);
   if (ids.length === 0) return false;
   process.stdout.write(
@@ -82,8 +92,11 @@ const main = async () => {
   let start = runSupabaseStart();
   if (start.status === 0) return;
 
-  const stderr = start.stderr ?? "";
-  if (/container name .* is already in use/i.test(stderr)) {
+  // The Supabase CLI sometimes prints the docker-daemon conflict to
+  // stdout rather than stderr (shell: true on Windows makes this
+  // fuzzier), so we match against both.
+  const combined = `${start.stdout ?? ""}\n${start.stderr ?? ""}`;
+  if (/container name .* is already in use/i.test(combined)) {
     if (clearDanglingSupabaseContainers()) {
       process.stdout.write("Retrying Supabase start…\n");
       start = runSupabaseStart();

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
@@ -11,7 +12,9 @@ type FormState =
   | { status: "error"; message: string };
 
 export function LoginForm() {
+  const router = useRouter();
   const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [state, setState] = useState<FormState>({ status: "idle" });
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -19,6 +22,24 @@ export function LoginForm() {
     setState({ status: "submitting" });
 
     const supabase = createClient();
+
+    if (password.length > 0) {
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+      if (error) {
+        // No fallback to magic link — a failed password means the
+        // member mistyped it; falling through silently would be
+        // confusing. They can clear the field and resubmit.
+        setState({ status: "error", message: error.message });
+        return;
+      }
+      router.push("/");
+      router.refresh();
+      return;
+    }
+
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
@@ -61,12 +82,31 @@ export function LoginForm() {
         disabled={state.status === "submitting"}
         className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-gray-300 focus:outline-none"
       />
+      <label htmlFor="password" className="text-sm text-gray-300">
+        Password (optional)
+      </label>
+      <input
+        id="password"
+        type="password"
+        autoComplete="current-password"
+        placeholder="Leave blank to use magic link"
+        value={password}
+        onChange={(event) => setPassword(event.target.value)}
+        disabled={state.status === "submitting"}
+        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-gray-300 focus:outline-none"
+      />
       <button
         type="submit"
         disabled={state.status === "submitting"}
         className="rounded bg-gray-100 px-3 py-2 text-sm font-medium text-gray-900 disabled:opacity-50"
       >
-        {state.status === "submitting" ? "Sending…" : "Send sign-in link"}
+        {state.status === "submitting"
+          ? password.length > 0
+            ? "Signing in…"
+            : "Sending…"
+          : password.length > 0
+            ? "Sign in"
+            : "Send sign-in link"}
       </button>
       {state.status === "error" && (
         <p role="alert" className="text-sm text-red-300">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -31,8 +31,9 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
       <h1 className="text-4xl font-bold">Intentional Society</h1>
-      <p className="text-sm text-gray-400">
-        Enter your email to receive a sign-in link.
+      <p className="max-w-sm text-center text-sm text-gray-400">
+        Sign in with your password, or leave it blank to receive a magic
+        link by email.
       </p>
       {errorMessage && (
         <p

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,7 @@
-import { eq } from "drizzle-orm";
 import { redirect } from "next/navigation";
 
 import { createClient } from "@/lib/supabase/server";
-import { db } from "@/server/db";
-import { upsertProfile } from "@/server/profiles";
-import { profiles } from "@/server/schema";
+import { getProfileForSelf, upsertProfile } from "@/server/profiles";
 
 import { MeSmokeWidget } from "./me-smoke";
 
@@ -24,14 +21,18 @@ export default async function Home() {
     redirect("/login");
   }
 
-  const readProfile = () =>
-    db.select().from(profiles).where(eq(profiles.id, user.id));
-
-  let [profile] = await readProfile();
+  let profile = await getProfileForSelf(user.id);
   if (!profile) {
     // Self-heal in case 1d's callback upsert failed.
     await upsertProfile(user);
-    [profile] = await readProfile();
+    profile = await getProfileForSelf(user.id);
+  }
+
+  // Incomplete-profile heuristic: bio null means the member has not
+  // completed /welcome yet. bio is the one field the welcome form
+  // always collects, so it's a reliable sentinel.
+  if (profile && profile.bio === null) {
+    redirect("/welcome");
   }
 
   return (

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,0 +1,42 @@
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/lib/supabase/server";
+import { getProfileForSelf, upsertProfile } from "@/server/profiles";
+
+import { WelcomeForm } from "./welcome-form";
+
+export default async function WelcomePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/login");
+  }
+
+  let profile = await getProfileForSelf(user.id);
+  if (!profile) {
+    await upsertProfile(user);
+    profile = await getProfileForSelf(user.id);
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <h1 className="text-4xl font-bold">Welcome</h1>
+      <p className="max-w-md text-center text-sm text-gray-400">
+        Tell us a little about yourself. You can edit this later.
+      </p>
+      <WelcomeForm
+        initial={{
+          bio: profile?.bio ?? "",
+          keywords: profile?.keywords ?? [],
+          location: profile?.location ?? "",
+          supplementaryInfo: profile?.supplementaryInfo ?? "",
+          avatarUrl: profile?.avatarUrl ?? "",
+          emergencyContact: profile?.emergencyContact ?? "",
+          liveDesire: profile?.liveDesire ?? "",
+        }}
+      />
+    </main>
+  );
+}

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -28,6 +28,7 @@ export default async function WelcomePage() {
       </p>
       <WelcomeForm
         initial={{
+          displayName: profile?.displayName ?? "",
           bio: profile?.bio ?? "",
           keywords: profile?.keywords ?? [],
           location: profile?.location ?? "",

--- a/src/app/welcome/welcome-form.tsx
+++ b/src/app/welcome/welcome-form.tsx
@@ -43,47 +43,58 @@ export function WelcomeForm({ initial }: { initial: Initial }) {
     event.preventDefault();
     setStatus({ kind: "submitting" });
 
-    const keywords = keywordsText
-      .split(",")
-      .map((k) => k.trim())
-      .filter(Boolean);
+    try {
+      const keywords = keywordsText
+        .split(",")
+        .map((k) => k.trim())
+        .filter(Boolean);
 
-    const res = await apiClient.api.me.$put({
-      json: {
-        displayName: displayName.trim() || null,
-        bio: bio.trim() || null,
-        keywords,
-        location: location.trim() || null,
-        supplementaryInfo: supplementaryInfo.trim() || null,
-        avatarUrl: avatarUrl.trim() || null,
-        emergencyContact: emergencyContact.trim() || null,
-        liveDesire: liveDesire.trim() || null,
-      },
-    });
-
-    if (!res.ok) {
-      const body = (await res.json().catch(() => ({}))) as { error?: string };
-      setStatus({
-        kind: "error",
-        message: body.error ?? "Failed to save profile.",
+      const res = await apiClient.api.me.$put({
+        json: {
+          displayName: displayName.trim() || null,
+          bio: bio.trim() || null,
+          keywords,
+          location: location.trim() || null,
+          supplementaryInfo: supplementaryInfo.trim() || null,
+          avatarUrl: avatarUrl.trim() || null,
+          emergencyContact: emergencyContact.trim() || null,
+          liveDesire: liveDesire.trim() || null,
+        },
       });
-      return;
-    }
 
-    if (password.length > 0) {
-      const supabase = createClient();
-      const { error } = await supabase.auth.updateUser({ password });
-      if (error) {
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
         setStatus({
           kind: "error",
-          message: `Profile saved, but password update failed: ${error.message}`,
+          message: body.error ?? "Failed to save profile.",
         });
         return;
       }
-    }
 
-    router.push("/");
-    router.refresh();
+      if (password.length > 0) {
+        const supabase = createClient();
+        const { error } = await supabase.auth.updateUser({ password });
+        if (error) {
+          setStatus({
+            kind: "error",
+            message: `Profile saved, but password update failed: ${error.message}`,
+          });
+          return;
+        }
+      }
+
+      router.push("/");
+      router.refresh();
+    } catch (err) {
+      // Unexpected throws (network drop, CORS, a thrown Supabase client
+      // bug) must not leave the button stuck on "Saving…" with no UI
+      // feedback. Surface the message and release the form.
+      setStatus({
+        kind: "error",
+        message:
+          err instanceof Error ? err.message : "Unexpected error while saving.",
+      });
+    }
   };
 
   const disabled = status.kind === "submitting";

--- a/src/app/welcome/welcome-form.tsx
+++ b/src/app/welcome/welcome-form.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { apiClient } from "@/lib/api";
+import { createClient } from "@/lib/supabase/client";
+
+type Initial = {
+  bio: string;
+  keywords: string[];
+  location: string;
+  supplementaryInfo: string;
+  avatarUrl: string;
+  emergencyContact: string;
+  liveDesire: string;
+};
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "error"; message: string };
+
+export function WelcomeForm({ initial }: { initial: Initial }) {
+  const router = useRouter();
+  const [bio, setBio] = useState(initial.bio);
+  const [keywordsText, setKeywordsText] = useState(initial.keywords.join(", "));
+  const [location, setLocation] = useState(initial.location);
+  const [supplementaryInfo, setSupplementaryInfo] = useState(
+    initial.supplementaryInfo,
+  );
+  const [avatarUrl, setAvatarUrl] = useState(initial.avatarUrl);
+  const [emergencyContact, setEmergencyContact] = useState(
+    initial.emergencyContact,
+  );
+  const [liveDesire, setLiveDesire] = useState(initial.liveDesire);
+  const [password, setPassword] = useState("");
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus({ kind: "submitting" });
+
+    const keywords = keywordsText
+      .split(",")
+      .map((k) => k.trim())
+      .filter(Boolean);
+
+    const res = await apiClient.api.me.$put({
+      json: {
+        bio: bio.trim() || null,
+        keywords,
+        location: location.trim() || null,
+        supplementaryInfo: supplementaryInfo.trim() || null,
+        avatarUrl: avatarUrl.trim() || null,
+        emergencyContact: emergencyContact.trim() || null,
+        liveDesire: liveDesire.trim() || null,
+      },
+    });
+
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      setStatus({
+        kind: "error",
+        message: body.error ?? "Failed to save profile.",
+      });
+      return;
+    }
+
+    if (password.length > 0) {
+      const supabase = createClient();
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) {
+        setStatus({
+          kind: "error",
+          message: `Profile saved, but password update failed: ${error.message}`,
+        });
+        return;
+      }
+    }
+
+    router.push("/");
+    router.refresh();
+  };
+
+  const disabled = status.kind === "submitting";
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex w-full max-w-md flex-col gap-3"
+    >
+      <label className="text-sm text-gray-300" htmlFor="bio">
+        Bio
+      </label>
+      <textarea
+        id="bio"
+        required
+        value={bio}
+        onChange={(e) => setBio(e.target.value)}
+        disabled={disabled}
+        rows={4}
+        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-gray-300 focus:outline-none"
+      />
+
+      <label className="text-sm text-gray-300" htmlFor="keywords">
+        Keywords (comma-separated)
+      </label>
+      <input
+        id="keywords"
+        type="text"
+        value={keywordsText}
+        onChange={(e) => setKeywordsText(e.target.value)}
+        disabled={disabled}
+        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-gray-300 focus:outline-none"
+      />
+
+      <label className="text-sm text-gray-300" htmlFor="location">
+        Location
+      </label>
+      <input
+        id="location"
+        type="text"
+        value={location}
+        onChange={(e) => setLocation(e.target.value)}
+        disabled={disabled}
+        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-gray-300 focus:outline-none"
+      />
+
+      <label className="text-sm text-gray-300" htmlFor="liveDesire">
+        Live desire
+      </label>
+      <textarea
+        id="liveDesire"
+        value={liveDesire}
+        onChange={(e) => setLiveDesire(e.target.value)}
+        disabled={disabled}
+        rows={3}
+        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-gray-300 focus:outline-none"
+      />
+
+      <label className="text-sm text-gray-300" htmlFor="supplementaryInfo">
+        Anything else
+      </label>
+      <textarea
+        id="supplementaryInfo"
+        value={supplementaryInfo}
+        onChange={(e) => setSupplementaryInfo(e.target.value)}
+        disabled={disabled}
+        rows={3}
+        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-gray-300 focus:outline-none"
+      />
+
+      <label className="text-sm text-gray-300" htmlFor="avatarUrl">
+        Avatar URL
+      </label>
+      <input
+        id="avatarUrl"
+        type="url"
+        value={avatarUrl}
+        onChange={(e) => setAvatarUrl(e.target.value)}
+        disabled={disabled}
+        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-gray-300 focus:outline-none"
+      />
+
+      <label className="text-sm text-gray-300" htmlFor="emergencyContact">
+        Emergency contact
+      </label>
+      <input
+        id="emergencyContact"
+        type="text"
+        value={emergencyContact}
+        onChange={(e) => setEmergencyContact(e.target.value)}
+        disabled={disabled}
+        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-gray-300 focus:outline-none"
+      />
+      <p className="text-xs text-gray-500">
+        Visible only to you (and admins in case of emergency).
+      </p>
+
+      <hr className="my-3 border-gray-700" />
+
+      <label className="text-sm text-gray-300" htmlFor="password">
+        Set a password (optional)
+      </label>
+      <input
+        id="password"
+        type="password"
+        autoComplete="new-password"
+        placeholder="Leave blank to continue using magic links"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        disabled={disabled}
+        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-gray-300 focus:outline-none"
+      />
+      <p className="text-xs text-gray-500">
+        You can always sign in with a magic link instead.
+      </p>
+
+      <button
+        type="submit"
+        disabled={disabled}
+        className="mt-3 rounded bg-gray-100 px-3 py-2 text-sm font-medium text-gray-900 disabled:opacity-50"
+      >
+        {disabled ? "Saving…" : "Save"}
+      </button>
+
+      {status.kind === "error" && (
+        <p role="alert" className="text-sm text-red-300">
+          {status.message}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/src/app/welcome/welcome-form.tsx
+++ b/src/app/welcome/welcome-form.tsx
@@ -7,6 +7,7 @@ import { apiClient } from "@/lib/api";
 import { createClient } from "@/lib/supabase/client";
 
 type Initial = {
+  displayName: string;
   bio: string;
   keywords: string[];
   location: string;
@@ -23,6 +24,7 @@ type Status =
 
 export function WelcomeForm({ initial }: { initial: Initial }) {
   const router = useRouter();
+  const [displayName, setDisplayName] = useState(initial.displayName);
   const [bio, setBio] = useState(initial.bio);
   const [keywordsText, setKeywordsText] = useState(initial.keywords.join(", "));
   const [location, setLocation] = useState(initial.location);
@@ -48,6 +50,7 @@ export function WelcomeForm({ initial }: { initial: Initial }) {
 
     const res = await apiClient.api.me.$put({
       json: {
+        displayName: displayName.trim() || null,
         bio: bio.trim() || null,
         keywords,
         location: location.trim() || null,
@@ -90,6 +93,19 @@ export function WelcomeForm({ initial }: { initial: Initial }) {
       onSubmit={handleSubmit}
       className="flex w-full max-w-md flex-col gap-3"
     >
+      <label className="text-sm text-gray-300" htmlFor="displayName">
+        Display name
+      </label>
+      <input
+        id="displayName"
+        type="text"
+        required
+        value={displayName}
+        onChange={(e) => setDisplayName(e.target.value)}
+        disabled={disabled}
+        className="rounded border border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-gray-300 focus:outline-none"
+      />
+
       <label className="text-sm text-gray-300" htmlFor="bio">
         Bio
       </label>
@@ -140,7 +156,7 @@ export function WelcomeForm({ initial }: { initial: Initial }) {
       />
 
       <label className="text-sm text-gray-300" htmlFor="supplementaryInfo">
-        Anything else
+        Supplementary info
       </label>
       <textarea
         id="supplementaryInfo"

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,10 +1,15 @@
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { log } from "next-axiom";
 
 import { type ApiVariables, requireAuth } from "./auth-middleware";
 import { db } from "./db";
-import { getProfileForSelf, upsertProfile } from "./profiles";
+import {
+  getProfileForSelf,
+  parseEditableProfile,
+  upsertProfile,
+} from "./profiles";
+import { profiles } from "./schema";
 
 const api = new Hono<{ Variables: ApiVariables }>()
   .basePath("/api")
@@ -34,6 +39,35 @@ const api = new Hono<{ Variables: ApiVariables }>()
       profile = await getProfileForSelf(user.id);
     }
 
+    return c.json({ id: user.id, email: user.email, profile });
+  })
+  .put("/me", async (c) => {
+    const user = c.get("user");
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid JSON" }, 400);
+    }
+
+    const parsed = parseEditableProfile(body);
+    if ("error" in parsed) {
+      return c.json({ error: parsed.error }, 400);
+    }
+
+    // Ensure a row exists before updating — same self-heal guarantee
+    // GET /me has, since a client can PUT /me before ever calling GET.
+    const existing = await getProfileForSelf(user.id);
+    if (!existing) {
+      await upsertProfile(user);
+    }
+
+    if (Object.keys(parsed).length > 0) {
+      await db.update(profiles).set(parsed).where(eq(profiles.id, user.id));
+    }
+
+    const profile = await getProfileForSelf(user.id);
     return c.json({ id: user.id, email: user.email, profile });
   })
   .get("/health", async (c) => {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,11 +1,10 @@
-import { eq, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { log } from "next-axiom";
 
 import { type ApiVariables, requireAuth } from "./auth-middleware";
 import { db } from "./db";
-import { upsertProfile } from "./profiles";
-import { profiles } from "./schema";
+import { getProfileForSelf, upsertProfile } from "./profiles";
 
 const api = new Hono<{ Variables: ApiVariables }>()
   .basePath("/api")
@@ -27,22 +26,12 @@ const api = new Hono<{ Variables: ApiVariables }>()
   .get("/me", async (c) => {
     const user = c.get("user");
 
-    const selectProfile = () =>
-      db
-        .select({
-          id: profiles.id,
-          displayName: profiles.displayName,
-          createdAt: profiles.createdAt,
-        })
-        .from(profiles)
-        .where(eq(profiles.id, user.id));
-
-    let [profile] = await selectProfile();
+    let profile = await getProfileForSelf(user.id);
     if (!profile) {
       // Self-heal: 1d's callback can leave a session without a profile
       // row if the upsert failed there. The next authed request repairs.
       await upsertProfile(user);
-      [profile] = await selectProfile();
+      profile = await getProfileForSelf(user.id);
     }
 
     return c.json({ id: user.id, email: user.email, profile });

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -5,6 +5,7 @@ import { db } from "./db";
 import { profiles } from "./schema";
 
 export const EDITABLE_PROFILE_FIELDS = [
+  "displayName",
   "bio",
   "keywords",
   "location",
@@ -17,6 +18,7 @@ export const EDITABLE_PROFILE_FIELDS = [
 type EditableField = (typeof EDITABLE_PROFILE_FIELDS)[number];
 
 export type EditableProfileInput = Partial<{
+  displayName: string | null;
   bio: string | null;
   keywords: string[];
   location: string | null;
@@ -34,8 +36,8 @@ const isStringArray = (v: unknown): v is string[] =>
 
 // Returns the sanitized update payload, or a string describing the
 // first validation failure. Unknown keys are treated as failures to
-// protect fields like isAdmin / referredBy / displayName from being
-// set via the editable endpoint.
+// protect fields like isAdmin / referredBy from being set via the
+// editable endpoint.
 export const parseEditableProfile = (
   body: unknown,
 ): EditableProfileInput | { error: string } => {

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -127,14 +127,12 @@ export const getProfileForSelf = async (
 // Placeholder. The member-directory endpoint is not built yet; throwing
 // here forces the access-control shape to be decided the moment that
 // work starts, instead of silently reusing the self shape.
-export const getProfileForMember = async (
-  _userId: string,
-): Promise<never> => {
+export const getProfileForMember = async (): Promise<never> => {
   throw new Error("NotImplemented: getProfileForMember");
 };
 
 // Placeholder. Same rationale as getProfileForMember — admin tooling
 // will choose its own shape when it lands.
-export const getProfileForAdmin = async (_userId: string): Promise<never> => {
+export const getProfileForAdmin = async (): Promise<never> => {
   throw new Error("NotImplemented: getProfileForAdmin");
 };

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -1,4 +1,5 @@
 import type { User } from "@supabase/supabase-js";
+import { eq } from "drizzle-orm";
 
 import { db } from "./db";
 import { profiles } from "./schema";
@@ -11,4 +12,62 @@ export const upsertProfile = async (user: User) => {
     .insert(profiles)
     .values({ id: user.id, displayName })
     .onConflictDoNothing({ target: profiles.id });
+};
+
+export type ProfileForSelf = {
+  id: string;
+  displayName: string | null;
+  bio: string | null;
+  keywords: string[];
+  location: string | null;
+  supplementaryInfo: string | null;
+  referredBy: string | null;
+  referredByLegacy: string | null;
+  avatarUrl: string | null;
+  emergencyContact: string | null;
+  liveDesire: string | null;
+  isAdmin: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export const getProfileForSelf = async (
+  userId: string,
+): Promise<ProfileForSelf | null> => {
+  const [row] = await db
+    .select({
+      id: profiles.id,
+      displayName: profiles.displayName,
+      bio: profiles.bio,
+      keywords: profiles.keywords,
+      location: profiles.location,
+      supplementaryInfo: profiles.supplementaryInfo,
+      referredBy: profiles.referredBy,
+      referredByLegacy: profiles.referredByLegacy,
+      avatarUrl: profiles.avatarUrl,
+      emergencyContact: profiles.emergencyContact,
+      liveDesire: profiles.liveDesire,
+      isAdmin: profiles.isAdmin,
+      createdAt: profiles.createdAt,
+      updatedAt: profiles.updatedAt,
+    })
+    .from(profiles)
+    .where(eq(profiles.id, userId));
+
+  return row ?? null;
+};
+
+// Placeholder. The member-directory endpoint is not built yet; throwing
+// here forces the access-control shape to be decided the moment that
+// work starts, instead of silently reusing the self shape.
+export const getProfileForMember = async (
+  _userId: string,
+): Promise<never> => {
+  throw new Error("NotImplemented: getProfileForMember");
+};
+
+// Placeholder. Same rationale as getProfileForMember — admin tooling
+// will choose its own shape when it lands.
+export const getProfileForAdmin = async (_userId: string): Promise<never> => {
+  throw new Error("NotImplemented: getProfileForAdmin");
 };

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -4,6 +4,73 @@ import { eq } from "drizzle-orm";
 import { db } from "./db";
 import { profiles } from "./schema";
 
+export const EDITABLE_PROFILE_FIELDS = [
+  "bio",
+  "keywords",
+  "location",
+  "supplementaryInfo",
+  "avatarUrl",
+  "emergencyContact",
+  "liveDesire",
+] as const;
+
+type EditableField = (typeof EDITABLE_PROFILE_FIELDS)[number];
+
+export type EditableProfileInput = Partial<{
+  bio: string | null;
+  keywords: string[];
+  location: string | null;
+  supplementaryInfo: string | null;
+  avatarUrl: string | null;
+  emergencyContact: string | null;
+  liveDesire: string | null;
+}>;
+
+const isNullableString = (v: unknown): v is string | null =>
+  v === null || typeof v === "string";
+
+const isStringArray = (v: unknown): v is string[] =>
+  Array.isArray(v) && v.every((s) => typeof s === "string");
+
+// Returns the sanitized update payload, or a string describing the
+// first validation failure. Unknown keys are treated as failures to
+// protect fields like isAdmin / referredBy / displayName from being
+// set via the editable endpoint.
+export const parseEditableProfile = (
+  body: unknown,
+): EditableProfileInput | { error: string } => {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { error: "body must be a JSON object" };
+  }
+
+  const input = body as Record<string, unknown>;
+  const out: EditableProfileInput = {};
+
+  for (const key of Object.keys(input)) {
+    if (!(EDITABLE_PROFILE_FIELDS as readonly string[]).includes(key)) {
+      return { error: `unknown or non-editable field: ${key}` };
+    }
+  }
+
+  for (const key of EDITABLE_PROFILE_FIELDS) {
+    if (!(key in input)) continue;
+    const value = input[key];
+    if (key === "keywords") {
+      if (!isStringArray(value)) {
+        return { error: "keywords must be an array of strings" };
+      }
+      out.keywords = value;
+    } else {
+      if (!isNullableString(value)) {
+        return { error: `${key} must be a string or null` };
+      }
+      out[key as Exclude<EditableField, "keywords">] = value;
+    }
+  }
+
+  return out;
+};
+
 export const upsertProfile = async (user: User) => {
   const displayName =
     (user.user_metadata?.displayName as string | undefined) ?? null;

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -1,8 +1,11 @@
 import { sql } from "drizzle-orm";
 import {
+  type AnyPgColumn,
+  boolean,
   check,
   pgSchema,
   pgTable,
+  primaryKey,
   text,
   timestamp,
   uuid,
@@ -21,6 +24,21 @@ export const profiles = pgTable("profiles", {
     .primaryKey()
     .references(() => authUsers.id),
   displayName: text("display_name"),
+  bio: text("bio"),
+  keywords: text("keywords")
+    .array()
+    .notNull()
+    .default(sql`'{}'::text[]`),
+  location: text("location"),
+  supplementaryInfo: text("supplementary_info"),
+  referredBy: uuid("referred_by").references((): AnyPgColumn => profiles.id, {
+    onDelete: "set null",
+  }),
+  referredByLegacy: text("referred_by_legacy"),
+  avatarUrl: text("avatar_url"),
+  emergencyContact: text("emergency_contact"),
+  liveDesire: text("live_desire"),
+  isAdmin: boolean("is_admin").notNull().default(false),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),
@@ -29,6 +47,32 @@ export const profiles = pgTable("profiles", {
     .defaultNow()
     .$onUpdate(() => new Date()),
 });
+
+export const programs = pgTable("programs", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  slug: text("slug").notNull().unique(),
+  name: text("name").notNull(),
+  description: text("description"),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export const profilePrograms = pgTable(
+  "profile_programs",
+  {
+    profileId: uuid("profile_id")
+      .notNull()
+      .references(() => profiles.id, { onDelete: "cascade" }),
+    programId: uuid("program_id")
+      .notNull()
+      .references(() => programs.id, { onDelete: "cascade" }),
+    assignedAt: timestamp("assigned_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [primaryKey({ columns: [table.profileId, table.programId] })],
+);
 
 export const invites = pgTable(
   "invites",

--- a/tests/e2e/login-password.spec.ts
+++ b/tests/e2e/login-password.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+
+// /login is public, so these tests run without a session. The Supabase
+// auth endpoints are intercepted at the Playwright level, which lets us
+// verify which method the form chooses (password vs magic link) without
+// needing a real session-minting helper (that's Phase 3's territory).
+
+const SUPABASE_AUTH = "**/auth/v1/**";
+
+test("password provided → signInWithPassword is called", async ({ page }) => {
+  let sawPasswordCall = false;
+  let sawOtpCall = false;
+
+  await page.route(SUPABASE_AUTH, async (route) => {
+    const url = route.request().url();
+    if (url.includes("/token") && url.includes("grant_type=password")) {
+      sawPasswordCall = true;
+      // Return a plausible-looking error so the form stops on the
+      // password branch and does not proceed to a real sign-in.
+      await route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "invalid_grant",
+          error_description: "Invalid login credentials",
+        }),
+      });
+      return;
+    }
+    if (url.includes("/otp")) {
+      sawOtpCall = true;
+    }
+    await route.fulfill({ status: 200, body: "{}" });
+  });
+
+  await page.goto("/login");
+  await page.getByLabel("Email").fill("member@example.test");
+  await page.getByLabel("Password (optional)").fill("hunter2");
+  await page.getByRole("button", { name: "Sign in" }).click();
+
+  // Next.js renders a hidden route-announcer with role="alert" too, so
+  // we target our error message by text rather than by role.
+  await expect(page.getByText("Invalid login credentials")).toBeVisible();
+  expect(sawPasswordCall).toBe(true);
+  expect(sawOtpCall).toBe(false);
+});
+
+test("password blank → signInWithOtp is called", async ({ page }) => {
+  let sawPasswordCall = false;
+  let sawOtpCall = false;
+
+  await page.route(SUPABASE_AUTH, async (route) => {
+    const url = route.request().url();
+    if (url.includes("/token") && url.includes("grant_type=password")) {
+      sawPasswordCall = true;
+    }
+    if (url.includes("/otp")) {
+      sawOtpCall = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: {}, error: null }),
+      });
+      return;
+    }
+    await route.fulfill({ status: 200, body: "{}" });
+  });
+
+  await page.goto("/login");
+  await page.getByLabel("Email").fill("member@example.test");
+  // Leave password blank intentionally.
+  await page.getByRole("button", { name: "Send sign-in link" }).click();
+
+  await expect(
+    page.getByText("Check member@example.test for a sign-in link."),
+  ).toBeVisible();
+  expect(sawOtpCall).toBe(true);
+  expect(sawPasswordCall).toBe(false);
+});

--- a/tests/functional/api-me.test.ts
+++ b/tests/functional/api-me.test.ts
@@ -102,6 +102,7 @@ describe("GET /api/me", () => {
 
   it("PUT /me updates allowed fields and returns the self shape", async () => {
     const res = await putMe({
+      displayName: "Member Name",
       bio: "Hi, I'm a member.",
       keywords: ["curious", "writing"],
       location: "Lisbon",
@@ -110,6 +111,7 @@ describe("GET /api/me", () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
+    expect(body.profile.displayName).toBe("Member Name");
     expect(body.profile.bio).toBe("Hi, I'm a member.");
     expect(body.profile.keywords).toEqual(["curious", "writing"]);
     expect(body.profile.location).toBe("Lisbon");
@@ -119,16 +121,11 @@ describe("GET /api/me", () => {
     expect(body.profile.avatarUrl).toBeNull();
     // isAdmin stays its default.
     expect(body.profile.isAdmin).toBe(false);
-
-    // displayName came from upsert on first PUT (self-heal), not from
-    // the request body — PUT doesn't accept displayName.
-    expect(body.profile.displayName).toBe("Test User");
   });
 
   it.each([
     ["isAdmin", { isAdmin: true }],
     ["referredBy", { referredBy: "11111111-1111-1111-1111-111111111111" }],
-    ["displayName", { displayName: "New Name" }],
     ["createdAt", { createdAt: "2026-01-01T00:00:00Z" }],
     ["id", { id: "11111111-1111-1111-1111-111111111111" }],
   ])("PUT /me rejects non-editable field: %s", async (_label, body) => {

--- a/tests/functional/api-me.test.ts
+++ b/tests/functional/api-me.test.ts
@@ -54,6 +54,13 @@ describe("GET /api/me", () => {
     );
   });
 
+  const putMe = (body: unknown) =>
+    app.request("/api/me", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
   it("returns the self shape and self-heals a missing profile row", async () => {
     // No profile pre-inserted — handler must upsert on first call.
     const res = await app.request("/api/me");
@@ -91,5 +98,65 @@ describe("GET /api/me", () => {
       .from(profiles)
       .where(eq(profiles.id, testUserId));
     expect(rows).toHaveLength(1);
+  });
+
+  it("PUT /me updates allowed fields and returns the self shape", async () => {
+    const res = await putMe({
+      bio: "Hi, I'm a member.",
+      keywords: ["curious", "writing"],
+      location: "Lisbon",
+      emergencyContact: "Alex · +351 999",
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.profile.bio).toBe("Hi, I'm a member.");
+    expect(body.profile.keywords).toEqual(["curious", "writing"]);
+    expect(body.profile.location).toBe("Lisbon");
+    expect(body.profile.emergencyContact).toBe("Alex · +351 999");
+
+    // Untouched nullable fields remain null.
+    expect(body.profile.avatarUrl).toBeNull();
+    // isAdmin stays its default.
+    expect(body.profile.isAdmin).toBe(false);
+
+    // displayName came from upsert on first PUT (self-heal), not from
+    // the request body — PUT doesn't accept displayName.
+    expect(body.profile.displayName).toBe("Test User");
+  });
+
+  it.each([
+    ["isAdmin", { isAdmin: true }],
+    ["referredBy", { referredBy: "11111111-1111-1111-1111-111111111111" }],
+    ["displayName", { displayName: "New Name" }],
+    ["createdAt", { createdAt: "2026-01-01T00:00:00Z" }],
+    ["id", { id: "11111111-1111-1111-1111-111111111111" }],
+  ])("PUT /me rejects non-editable field: %s", async (_label, body) => {
+    const res = await putMe(body);
+    expect(res.status).toBe(400);
+
+    // Confirm nothing leaked through: isAdmin stays false in DB.
+    const [row] = await db
+      .select()
+      .from(profiles)
+      .where(eq(profiles.id, testUserId));
+    expect(row?.isAdmin ?? false).toBe(false);
+  });
+
+  it("PUT /me rejects keywords that are not an array of strings", async () => {
+    const res = await putMe({ keywords: "not-an-array" });
+    expect(res.status).toBe(400);
+
+    const res2 = await putMe({ keywords: [1, 2, 3] });
+    expect(res2.status).toBe(400);
+  });
+
+  it("PUT /me rejects malformed JSON body", async () => {
+    const res = await app.request("/api/me", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: "{not json",
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/tests/functional/api-me.test.ts
+++ b/tests/functional/api-me.test.ts
@@ -54,22 +54,34 @@ describe("GET /api/me", () => {
     );
   });
 
-  it("returns the strict shape and self-heals a missing profile row", async () => {
+  it("returns the self shape and self-heals a missing profile row", async () => {
     // No profile pre-inserted — handler must upsert on first call.
     const res = await app.request("/api/me");
 
     expect(res.status).toBe(200);
     const body = await res.json();
 
-    // Strict equality: any accidental field leakage (e.g. Phase 2's
-    // emergencyContact) will fail this assertion loudly.
+    // Strict equality: the self shape is explicit. Any accidental
+    // field addition or omission will fail this assertion loudly.
+    // Programs intentionally absent — they're not a profile field.
     expect(body).toEqual({
       id: testUserId,
       email: "me-test@testfake.local",
       profile: {
         id: testUserId,
         displayName: "Test User",
+        bio: null,
+        keywords: [],
+        location: null,
+        supplementaryInfo: null,
+        referredBy: null,
+        referredByLegacy: null,
+        avatarUrl: null,
+        emergencyContact: null,
+        liveDesire: null,
+        isAdmin: false,
         createdAt: expect.any(String),
+        updatedAt: expect.any(String),
       },
     });
 

--- a/tests/functional/profiles.test.ts
+++ b/tests/functional/profiles.test.ts
@@ -5,7 +5,12 @@ import { eq, sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { db } from "@/server/db";
-import { upsertProfile } from "@/server/profiles";
+import {
+  getProfileForAdmin,
+  getProfileForMember,
+  getProfileForSelf,
+  upsertProfile,
+} from "@/server/profiles";
 import { profiles } from "@/server/schema";
 
 describe("upsertProfile", () => {
@@ -67,5 +72,69 @@ describe("upsertProfile", () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0]?.displayName).toBeNull();
+  });
+});
+
+describe("getProfileForSelf", () => {
+  let testUserId: string;
+
+  beforeEach(async () => {
+    testUserId = randomUUID();
+    await db.execute(
+      sql`INSERT INTO auth.users (id, is_sso_user, is_anonymous) VALUES (${testUserId}::uuid, false, false)`,
+    );
+    await db.insert(profiles).values({ id: testUserId, displayName: "Me" });
+  });
+
+  afterEach(async () => {
+    await db.delete(profiles).where(eq(profiles.id, testUserId));
+    await db.execute(
+      sql`DELETE FROM auth.users WHERE id = ${testUserId}::uuid`,
+    );
+  });
+
+  it("returns null for an unknown id", async () => {
+    expect(await getProfileForSelf(randomUUID())).toBeNull();
+  });
+
+  it("returns the full self shape, including emergencyContact and isAdmin", async () => {
+    const profile = await getProfileForSelf(testUserId);
+
+    // Explicit key list guards against accidental field removal during
+    // future refactors and locks in emergencyContact visibility for
+    // self. Programs are deliberately NOT a profile field.
+    expect(profile).not.toBeNull();
+    expect(Object.keys(profile!).sort()).toEqual(
+      [
+        "id",
+        "displayName",
+        "bio",
+        "keywords",
+        "location",
+        "supplementaryInfo",
+        "referredBy",
+        "referredByLegacy",
+        "avatarUrl",
+        "emergencyContact",
+        "liveDesire",
+        "isAdmin",
+        "createdAt",
+        "updatedAt",
+      ].sort(),
+    );
+  });
+});
+
+describe("getProfileForMember / getProfileForAdmin stubs", () => {
+  it("getProfileForMember throws NotImplemented", async () => {
+    await expect(getProfileForMember(randomUUID())).rejects.toThrow(
+      /NotImplemented/,
+    );
+  });
+
+  it("getProfileForAdmin throws NotImplemented", async () => {
+    await expect(getProfileForAdmin(randomUUID())).rejects.toThrow(
+      /NotImplemented/,
+    );
   });
 });

--- a/tests/functional/profiles.test.ts
+++ b/tests/functional/profiles.test.ts
@@ -127,14 +127,10 @@ describe("getProfileForSelf", () => {
 
 describe("getProfileForMember / getProfileForAdmin stubs", () => {
   it("getProfileForMember throws NotImplemented", async () => {
-    await expect(getProfileForMember(randomUUID())).rejects.toThrow(
-      /NotImplemented/,
-    );
+    await expect(getProfileForMember()).rejects.toThrow(/NotImplemented/);
   });
 
   it("getProfileForAdmin throws NotImplemented", async () => {
-    await expect(getProfileForAdmin(randomUUID())).rejects.toThrow(
-      /NotImplemented/,
-    );
+    await expect(getProfileForAdmin()).rejects.toThrow(/NotImplemented/);
   });
 });


### PR DESCRIPTION
## Summary
- Expands `profiles` from three columns to the full community shape (bio, keywords, location, supplementaryInfo, referredBy, referredByLegacy, avatarUrl, emergencyContact, liveDesire, isAdmin) and lands `programs` + `profilePrograms` as empty structural tables.
- Introduces the serialization-layer access-control pattern: `getProfileForSelf` returns the full self view; `getProfileForMember` / `getProfileForAdmin` are `NotImplemented` stubs so the next person to add a directory/admin surface is forced to decide the shape. `PUT /api/me` accepts only the editable subset (including `displayName`) and rejects unknown / privileged keys.
- Adds `/welcome` first-sign-in completion flow, an optional password on login, and a few follow-ups that surfaced during manual testing: Supabase-start conflict recovery on Windows, a try/catch on the welcome submit handler, and plan docs for Turbopack and `secure_password_change`.

## Test plan
- [x] `npm test` — 20 functional + 5 e2e green locally
- [x] Manual: magic-link sign-in → `/welcome` → fill form → land on `/`
- [x] Manual: set a password on `/welcome` → sign out → sign in with password
- [x] Manual: sign in with wrong password → see error, no magic-link fallback
- [x] CI lint + functional tests pass
- [x] Playwright against Vercel preview passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)