### PR TITLE
Improve logged-out home page (#66)

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-04-23 | Benji | Logged-out home page (#66)
+
+`/` no longer redirects unauthenticated visitors to `/login`. Instead it renders a landing page with a "Sign in" button, a "Join with an invite code" link to `/signup`, and a friendly nudge for non-members to join a Connection Call (links to the www site's get-involved page). `/login` and `/signup` now cross-link to each other so visitors can always find the right path. Updated the auth and logout e2e tests to match the new behavior.
+
 ## 2026-04-22 | James | Skip Vercel preview for docs-only changes
 
 Vercel's `ignoreCommand` now diffs HEAD against the previous successful deploy and skips the build when only `docs/` or root `CLAUDE.md` changed. See `docs/doc-strategy-committing.md`.

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { createClient } from "@/lib/supabase/server";
@@ -46,6 +47,12 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
         </p>
       )}
       <LoginForm />
+      <p className="text-sm text-gray-500">
+        Have an invite code?{" "}
+        <Link href="/signup" className="underline text-gray-400 hover:text-gray-200">
+          Sign up
+        </Link>
+      </p>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { createClient } from "@/lib/supabase/server";
@@ -13,13 +14,52 @@ async function signOut() {
   redirect("/login");
 }
 
+function LoggedOutHome() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-8 p-8">
+      <h1 className="text-4xl font-bold">Intentional Society</h1>
+      <p className="max-w-md text-center text-gray-400">
+        A community of people practicing relational growth together.
+      </p>
+
+      <div className="flex w-full max-w-sm flex-col gap-3">
+        <Link
+          href="/login"
+          className="block rounded bg-gray-100 px-3 py-2 text-center text-sm font-medium text-gray-900"
+        >
+          Sign in
+        </Link>
+        <Link
+          href="/signup"
+          className="block rounded border border-gray-600 px-3 py-2 text-center text-sm font-medium text-gray-300"
+        >
+          Join with an invite code
+        </Link>
+      </div>
+
+      <p className="max-w-sm text-center text-sm text-gray-500">
+        Don&apos;t have an invite?{" "}
+        <a
+          href="https://www.intentionalsociety.org/get-involved#connection-calls"
+          className="underline text-gray-400 hover:text-gray-200"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Join a Connection Call
+        </a>{" "}
+        to meet the community and learn more.
+      </p>
+    </main>
+  );
+}
+
 export default async function Home() {
   const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/login");
+    return <LoggedOutHome />;
   }
 
   let profile = await getProfileForSelf(user.id);

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { createClient } from "@/lib/supabase/server";
@@ -27,6 +28,12 @@ export default async function SignupPage({ searchParams }: SignupPageProps) {
         Joining by invite? Enter the code a member shared with you.
       </p>
       <SignupForm initialCode={code ?? ""} />
+      <p className="text-sm text-gray-500">
+        Already a member?{" "}
+        <Link href="/login" className="underline text-gray-400 hover:text-gray-200">
+          Sign in
+        </Link>
+      </p>
     </main>
   );
 }

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,13 +1,18 @@
 import { test, expect } from "@playwright/test";
 
-test("unauthenticated visit to / redirects to /login", async ({ page }) => {
+test("unauthenticated visit to / shows logged-out home page", async ({ page }) => {
   await page.goto("/");
-  await page.waitForURL("**/login");
 
   await expect(
     page.getByRole("heading", { name: "Intentional Society" }),
   ).toBeVisible();
-  await expect(page.getByLabel("Email")).toBeVisible();
+  await expect(page.getByRole("link", { name: "Sign in" })).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "Join with an invite code" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "Join a Connection Call" }),
+  ).toBeVisible();
 });
 
 test("unauthenticated /api/hello returns 401", async ({ request }) => {

--- a/tests/e2e/logout.spec.ts
+++ b/tests/e2e/logout.spec.ts
@@ -10,13 +10,10 @@ test("GET /logout signs the user out and lands on /login", async ({ page }) => {
     timeout: 10_000,
   });
 
-  // Confirm the session really is gone — / should bounce us back to
-  // /login rather than re-render the authed home page.
+  // Confirm the session really is gone — / should show the logged-out
+  // home page rather than the authed view.
   await page.goto("/");
-  await page.waitForURL((url) => url.pathname === "/login", {
-    timeout: 10_000,
-  });
-  await expect(page.getByLabel("Email")).toBeVisible();
+  await expect(page.getByRole("link", { name: "Sign in" })).toBeVisible();
 });
 
 test("GET /logout works even with no session", async ({ page }) => {


### PR DESCRIPTION
/ now renders a landing page for unauthenticated visitors instead of redirecting to /login. Shows sign-in and signup buttons, plus a link to the www get-involved page for non-members without an invite. /login and /signup cross-link to each other. E2E tests updated.