### PR TITLE
Programs list and self-join management

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-01 | Benji | Programs list and self-join management
+
+New `/programs` page lists all programs with title, description, and member count. Signed-in users can join or leave programs with a single click. The join/leave state is tracked via the existing `profile_programs` table with its `assigned_at` timestamp. Three new API endpoints: `GET /api/programs` (lists all programs with the current user's membership status), `POST /api/programs/:id/join`, and `POST /api/programs/:id/leave`. Home page now links to Programs alongside My profile and Manage invites.
+
 ## 2026-04-30 | Benji | Read-only profile view, edit moved to /profile/edit
 
 `/profile` is now a read-only view of the user's profile info, with serif font (Ovo) for user-entered content and sans-serif labels. The edit form moved to `/profile/edit`, accessible via an "Edit profile" button. After saving, the form redirects back to `/profile`. Home page link updated from "Edit profile" to "My profile". Also bumped all `gray-200` hover/text classes to `gray-500` across the app for better contrast.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -90,6 +90,12 @@ export default async function Home() {
       >
         Manage invites
       </Link>
+      <Link
+        href="/programs"
+        className="rounded border border-gray-600 px-4 py-2 text-sm font-medium hover:bg-gray-800"
+      >
+        Programs
+      </Link>
       <form action={signOut}>
         <button
           type="submit"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,19 +80,19 @@ export default async function Home() {
       <p className="text-sm">Display name: {profile?.displayName ?? "—"}</p>
       <Link
         href="/profile"
-        className="rounded border border-gray-600 px-4 py-2 text-sm font-medium hover:bg-gray-800"
+        className="rounded border border-gray-600 px-4 py-2 text-sm font-medium hover:bg-gray-100"
       >
         My profile
       </Link>
       <Link
         href="/invites"
-        className="rounded border border-gray-600 px-4 py-2 text-sm font-medium hover:bg-gray-800"
+        className="rounded border border-gray-600 px-4 py-2 text-sm font-medium hover:bg-gray-100"
       >
         Manage invites
       </Link>
       <Link
         href="/programs"
-        className="rounded border border-gray-600 px-4 py-2 text-sm font-medium hover:bg-gray-800"
+        className="rounded border border-gray-600 px-4 py-2 text-sm font-medium hover:bg-gray-100"
       >
         Programs
       </Link>

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/lib/supabase/server";
+
+import { ProgramsList } from "./programs-list";
+
+export default async function ProgramsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <div className="flex w-full max-w-xl items-center justify-between">
+        <h1 className="text-2xl font-bold">Programs</h1>
+        <Link href="/" className="text-sm text-gray-400 hover:text-gray-500">
+          ← Back
+        </Link>
+      </div>
+      <p className="w-full max-w-xl text-sm text-gray-400">
+        Browse programs and join the ones that interest you.
+      </p>
+      <ProgramsList />
+    </main>
+  );
+}

