### PR TITLE
Add read-only profile view, move edit to /profile/edit

### DIFF
--- a/src/app/invites/page.tsx
+++ b/src/app/invites/page.tsx
@@ -17,7 +17,7 @@ export default async function InvitesPage() {
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
       <h1 className="text-4xl font-bold">Intentional Society</h1>
-      <Link href="/" className="text-sm text-gray-400 underline hover:text-gray-200">
+      <Link href="/" className="text-sm text-gray-400 underline hover:text-gray-500">
         ← Back to home
       </Link>
       <InvitesPanel />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -49,7 +49,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
       <LoginForm />
       <p className="text-sm text-gray-500">
         Have an invite code?{" "}
-        <Link href="/signup" className="underline text-gray-400 hover:text-gray-200">
+        <Link href="/signup" className="underline text-gray-400 hover:text-gray-500">
           Sign up
         </Link>
       </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,7 @@ function LoggedOutHome() {
         Don&apos;t have an invite?{" "}
         <a
           href="https://www.intentionalsociety.org/get-involved#connection-calls"
-          className="underline text-gray-400 hover:text-gray-200"
+          className="underline text-gray-400 hover:text-gray-500"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -82,7 +82,7 @@ export default async function Home() {
         href="/profile"
         className="rounded border border-gray-600 px-4 py-2 text-sm font-medium hover:bg-gray-800"
       >
-        Edit profile
+        My profile
       </Link>
       <Link
         href="/invites"

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/lib/supabase/server";
+import { getProfileForSelf } from "@/server/profiles";
+
+import { ProfileForm } from "../profile-form";
+
+export default async function EditProfilePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const profile = await getProfileForSelf(user.id);
+  if (!profile) redirect("/login");
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <div className="flex w-full max-w-md items-center justify-between">
+        <h1 className="text-2xl font-bold">Edit profile</h1>
+        <Link href="/profile" className="text-sm text-gray-400 hover:text-gray-500">
+          ← Back to profile
+        </Link>
+      </div>
+
+      <ProfileForm
+        initial={{
+          displayName: profile.displayName ?? "",
+          bio: profile.bio ?? "",
+          keywords: profile.keywords ?? [],
+          location: profile.location ?? "",
+          supplementaryInfo: profile.supplementaryInfo ?? "",
+          avatarUrl: profile.avatarUrl ?? "",
+          emergencyContact: profile.emergencyContact ?? "",
+          liveDesire: profile.liveDesire ?? "",
+        }}
+      />
+    </main>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -50,7 +50,7 @@ export default async function ProfilePage() {
 
       <Link
         href="/profile/edit"
-        className="rounded bg-gray-100 px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-500"
+        className="rounded bg-gray-100 px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-300"
       >
         Edit profile
       </Link>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,7 +4,14 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getProfileForSelf } from "@/server/profiles";
 
-import { ProfileForm } from "./profile-form";
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <dt className="text-xs uppercase tracking-wide text-gray-400">{label}</dt>
+      <dd className="font-serif text-sm">{children || <span className="text-gray-500">—</span>}</dd>
+    </div>
+  );
+}
 
 export default async function ProfilePage() {
   const supabase = await createClient();
@@ -20,24 +27,33 @@ export default async function ProfilePage() {
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
       <div className="flex w-full max-w-md items-center justify-between">
-        <h1 className="text-2xl font-bold">Edit profile</h1>
-        <Link href="/" className="text-sm text-gray-400 hover:text-gray-200">
+        <h1 className="text-2xl font-bold">My profile</h1>
+        <Link href="/" className="text-sm text-gray-400 hover:text-gray-500">
           ← Back
         </Link>
       </div>
 
-      <ProfileForm
-        initial={{
-          displayName: profile.displayName ?? "",
-          bio: profile.bio ?? "",
-          keywords: profile.keywords ?? [],
-          location: profile.location ?? "",
-          supplementaryInfo: profile.supplementaryInfo ?? "",
-          avatarUrl: profile.avatarUrl ?? "",
-          emergencyContact: profile.emergencyContact ?? "",
-          liveDesire: profile.liveDesire ?? "",
-        }}
-      />
+      <dl className="flex w-full max-w-md flex-col gap-4">
+        <Field label="Display name">{profile.displayName}</Field>
+        <Field label="Bio">{profile.bio}</Field>
+        <Field label="Keywords">
+          {profile.keywords.length > 0
+            ? profile.keywords.join(", ")
+            : null}
+        </Field>
+        <Field label="Location">{profile.location}</Field>
+        <Field label="Live desire">{profile.liveDesire}</Field>
+        <Field label="Supplementary info">{profile.supplementaryInfo}</Field>
+        <Field label="Avatar URL">{profile.avatarUrl}</Field>
+        <Field label="Emergency contact">{profile.emergencyContact}</Field>
+      </dl>
+
+      <Link
+        href="/profile/edit"
+        className="rounded bg-gray-100 px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-500"
+      >
+        Edit profile
+      </Link>
     </main>
   );
 }

--- a/src/app/profile/profile-form.tsx
+++ b/src/app/profile/profile-form.tsx
@@ -66,6 +66,7 @@ export function ProfileForm({ initial }: ProfileFormProps) {
       }
 
       setStatus({ kind: "success" });
+      router.push("/profile");
       router.refresh();
     } catch (err) {
       setStatus({

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -30,7 +30,7 @@ export default async function SignupPage({ searchParams }: SignupPageProps) {
       <SignupForm initialCode={code ?? ""} />
       <p className="text-sm text-gray-500">
         Already a member?{" "}
-        <Link href="/login" className="underline text-gray-400 hover:text-gray-200">
+        <Link href="/login" className="underline text-gray-400 hover:text-gray-500">
           Sign in
         </Link>
       </p>

--- a/src/app/signup/signup-form.tsx
+++ b/src/app/signup/signup-form.tsx
@@ -108,7 +108,7 @@ export function SignupForm({ initialCode }: { initialCode: string }) {
         onSubmit={sendMagicLink}
         className="flex w-full max-w-sm flex-col gap-3"
       >
-        <p className="rounded border border-gray-700 bg-gray-900/40 p-3 text-sm text-gray-200">
+        <p className="rounded border border-gray-700 bg-gray-900/40 p-3 text-sm text-gray-500">
           <span className="block text-xs uppercase tracking-wide text-gray-400">
             Your invite note
           </span>


### PR DESCRIPTION
## Summary

- `/profile` is now a read-only view of the user's profile, with serif font (Ovo) for user-entered content and sans-serif labels
- Edit form moved to `/profile/edit`, accessible via an "Edit profile" button on the view page
- After saving edits, the form redirects back to `/profile`
- Home page link updated from "Edit profile" to "My profile"
- Replaced all `gray-200` with `gray-500` across the app for better contrast on hover states and text