### PR TITLE
Add member profile view at /members/[id] (#112)

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { createClient } from "@/lib/supabase/server";
+import { getProfileForMember } from "@/server/profiles";
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <dt className="text-sm uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd className="font-serif text-base">{children || <span className="text-muted-foreground">—</span>}</dd>
+    </div>
+  );
+}
+
+export default async function MemberProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/signin");
+
+  const { id } = await params;
+  const profile = await getProfileForMember(id);
+  if (!profile) notFound();
+
+  const memberSince = profile.createdAt.getFullYear();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <div className="flex w-full max-w-md items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">
+            {profile.displayName ?? "Member"}
+          </h1>
+          <p className="text-sm text-muted-foreground">Member since {memberSince}</p>
+        </div>
+        <Link href="/" className="text-base text-muted-foreground hover:text-foreground">
+          ← Back
+        </Link>
+      </div>
+
+      <dl className="flex w-full max-w-md flex-col gap-4">
+        <Field label="Bio">{profile.bio}</Field>
+        <Field label="Keywords">
+          {profile.keywords.length > 0 ? profile.keywords.join(", ") : null}
+        </Field>
+        <Field label="Location">{profile.location}</Field>
+        <Field label="Live desire">{profile.liveDesire}</Field>
+        <Field label="Supplementary info">{profile.supplementaryInfo}</Field>
+      </dl>
+    </main>
+  );
+}

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -12,6 +12,7 @@ import {
   validateNote,
 } from "./invites";
 import {
+  getProfileForMember,
   getProfileForSelf,
   parseEditableProfile,
   upsertProfile,
@@ -142,6 +143,12 @@ const api = new Hono<{ Variables: ApiVariables }>()
       return c.json({ valid: true, note: result.note });
     }
     return c.json({ valid: false, reason: result.reason });
+  })
+  .get("/members/:id", async (c) => {
+    const memberId = c.req.param("id");
+    const profile = await getProfileForMember(memberId);
+    if (!profile) return c.json({ error: "not_found" }, 404);
+    return c.json({ profile });
   })
   .get("/programs", async (c) => {
     const user = c.get("user");

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -133,11 +133,37 @@ export const getProfileForSelf = cache(async (
   return row ?? null;
 });
 
-// Placeholder. The member-directory endpoint is not built yet; throwing
-// here forces the access-control shape to be decided the moment that
-// work starts, instead of silently reusing the self shape.
-export const getProfileForMember = async (): Promise<never> => {
-  throw new Error("NotImplemented: getProfileForMember");
+export type ProfileForMember = {
+  id: string;
+  displayName: string | null;
+  bio: string | null;
+  keywords: string[];
+  location: string | null;
+  supplementaryInfo: string | null;
+  avatarUrl: string | null;
+  liveDesire: string | null;
+  createdAt: Date;
+};
+
+export const getProfileForMember = async (
+  memberId: string,
+): Promise<ProfileForMember | null> => {
+  const [row] = await db
+    .select({
+      id: profiles.id,
+      displayName: profiles.displayName,
+      bio: profiles.bio,
+      keywords: profiles.keywords,
+      location: profiles.location,
+      supplementaryInfo: profiles.supplementaryInfo,
+      avatarUrl: profiles.avatarUrl,
+      liveDesire: profiles.liveDesire,
+      createdAt: profiles.createdAt,
+    })
+    .from(profiles)
+    .where(eq(profiles.id, memberId));
+
+  return row ?? null;
 };
 
 // Placeholder. Same rationale as getProfileForMember — admin tooling

--- a/tests/functional/server/profiles.test.ts
+++ b/tests/functional/server/profiles.test.ts
@@ -138,11 +138,45 @@ describe("getProfileForSelf", () => {
   });
 });
 
-describe("getProfileForMember / getProfileForAdmin stubs", () => {
-  it("getProfileForMember throws NotImplemented", async () => {
-    await expect(getProfileForMember()).rejects.toThrow(/NotImplemented/);
+describe("getProfileForMember", () => {
+  let memberId: string;
+
+  beforeEach(async () => {
+    memberId = randomUUID();
+    await db.execute(
+      sql`INSERT INTO auth.users (id, instance_id, aud, role, email, email_confirmed_at, created_at, updated_at, is_sso_user, is_anonymous, confirmation_token, recovery_token, email_change_token_new, email_change)
+          VALUES (${memberId}::uuid, '00000000-0000-0000-0000-000000000000'::uuid, 'authenticated', 'authenticated', ${`member-${memberId}@test.local`}, now(), now(), now(), false, false, '', '', '', '')`,
+    );
+    await db.insert(profiles).values({ id: memberId, displayName: "Test Member", bio: "Hello" });
   });
 
+  afterEach(async () => {
+    await db.delete(profiles).where(eq(profiles.id, memberId));
+    await db.execute(sql`DELETE FROM auth.users WHERE id = ${memberId}::uuid`);
+  });
+
+  it("returns public fields for an existing member", async () => {
+    const profile = await getProfileForMember(memberId);
+    expect(profile).not.toBeNull();
+    expect(profile?.displayName).toBe("Test Member");
+    expect(Object.keys(profile!).sort()).toEqual(
+      ["id", "displayName", "bio", "keywords", "location", "supplementaryInfo", "avatarUrl", "liveDesire", "createdAt"].sort(),
+    );
+  });
+
+  it("does not include emergencyContact or isAdmin", async () => {
+    const profile = await getProfileForMember(memberId);
+    expect(profile).not.toHaveProperty("emergencyContact");
+    expect(profile).not.toHaveProperty("isAdmin");
+  });
+
+  it("returns null for an unknown id", async () => {
+    const profile = await getProfileForMember(randomUUID());
+    expect(profile).toBeNull();
+  });
+});
+
+describe("getProfileForAdmin stub", () => {
   it("getProfileForAdmin throws NotImplemented", async () => {
     await expect(getProfileForAdmin()).rejects.toThrow(/NotImplemented/);
   });


### PR DESCRIPTION
## Summary
- Implements `getProfileForMember` — public shape that excludes `emergencyContact`, `referredBy`, `referredByLegacy`, and `isAdmin`
- Adds `GET /api/members/:id` endpoint (auth-gated, returns 404 for unknown IDs)
- Creates `/members/[id]` page showing display name, bio, keywords, location, live desire, supplementary info, and member-since year
- Unauthenticated visitors redirected to `/signin`
- Updated functional tests: replaced the old `NotImplemented` stub test with real coverage

## Test plan
- [x] Visit `/members/<uuid-of-seeded-member>` while signed in — profile renders
- [ ] Visit with unknown UUID — 404 page
- [x] Confirm `emergencyContact` is not visible on the page
- [x] Unauthenticated visit redirects to `/signin`

Closes #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)