--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -22,6 +22,7 @@ type ListState =
 export function ProgramsList() {
   const [state, setState] = useState<ListState>({ kind: "loading" });
   const [pendingId, setPendingId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
@@ -50,17 +51,18 @@ export function ProgramsList() {
 
   const join = async (programId: string) => {
     setPendingId(programId);
+    setActionError(null);
     try {
       const res = await apiClient.api.programs[":id"].join.$post({
         param: { id: programId },
       });
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string };
-        alert(body.error === "already_joined" ? "You've already joined this program." : "Failed to join.");
+        setActionError(body.error === "already_joined" ? "You've already joined this program." : "Failed to join program.");
       }
       reload();
     } catch {
-      alert("Network error joining program.");
+      setActionError("Network error joining program.");
     } finally {
       setPendingId(null);
     }
@@ -68,16 +70,17 @@ export function ProgramsList() {
 
   const leave = async (programId: string) => {
     setPendingId(programId);
+    setActionError(null);
     try {
       const res = await apiClient.api.programs[":id"].leave.$post({
         param: { id: programId },
       });
       if (!res.ok) {
-        alert("Failed to leave program.");
+        setActionError("Failed to leave program.");
       }
       reload();
     } catch {
-      alert("Network error leaving program.");
+      setActionError("Network error leaving program.");
     } finally {
       setPendingId(null);
     }
@@ -96,7 +99,13 @@ export function ProgramsList() {
   }
 
   return (
-    <ul className="flex w-full max-w-xl flex-col gap-4">
+    <>
+      {actionError && (
+        <p role="alert" className="w-full max-w-xl text-sm text-red-300">
+          {actionError}
+        </p>
+      )}
+      <ul className="flex w-full max-w-xl flex-col gap-4">
       {state.programs.map((program) => (
         <li
           key={program.id}
@@ -144,6 +153,7 @@ export function ProgramsList() {
         </li>
       ))}
     </ul>
+    </>
   );
 }
 

--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { apiClient } from "@/lib/api";
+
+type Program = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  memberCount: number;
+  joined: boolean;
+  joinedAt: string | null;
+};
+
+type ListState =
+  | { kind: "loading" }
+  | { kind: "loaded"; programs: Program[] }
+  | { kind: "error"; message: string };
+
+export function ProgramsList() {
+  const [state, setState] = useState<ListState>({ kind: "loading" });
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await apiClient.api.programs.$get();
+      if (!res.ok) {
+        setState({ kind: "error", message: `Failed to load programs (${res.status}).` });
+        return;
+      }
+      const body = await res.json();
+      setState({ kind: "loaded", programs: body.programs as Program[] });
+    } catch {
+      setState({ kind: "error", message: "Network error loading programs." });
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const join = async (programId: string) => {
+    setPendingId(programId);
+    try {
+      const res = await apiClient.api.programs[":id"].join.$post({
+        param: { id: programId },
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        alert(body.error === "already_joined" ? "You've already joined this program." : "Failed to join.");
+      }
+      await load();
+    } catch {
+      alert("Network error joining program.");
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const leave = async (programId: string) => {
+    setPendingId(programId);
+    try {
+      const res = await apiClient.api.programs[":id"].leave.$post({
+        param: { id: programId },
+      });
+      if (!res.ok) {
+        alert("Failed to leave program.");
+      }
+      await load();
+    } catch {
+      alert("Network error leaving program.");
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  if (state.kind === "loading") {
+    return <p className="text-sm text-gray-400">Loading programs…</p>;
+  }
+
+  if (state.kind === "error") {
+    return <p role="alert" className="text-sm text-red-300">{state.message}</p>;
+  }
+
+  if (state.programs.length === 0) {
+    return <p className="text-sm text-gray-400">No programs available yet.</p>;
+  }
+
+  return (
+    <ul className="flex w-full max-w-xl flex-col gap-4">
+      {state.programs.map((program) => (
+        <li
+          key={program.id}
+          className="flex flex-col gap-2 rounded border border-gray-700 p-4"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-lg font-semibold">{program.name}</h2>
+              {program.description && (
+                <p className="font-serif text-sm text-gray-300">
+                  {program.description}
+                </p>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-gray-400">
+              {program.memberCount} {program.memberCount === 1 ? "member" : "members"}
+            </span>
+            {program.joined ? (
+              <button
+                type="button"
+                disabled={pendingId === program.id}
+                onClick={() => leave(program.id)}
+                className="rounded border border-red-500/40 px-3 py-1 text-sm text-red-300 disabled:opacity-50"
+              >
+                {pendingId === program.id ? "Leaving…" : "Leave"}
+              </button>
+            ) : (
+              <button
+                type="button"
+                disabled={pendingId === program.id}
+                onClick={() => join(program.id)}
+                className="rounded bg-gray-100 px-3 py-1 text-sm font-medium text-gray-900 disabled:opacity-50"
+              >
+                {pendingId === program.id ? "Joining…" : "Join"}
+              </button>
+            )}
+          </div>
+          {program.joined && program.joinedAt && (
+            <p className="text-xs text-gray-500">
+              Joined {formatDate(program.joinedAt)}
+            </p>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function formatDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}

--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -99,7 +99,7 @@ export function ProgramsList() {
             <div className="flex flex-col gap-1">
               <h2 className="text-lg font-semibold">{program.name}</h2>
               {program.description && (
-                <p className="font-serif text-sm text-gray-300">
+                <p className="font-serif text-sm text-gray-500">
                   {program.description}
                 </p>
               )}

--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { apiClient } from "@/lib/api";
 
@@ -22,24 +22,31 @@ type ListState =
 export function ProgramsList() {
   const [state, setState] = useState<ListState>({ kind: "loading" });
   const [pendingId, setPendingId] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    try {
-      const res = await apiClient.api.programs.$get();
-      if (!res.ok) {
-        setState({ kind: "error", message: `Failed to load programs (${res.status}).` });
-        return;
-      }
-      const body = await res.json();
-      setState({ kind: "loaded", programs: body.programs as Program[] });
-    } catch {
-      setState({ kind: "error", message: "Network error loading programs." });
-    }
-  }, []);
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
-    void load();
-  }, [load]);
+    let cancelled = false;
+    async function fetchPrograms() {
+      try {
+        const res = await apiClient.api.programs.$get();
+        if (cancelled) return;
+        if (!res.ok) {
+          setState({ kind: "error", message: `Failed to load programs (${res.status}).` });
+          return;
+        }
+        const body = await res.json();
+        setState({ kind: "loaded", programs: body.programs as Program[] });
+      } catch {
+        if (!cancelled) {
+          setState({ kind: "error", message: "Network error loading programs." });
+        }
+      }
+    }
+    void fetchPrograms();
+    return () => { cancelled = true; };
+  }, [reloadKey]);
+
+  const reload = () => setReloadKey((k) => k + 1);
 
   const join = async (programId: string) => {
     setPendingId(programId);
@@ -51,7 +58,7 @@ export function ProgramsList() {
         const body = (await res.json().catch(() => ({}))) as { error?: string };
         alert(body.error === "already_joined" ? "You've already joined this program." : "Failed to join.");
       }
-      await load();
+      reload();
     } catch {
       alert("Network error joining program.");
     } finally {
@@ -68,7 +75,7 @@ export function ProgramsList() {
       if (!res.ok) {
         alert("Failed to leave program.");
       }
-      await load();
+      reload();
     } catch {
       alert("Network error leaving program.");
     } finally {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -16,6 +16,7 @@ import {
   parseEditableProfile,
   upsertProfile,
 } from "./profiles";
+import { joinProgram, leaveProgram, listPrograms } from "./programs";
 import { profiles } from "./schema";
 import { isResetEnabled, resetE2EUsers } from "./test-reset";
 
@@ -141,6 +142,32 @@ const api = new Hono<{ Variables: ApiVariables }>()
       return c.json({ valid: true, note: result.note });
     }
     return c.json({ valid: false, reason: result.reason });
+  })
+  .get("/programs", async (c) => {
+    const user = c.get("user");
+    const programsList = await listPrograms(user.id);
+    return c.json({ programs: programsList });
+  })
+  .post("/programs/:id/join", async (c) => {
+    const user = c.get("user");
+    const programId = c.req.param("id");
+    const result = await joinProgram(user.id, programId);
+    if ("error" in result) {
+      if (result.error === "not_found") {
+        return c.json({ error: "not_found" }, 404);
+      }
+      return c.json({ error: "already_joined" }, 409);
+    }
+    return c.json({ ok: true });
+  })
+  .post("/programs/:id/leave", async (c) => {
+    const user = c.get("user");
+    const programId = c.req.param("id");
+    const result = await leaveProgram(user.id, programId);
+    if ("error" in result) {
+      return c.json({ error: "not_found" }, 404);
+    }
+    return c.json({ ok: true });
   })
   .get("/health", async (c) => {
     const result = await db.execute(sql`SELECT now() AS server_time`);

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -1,0 +1,85 @@
+import { and, eq, sql } from "drizzle-orm";
+
+import { db } from "./db";
+import { profilePrograms, programs } from "./schema";
+
+export type ProgramWithMembership = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  memberCount: number;
+  joined: boolean;
+  joinedAt: string | null;
+};
+
+export const listPrograms = async (
+  userId: string,
+): Promise<ProgramWithMembership[]> => {
+  const rows = await db
+    .select({
+      id: programs.id,
+      slug: programs.slug,
+      name: programs.name,
+      description: programs.description,
+      memberCount: sql<number>`(
+        SELECT count(*)::int FROM ${profilePrograms}
+        WHERE ${profilePrograms.programId} = ${programs.id}
+      )`,
+      joinedAt: sql<string | null>`(
+        SELECT ${profilePrograms.assignedAt}::text FROM ${profilePrograms}
+        WHERE ${profilePrograms.programId} = ${programs.id}
+          AND ${profilePrograms.profileId} = ${userId}
+      )`,
+    })
+    .from(programs)
+    .orderBy(programs.name);
+
+  return rows.map((r) => ({
+    ...r,
+    joined: r.joinedAt !== null,
+  }));
+};
+
+export const joinProgram = async (
+  userId: string,
+  programId: string,
+): Promise<{ ok: true } | { error: "not_found" | "already_joined" }> => {
+  // Verify program exists
+  const [program] = await db
+    .select({ id: programs.id })
+    .from(programs)
+    .where(eq(programs.id, programId));
+
+  if (!program) return { error: "not_found" };
+
+  // Insert membership — conflict means already joined
+  const result = await db
+    .insert(profilePrograms)
+    .values({ profileId: userId, programId })
+    .onConflictDoNothing()
+    .returning({ profileId: profilePrograms.profileId });
+
+  if (result.length === 0) return { error: "already_joined" };
+
+  return { ok: true };
+};
+
+export const leaveProgram = async (
+  userId: string,
+  programId: string,
+): Promise<{ ok: true } | { error: "not_found" }> => {
+  const result = await db
+    .delete(profilePrograms)
+    .where(
+      and(
+        eq(profilePrograms.profileId, userId),
+        eq(profilePrograms.programId, programId),
+      ),
+    )
+    .returning({ profileId: profilePrograms.profileId });
+
+  if (result.length === 0) return { error: "not_found" };
+
+  return { ok: true };
+};

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -1,7 +1,7 @@
 import { and, eq, sql } from "drizzle-orm";
 
 import { db } from "./db";
-import { profilePrograms, programs } from "./schema";
+import { profilePrograms, profiles, programs } from "./schema";
 
 export type ProgramWithMembership = {
   id: string;
@@ -13,6 +13,10 @@ export type ProgramWithMembership = {
   joinedAt: string | null;
 };
 
+// Note: memberCount and joinedAt use correlated subqueries which is
+// fine for a small number of programs. If the programs table grows
+// significantly, refactor to LEFT JOIN + GROUP BY with a conditional
+// aggregate for the current user's assigned_at.
 export const listPrograms = async (
   userId: string,
 ): Promise<ProgramWithMembership[]> => {
@@ -27,7 +31,7 @@ export const listPrograms = async (
         WHERE ${profilePrograms.programId} = ${programs.id}
       )`,
       joinedAt: sql<string | null>`(
-        SELECT ${profilePrograms.assignedAt}::text FROM ${profilePrograms}
+        SELECT to_json(${profilePrograms.assignedAt}) #>> '{}' FROM ${profilePrograms}
         WHERE ${profilePrograms.programId} = ${programs.id}
           AND ${profilePrograms.profileId} = ${userId}
       )`,
@@ -41,6 +45,24 @@ export const listPrograms = async (
   }));
 };
 
+// Ensures the profile row exists before inserting into profile_programs,
+// matching the self-heal pattern used by GET /api/me. Without this,
+// the FK from profile_programs.profile_id → profiles.id would throw
+// if a session exists but the profile upsert in /auth/callback failed.
+const ensureProfile = async (userId: string): Promise<void> => {
+  const [existing] = await db
+    .select({ id: profiles.id })
+    .from(profiles)
+    .where(eq(profiles.id, userId));
+
+  if (!existing) {
+    await db
+      .insert(profiles)
+      .values({ id: userId })
+      .onConflictDoNothing();
+  }
+};
+
 export const joinProgram = async (
   userId: string,
   programId: string,
@@ -52,6 +74,9 @@ export const joinProgram = async (
     .where(eq(programs.id, programId));
 
   if (!program) return { error: "not_found" };
+
+  // Self-heal: ensure profile row exists before FK insert
+  await ensureProfile(userId);
 
   // Insert membership — conflict means already joined
   const result = await db

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -3,6 +3,9 @@ import { and, eq, sql } from "drizzle-orm";
 import { db } from "./db";
 import { profilePrograms, profiles, programs } from "./schema";
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const isValidUuid = (s: string): boolean => UUID_RE.test(s);
+
 export type ProgramWithMembership = {
   id: string;
   slug: string;
@@ -67,6 +70,8 @@ export const joinProgram = async (
   userId: string,
   programId: string,
 ): Promise<{ ok: true } | { error: "not_found" | "already_joined" }> => {
+  if (!isValidUuid(programId)) return { error: "not_found" };
+
   // Verify program exists
   const [program] = await db
     .select({ id: programs.id })
@@ -94,6 +99,8 @@ export const leaveProgram = async (
   userId: string,
   programId: string,
 ): Promise<{ ok: true } | { error: "not_found" }> => {
+  if (!isValidUuid(programId)) return { error: "not_found" };
+
   const result = await db
     .delete(profilePrograms)
     .where(

--- a/tests/functional/server/programs.test.ts
+++ b/tests/functional/server/programs.test.ts
@@ -36,7 +36,7 @@ describe("Programs API", () => {
 
     await db.execute(
       sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous)
-          VALUES (${userId}::uuid, 'programs-test@testfake.local', false, false)`,
+          VALUES (${userId}::uuid, ${`programs-${userId.slice(0, 8)}@testfake.local`}, false, false)`,
     );
     await db.insert(profiles).values({ id: userId });
     await db.insert(programs).values({
@@ -49,7 +49,7 @@ describe("Programs API", () => {
     mockCreateServerClient.mockReturnValue({
       auth: {
         getUser: vi.fn().mockResolvedValue({
-          data: { user: makeUser(userId, "programs-test@testfake.local") },
+          data: { user: makeUser(userId, `programs-${userId.slice(0, 8)}@testfake.local`) },
           error: null,
         }),
       },
@@ -133,6 +133,14 @@ describe("Programs API", () => {
     it("returns 404 for non-existent program", async () => {
       const fakeId = randomUUID();
       const res = await app.request(`/api/programs/${fakeId}/join`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: "not_found" });
+    });
+
+    it("returns 404 for invalid UUID", async () => {
+      const res = await app.request("/api/programs/not-a-uuid/join", {
         method: "POST",
       });
       expect(res.status).toBe(404);

--- a/tests/functional/server/programs.test.ts
+++ b/tests/functional/server/programs.test.ts
@@ -1,0 +1,169 @@
+import { randomUUID } from "node:crypto";
+
+import type { User } from "@supabase/supabase-js";
+import { eq, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+import { createServerClient } from "@supabase/ssr";
+
+import app from "@/server/api";
+import { db } from "@/server/db";
+import { profilePrograms, profiles, programs } from "@/server/schema";
+
+const mockCreateServerClient = vi.mocked(createServerClient);
+
+const makeUser = (id: string, email: string): User =>
+  ({
+    id,
+    email,
+    user_metadata: {},
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+  }) as User;
+
+describe("Programs API", () => {
+  let userId: string;
+  let programId: string;
+
+  beforeEach(async () => {
+    userId = randomUUID();
+    programId = randomUUID();
+
+    await db.execute(
+      sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous)
+          VALUES (${userId}::uuid, 'programs-test@testfake.local', false, false)`,
+    );
+    await db.insert(profiles).values({ id: userId });
+    await db.insert(programs).values({
+      id: programId,
+      slug: `test-program-${programId.slice(0, 8)}`,
+      name: "Test Program",
+      description: "A program for testing.",
+    });
+
+    mockCreateServerClient.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: makeUser(userId, "programs-test@testfake.local") },
+          error: null,
+        }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await db.delete(profilePrograms).where(eq(profilePrograms.profileId, userId));
+    await db.delete(profiles).where(eq(profiles.id, userId));
+    await db.delete(programs).where(eq(programs.id, programId));
+    await db.execute(
+      sql`DELETE FROM auth.users WHERE id = ${userId}::uuid`,
+    );
+  });
+
+  describe("GET /api/programs", () => {
+    it("returns programs with membership status and member count", async () => {
+      const res = await app.request("/api/programs");
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.programs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: programId,
+            name: "Test Program",
+            description: "A program for testing.",
+            memberCount: 0,
+            joined: false,
+            joinedAt: null,
+          }),
+        ]),
+      );
+    });
+
+    it("reflects joined status after joining", async () => {
+      await db.insert(profilePrograms).values({ profileId: userId, programId });
+
+      const res = await app.request("/api/programs");
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      const program = body.programs.find(
+        (p: { id: string }) => p.id === programId,
+      );
+      expect(program.joined).toBe(true);
+      expect(program.joinedAt).toBeTruthy();
+      expect(program.memberCount).toBe(1);
+    });
+  });
+
+  describe("POST /api/programs/:id/join", () => {
+    it("joins a program successfully", async () => {
+      const res = await app.request(`/api/programs/${programId}/join`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+
+      // Verify DB row
+      const [row] = await db
+        .select()
+        .from(profilePrograms)
+        .where(eq(profilePrograms.profileId, userId));
+      expect(row).toBeTruthy();
+      expect(row.programId).toBe(programId);
+    });
+
+    it("returns 409 when already joined", async () => {
+      await db.insert(profilePrograms).values({ profileId: userId, programId });
+
+      const res = await app.request(`/api/programs/${programId}/join`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(409);
+      expect(await res.json()).toEqual({ error: "already_joined" });
+    });
+
+    it("returns 404 for non-existent program", async () => {
+      const fakeId = randomUUID();
+      const res = await app.request(`/api/programs/${fakeId}/join`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: "not_found" });
+    });
+  });
+
+  describe("POST /api/programs/:id/leave", () => {
+    it("leaves a program successfully", async () => {
+      await db.insert(profilePrograms).values({ profileId: userId, programId });
+
+      const res = await app.request(`/api/programs/${programId}/leave`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+
+      // Verify row deleted
+      const rows = await db
+        .select()
+        .from(profilePrograms)
+        .where(eq(profilePrograms.profileId, userId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("returns 404 when not a member", async () => {
+      const res = await app.request(`/api/programs/${programId}/leave`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: "not_found" });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

New `/programs` page where signed-in users can browse all programs and join or leave them.

### What's new

- **`/programs` page** — lists all programs with name, description, member count, and a Join/Leave button. Joined date shown for programs the user is in.
- **`GET /api/programs`** — returns all programs with the current user's membership status and member counts.
- **`POST /api/programs/:id/join`** — join a program (409 if already joined, 404 if program doesn't exist).
- **`POST /api/programs/:id/leave`** — leave a program (404 if not a member).
- **Home page** — new "Programs" link alongside My profile and Manage invites.

### Schema

No migration needed — uses the existing `programs` and `profile_programs` tables. The `assigned_at` column on `profile_programs` already records when the user joined.