### PR TITLE
Add --fix flag to check-env.mjs to append missing keys

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -18,6 +18,10 @@ Added shadcn/ui (4.5.0, Base Nova style, neutral palette, lucide icons), startin
 
 To make React component tests first-class, split Vitest into two projects — `functional-server` (Node, existing API tests, needs DB) and `functional-client` (jsdom + `@vitejs/plugin-react`, no DB, ~5s) — and enhanced `npm test` to include lint → typecheck → functional (both) → e2e. New client tests cover `AuthProvider` and `SiteHeader`, and TDD'd a fix where the tests can assert no `console.error` happens.
 
+## 2026-04-25 | Blake | `check-env.mjs --fix` appends missing keys
+
+Follow-up to the env-preflight work: `node scripts/check-env.mjs --fix` now appends any missing keys (with their `.env.local.example` values) directly to `.env.local`, with a dated provenance comment, so devs don't have to copy lines by hand. Existing values stay untouched; idempotent on re-run. Both the preflight error message and the `setup.mjs` hint now recommend `--fix` directly.
+
 ## 2026-04-23 | Blake | GitHub CLI documented as optional prerequisite
 
 Added `## GitHub CLI` to `docs/setup-dev-machine.md` and a pointer in `docs/doc-local-setup.md`. Not required to run the app, but required for PR / issue workflows from the terminal — including via Claude Code, which can't drive a browser. Install via `winget` on Windows or `brew` on Mac, then `gh auth login` once per OS user. Credentials live in the OS keyring, so one login covers every same-user shell including the VS Code / Claude Code integrated terminal; WSL has its own state and needs a separate login.

--- a/scripts/check-env.mjs
+++ b/scripts/check-env.mjs
@@ -4,9 +4,14 @@
 // dev/test boundary with an actionable error, instead of leaking through to
 // test failures ten layers deep. Keys-only — values are not compared, since
 // devs are free to override locally.
+//
+// Pass --fix to append any missing key lines from .env.local.example to
+// .env.local. Non-destructive: existing values are untouched.
 
