### PR TITLE
Skip CI lint+functional tests on docs-only PRs

### DIFF
--- a/.github/workflows/ci-docs-skip.yml
+++ b/.github/workflows/ci-docs-skip.yml
@@ -1,0 +1,26 @@
+name: CI
+
+# Companion to ci.yml. Branch protection requires the "Lint & Functional
+# Tests" status check, which means ci.yml's `paths-ignore` alone would
+# leave the check stuck at "expected" on docs-only PRs and block merge.
+# This workflow's `paths` filter is the inverse, so docs-only PRs trigger
+# this no-op instead — same job name → same status context → satisfied.
+#
+# Mixed PRs (docs + code) trigger both workflows; both report under the
+# same name, both pass, branch protection is happy.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'CLAUDE.md'
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-test:
+    name: Lint & Functional Tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only PR — lint and functional tests skipped."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'CLAUDE.md'
 
 # Minimum GITHUB_TOKEN scope the job actually needs. Default on public
 # repos is `write` on most resources, which would let a compromised

--- a/docs/doc-strategy-committing.md
+++ b/docs/doc-strategy-committing.md
@@ -32,7 +32,12 @@ Failure modes all default to deploying (the safe direction):
 
 Playwright e2e skips downstream because it's triggered by Vercel's `deployment_status` event, which only fires on a real deploy.
 
-CI (lint + functional tests) still runs on every PR — branch protection requires its status check, and `paths-ignore` would leave the check stuck at "expected" and block merge. CI is cheap compared to Vercel's build minutes; the Vercel skip is where the savings come from.
+CI (lint + functional tests) is also skipped on docs-only PRs, but the mechanism is different from Vercel's. Branch protection requires the "Lint & Functional Tests" status check, so a plain `paths-ignore` on `ci.yml` would leave the check stuck at "expected" and block merge. The fix is two workflow files:
+
+- `ci.yml` — runs the real tests, with `paths-ignore: ['docs/**', 'CLAUDE.md']`.
+- `ci-docs-skip.yml` — a no-op job whose `name` matches ("Lint & Functional Tests"), with the inverse `paths: ['docs/**', 'CLAUDE.md']`.
+
+Their path filters union to "everything," so exactly one (or, on mixed PRs, both) triggers. Either way, a status check called "Lint & Functional Tests" reports success and branch protection is satisfied.
 
 ## Schema and data migrations: expand-contract pattern
 


### PR DESCRIPTION
## Summary
- Branch protection requires the "Lint & Functional Tests" status check, so a plain `paths-ignore` on `ci.yml` would leave the check stuck at "expected" and block docs-only PRs from merging.
- Two-workflow pattern: `ci.yml` keeps the real tests with `paths-ignore` for docs; new `ci-docs-skip.yml` runs a no-op under the same job name with the inverse `paths` filter.
- Their path filters union to "everything", so every PR triggers at least one workflow that reports "Lint & Functional Tests". Pure-docs PRs trigger only the no-op; pure-code PRs trigger only the real tests; mixed PRs trigger both.

## Test plan
- [x] `npm test` passes locally (55 functional + 15 e2e)
- [x] This PR is a code change (workflow files), so it should trigger ci.yml's real tests — visible as the "Lint & Functional Tests" check.
- [ ] After merge, a follow-up docs-only PR should still report "Lint & Functional Tests" green (from `ci-docs-skip.yml`'s no-op) without running the real test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)