### PR TITLE
Add resend magic link button with 60s cooldown (#32)

### DIFF
--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -16,19 +16,17 @@ type FormState =
 
 function SentView({ email, origin }: { email: string; origin: string }) {
   const [secondsLeft, setSecondsLeft] = useState(RESEND_COOLDOWN_SECONDS);
-  const [resendState, setResendState] = useState<"waiting" | "ready" | "sending" | "done">("waiting");
+  const [sending, setSending] = useState(false);
+  const [resent, setResent] = useState(false);
 
   useEffect(() => {
-    if (secondsLeft <= 0) {
-      setResendState("ready");
-      return;
-    }
+    if (secondsLeft <= 0) return;
     const id = setTimeout(() => setSecondsLeft((s) => s - 1), 1000);
     return () => clearTimeout(id);
   }, [secondsLeft]);
 
   const handleResend = async () => {
-    setResendState("sending");
+    setSending(true);
     const supabase = createClient();
     await supabase.auth.signInWithOtp({
       email,
@@ -37,26 +35,29 @@ function SentView({ email, origin }: { email: string; origin: string }) {
         shouldCreateUser: false,
       },
     });
-    setResendState("done");
+    setSending(false);
+    setResent(true);
     setSecondsLeft(RESEND_COOLDOWN_SECONDS);
   };
+
+  const canResend = secondsLeft <= 0 && !sending && !resent;
 
   return (
     <div className="flex max-w-sm flex-col items-center gap-4 text-center">
       <p className="text-sm text-gray-300">
         Check <span className="font-semibold">{email}</span> for a sign-in link.
       </p>
-      {resendState === "done" ? (
+      {resent ? (
         <p className="text-sm text-green-400">Link resent.</p>
       ) : (
         <button
           onClick={handleResend}
-          disabled={resendState !== "ready"}
+          disabled={!canResend}
           className="text-sm text-gray-400 underline disabled:no-underline disabled:opacity-50"
         >
-          {resendState === "sending"
+          {sending
             ? "Resending…"
-            : resendState === "waiting"
+            : secondsLeft > 0
               ? `Resend in ${secondsLeft}s`
               : "Resend email"}
         </button>

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,15 +1,69 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
+
+const RESEND_COOLDOWN_SECONDS = 60;
 
 type FormState =
   | { status: "idle" }
   | { status: "submitting" }
   | { status: "sent"; email: string }
+  | { status: "resending" }
   | { status: "error"; message: string };
+
+function SentView({ email, origin }: { email: string; origin: string }) {
+  const [secondsLeft, setSecondsLeft] = useState(RESEND_COOLDOWN_SECONDS);
+  const [resendState, setResendState] = useState<"waiting" | "ready" | "sending" | "done">("waiting");
+
+  useEffect(() => {
+    if (secondsLeft <= 0) {
+      setResendState("ready");
+      return;
+    }
+    const id = setTimeout(() => setSecondsLeft((s) => s - 1), 1000);
+    return () => clearTimeout(id);
+  }, [secondsLeft]);
+
+  const handleResend = async () => {
+    setResendState("sending");
+    const supabase = createClient();
+    await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${origin}/auth/callback`,
+        shouldCreateUser: false,
+      },
+    });
+    setResendState("done");
+    setSecondsLeft(RESEND_COOLDOWN_SECONDS);
+  };
+
+  return (
+    <div className="flex max-w-sm flex-col items-center gap-4 text-center">
+      <p className="text-sm text-gray-300">
+        Check <span className="font-semibold">{email}</span> for a sign-in link.
+      </p>
+      {resendState === "done" ? (
+        <p className="text-sm text-green-400">Link resent.</p>
+      ) : (
+        <button
+          onClick={handleResend}
+          disabled={resendState !== "ready"}
+          className="text-sm text-gray-400 underline disabled:no-underline disabled:opacity-50"
+        >
+          {resendState === "sending"
+            ? "Resending…"
+            : resendState === "waiting"
+              ? `Resend in ${secondsLeft}s`
+              : "Resend email"}
+        </button>
+      )}
+    </div>
+  );
+}
 
 export function LoginForm() {
   const router = useRouter();
@@ -17,7 +71,7 @@ export function LoginForm() {
   const [password, setPassword] = useState("");
   const [state, setState] = useState<FormState>({ status: "idle" });
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: React.SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
     setState({ status: "submitting" });
 
@@ -76,10 +130,7 @@ export function LoginForm() {
 
   if (state.status === "sent") {
     return (
-      <p className="max-w-sm text-center text-sm text-gray-300">
-        Check <span className="font-semibold">{state.email}</span> for a
-        sign-in link.
-      </p>
+      <SentView email={state.email} origin={window.location.origin} />
     );
   }
 


### PR DESCRIPTION
## Summary
- After submitting email on the login form, the confirmation view now shows a "Resend in Xs" countdown button
- Button becomes active after 60 seconds and resets the countdown on click
- Shows "Link resent." confirmation after a successful resend
- Also fixes a React 19 deprecation: `FormEvent` → `SyntheticEvent`

## Test plan
- [ ] Submit a valid email on `/login` — confirmation message appears
- [ ] Button shows "Resend in 60s" and counts down
- [ ] After 60s, button becomes "Resend email" and is clickable
- [ ] Click resend — button shows "Resending…" then "Link resent."
- [ ] Check Inbucket locally to confirm a second email arrives

Closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)