-import { existsSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+
+const fixMode = process.argv.slice(2).includes("--fix");
 
 const repoRoot = resolve(import.meta.dirname, "..");
 const examplePath = resolve(repoRoot, ".env.local.example");
@@ -37,20 +42,44 @@ if (!existsSync(localPath)) {
   process.exit(1);
 }
 
-const exampleKeys = extractKeys(readFileSync(examplePath, "utf8"));
-const localKeys = extractKeys(readFileSync(localPath, "utf8"));
+const exampleContents = readFileSync(examplePath, "utf8");
+const localContents = readFileSync(localPath, "utf8");
+const exampleKeys = extractKeys(exampleContents);
+const localKeys = extractKeys(localContents);
 
 const missing = [...exampleKeys].filter((k) => !localKeys.has(k));
 if (missing.length > 0) {
+  if (fixMode) {
+    const missingSet = new Set(missing);
+    const linesToAppend = exampleContents.split(/\r?\n/).filter((line) => {
+      const m = line.match(KEY_LINE);
+      return m && missingSet.has(m[1]);
+    });
+    const needsLeadingNewline =
+      localContents.length > 0 && !localContents.endsWith("\n");
+    const today = new Date().toISOString().slice(0, 10);
+    const block =
+      (needsLeadingNewline ? "\n" : "") +
+      `# Appended by \`scripts/check-env.mjs --fix\` on ${today}\n` +
+      linesToAppend.join("\n") +
+      "\n";
+    appendFileSync(localPath, block);
+    process.stdout.write(
+      `check-env --fix: appended ${missing.length} key(s) to .env.local:\n`,
+    );
+    for (const key of missing) process.stdout.write(`  + ${key}\n`);
+    process.exit(0);
+  }
+
   console.error(
     `check-env: .env.local is missing ${missing.length} key(s) declared in .env.local.example:`,
   );
   for (const key of missing) console.error(`  - ${key}`);
   console.error(
-    "  Fix: append the missing keys from .env.local.example to .env.local",
+    "  Fix: run `node scripts/check-env.mjs --fix` to append the missing keys",
   );
   console.error(
-    "       — this preserves any custom values you've added.",
+    "       (preserves any custom values you've added).",
   );
   console.error(
     "       Or (destructive, wipes local customizations): delete .env.local",

--- a/scripts/check-env.mjs
+++ b/scripts/check-env.mjs
@@ -8,7 +8,7 @@
 // Pass --fix to append any missing key lines from .env.local.example to
 // .env.local. Non-destructive: existing values are untouched.
 
-import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const fixMode = process.argv.slice(2).includes("--fix");
@@ -28,7 +28,11 @@ function extractKeys(contents) {
   return keys;
 }
 
-if (!existsSync(examplePath)) {
+let exampleContents;
+try {
+  exampleContents = readFileSync(examplePath, "utf8");
+} catch (err) {
+  if (err.code !== "ENOENT") throw err;
   console.error("check-env: .env.local.example is missing from the repo.");
   console.error(
     "  This file is the canonical list of env keys and should be committed.",
@@ -36,14 +40,16 @@ if (!existsSync(examplePath)) {
   process.exit(1);
 }
 
-if (!existsSync(localPath)) {
+let localContents;
+try {
+  localContents = readFileSync(localPath, "utf8");
+} catch (err) {
+  if (err.code !== "ENOENT") throw err;
   console.error("check-env: .env.local is missing.");
   console.error("  Fix: run `npm run setup`.");
   process.exit(1);
 }
 
-const exampleContents = readFileSync(examplePath, "utf8");
-const localContents = readFileSync(localPath, "utf8");
 const exampleKeys = extractKeys(exampleContents);
 const localKeys = extractKeys(localContents);
 

--- a/scripts/check-env.mjs
+++ b/scripts/check-env.mjs
@@ -82,17 +82,13 @@ if (missing.length > 0) {
   );
   for (const key of missing) console.error(`  - ${key}`);
   console.error(
-    "  Fix: run `node scripts/check-env.mjs --fix` to append the missing keys",
+    "  Fix: run `node scripts/check-env.mjs --fix` to append them from .env.local.example",
   );
+  console.error("       (existing values are preserved).");
   console.error(
-    "       (preserves any custom values you've added).",
+    "       Or to start fresh (wipes local customizations): delete .env.local",
   );
-  console.error(
-    "       Or (destructive, wipes local customizations): delete .env.local",
-  );
-  console.error(
-    "       and run `npm run setup` to regenerate from the template.",
-  );
+  console.error("       and run `npm run setup`.");
   process.exit(1);
 }
 

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -13,7 +13,7 @@ function ensureLocalEnv() {
   if (existsSync(target)) {
     console.log("  .env.local already exists — leaving it alone");
     console.log(
-      "  (if tests complain about missing keys, run `node scripts/check-env.mjs`)",
+      "  (if tests complain about missing keys, run `node scripts/check-env.mjs --fix`)",
     );
     return;
   }

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -13,7 +13,7 @@ function ensureLocalEnv() {
   if (existsSync(target)) {
     console.log("  .env.local already exists — leaving it alone");
     console.log(
-      "  (if tests complain about missing keys, run `node scripts/check-env.mjs --fix`)",
+      "  (if tests complain about missing keys, run `node scripts/check-env.mjs` to list them, or with `--fix` to append them)",
     );
     return;
   }


### PR DESCRIPTION
Closes #73

## Context
Follow-up to the env-preflight work in #60. That PR detects when `.env.local` is missing keys declared in `.env.local.example`, but the only remediation it offers is "copy the lines over manually." This is the "non-destructive fix" outcome described in #70 that #60 deferred.

## What changed
- `scripts/check-env.mjs`: new `--fix` flag. Reads missing keys from `.env.local.example` and appends just the `KEY=VALUE` lines to `.env.local`, prefixed with a dated provenance comment (`# Appended by scripts/check-env.mjs --fix on YYYY-MM-DD`). Existing values stay untouched. Idempotent — a second `--fix` finds nothing missing and exits 0 via the normal success path. Without `--fix`, behavior is unchanged except the error message now recommends running with `--fix` instead of "append manually".
- `scripts/setup.mjs`: hint now points at `--fix` directly so the flag is discoverable from first-time setup output.
- `docs/devjournal.md`: 2026-04-25 entry.

## Why
The more keys we add to `.env.local.example`, the more friction the manual-copy step creates. A dev who hits the preflight error today already has the file open and the keys they need — `--fix` lets them resolve it with one command instead of context-switching to an editor. Existing `.env.local` values (local overrides, custom secrets) are preserved, so the fix is safe to recommend by default.

## Test Plan
- `npm run lint` — clean
- `npm run test:functional` — 7 files / 52 tests pass (after rebase on latest main, which split Vitest into server/client projects)
- Manual: backed up `.env.local`, removed `E2E_ADMIN_PASSWORD` and `CI_RESET_TOKEN`, ran `node scripts/check-env.mjs` (correctly errored, listed both missing keys, recommended `--fix`); ran `node scripts/check-env.mjs --fix` (appended both keys with the dated header, exit 0); re-ran `--fix` (no-op, exit 0); ran plain `check-env` (ok, 7 keys); restored backup.
- Not exercised in CI — CI does `cp .env.local.example .env.local` before any preflight, so `--fix` has no CI surface area.

## Heads-up for reviewer
- Pre-existing typecheck error on `main` at `src/app/page.tsx:84` (`/invites` route literal). Not introduced by this branch — present on bare `origin/main` too — but `npm test` now runs typecheck, so CI may red until that's fixed on main.