### PR TITLE
Fix Vercel docs-only skip — fetch from explicit URL

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "buildCommand": "if [ \"$VERCEL_ENV\" = \"production\" ]; then node scripts/migrate.mjs; fi && next build",
-  "ignoreCommand": "{ [ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] && git fetch --depth=1 origin main && git diff --quiet FETCH_HEAD HEAD -- . ':!docs/' ':!CLAUDE.md' ; } || exit 1"
+  "ignoreCommand": "{ [ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] && git fetch --depth=1 \"https://github.com/$VERCEL_GIT_REPO_OWNER/$VERCEL_GIT_REPO_SLUG.git\" main && git diff --quiet FETCH_HEAD HEAD -- . ':!docs/' ':!CLAUDE.md' ; } || exit 1"
 }


### PR DESCRIPTION
## Summary
- Vercel's build container has no `origin` remote configured, so `git fetch origin main` fails with `fatal: 'origin' does not appear to be a git repository`. The `|| exit 1` fallback then deploys, defeating the docs-only skip and burning a build minute on every docs PR push.
- Reconstruct the URL from `VERCEL_GIT_REPO_OWNER` / `VERCEL_GIT_REPO_SLUG` and fetch from it directly. Public-repo only — if the repo flips back to private, this fetch will need a token.

## Test plan
- [x] This PR's deploy will run (vercel.json change is non-docs-only — expected, not a test of the fix).
- [ ] After merge, a follow-up docs-only PR validates the skip — should report Vercel as canceled/skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)