### PR TITLE
Add budget and email docs; note Vercel build times

### DIFF
--- a/docs/budget.md
+++ b/docs/budget.md
@@ -1,0 +1,21 @@
+# Budget
+
+Recurring costs for the app stack. Last reviewed **2026-05-02**. Provider limits can drift — re-verify before relying on these for capacity planning.
+
+Bare minimum $20/mo (Vercel only), but we could be up to $70 shortly.
+
+## App stack
+
+| Service | Monthly cost | Budget | Plan | What that gets us | Next step-up if outgrown |
+|---|---|---|---|---|---|
+| **Vercel** | **$20/seat** + usage | $30 | Pro | $20 of included usage credit, then pay-as-you-go: 1 TB fast data transfer, 10M edge requests, $0.014/min standard build minutes, $0.60/1M function invocations | No fixed step-up — overages stack on the same plan. Already incurred overages in month one, but moving to Next16 cut build times by 40% and we're skipping docs-only deploys now so, recheck next month. |
+| **Supabase** | $0 | $25 | Free | 500 MB Postgres, 50k MAU, 5 GB egress, 1 GB file storage, 7-day log retention, project pauses after 1 week idle, max 2 active projects | Pro **from $25/mo** — no auto-pause, daily backups, 8 GB DB included, 250 GB egress, point-in-time recovery as add-on. Likely needed at or before launch. |
+| **Sentry** | $0 | — | Developer | 5k errors, 50 session replays, 5M performance spans per month; 1 seat | Team **$26/mo** (annual billing) — unlimited seats, more events, third-party integrations |
+| **Axiom** | $0 | — | Personal | 500 GB/mo ingest, 30-day retention, 10 GB-hrs query compute, 25 GB storage, 2 datasets, 1 user | Axiom Cloud **from $25/mo** — 1 TB ingest, 100 GB-hrs query, configurable retention, usage-based beyond included |
+| **GitHub** | $0 | — | Free org | Unlimited public-repo Actions; 2,000 Actions minutes/mo on private repos | Team **$4/user/mo** — 3,000 Actions minutes/mo on private repos plus more collaboration features |
+| **Transactional email** | $0 today | $15 | _not yet provisioned_ | Pre-launch decision; leading candidate is Postmark (free tier: 100 emails/mo, never expires) | Postmark Basic **$15/mo** for 10k emails when dev tier is outgrown. Resend and SES are the alternatives — see prior discussion / future devjournal entry. |
+
+## Budgeted elsewhere
+
+- **Domain** — `intentionalsociety.org` annual registrar renewal (~$15/yr).
+- **Newsletters** — Buttondown subscription, already paid outside the app stack. Listed here only so total cost of comms is visible.

--- a/docs/doc-email.md
+++ b/docs/doc-email.md
@@ -1,0 +1,59 @@
+# Email — Configuration Reference
+
+Covers transactional email (auth confirmations, password resets, invite-flow magic links) and how it relates to the existing newsletter stack. **Status: pending — provider not yet provisioned.** Picked up 2026-05-02; resuming next session.
+
+---
+
+## Current state
+
+Supabase auth emails are sent via Supabase's built-in SMTP. Supabase explicitly labels this service for testing only:
+
+- 2 emails/hour rate limit on the default service
+- No SLA on delivery or uptime
+- Sender domain not aligned to `intentionalsociety.org`, so SPF/DKIM/DMARC do nothing for us
+- Risk at launch: a small burst of signups (or password resets after a comms blast) can hit the rate limit and break onboarding
+
+---
+
+## Leading direction: Postmark
+
+Deliverability is the top priority for this decision. Postmark is the leading candidate over Resend on architectural grounds, not just marketing claims:
+
+- **Message Streams** — Postmark forces transactional and broadcast email onto separate IP pools with independent reputation scores. Gmail officially recommends this exact separation. Resend doesn't separate them, so a marketing-side complaint spike could drag down auth deliverability.
+- **Strict shared-pool policy** — Postmark refuses promotional senders entirely and actively boots senders that hurt reputation, keeping the shared IP pool clean.
+- **Track record** — Postmark since 2009; Resend since 2023. Resend routes through Amazon SES under the hood, so "Resend vs. Postmark" is really "SES with a developer wrapper vs. vertically integrated transactional infrastructure."
+- **Measured numbers** — third-party tests put Postmark at ~98.7% inbox placement and ~26ms median response; Resend ~79ms median, no comparable inbox-placement number published.
+
+**Cost:** free dev tier (100 emails/mo, never expires) covers pre-launch. Basic plan **$15/mo** for 10k emails once outgrown — already allocated in `docs/budget.md`.
+
+---
+
+## Alternatives considered
+
+- **Resend** — better DX (React Email, Vercel-ecosystem feel), bigger free tier (3k/mo, 100/day). Lower pick because deliverability is the priority and Resend's underlying infrastructure is SES with no transactional/broadcast separation.
+- **Amazon SES** — cheapest by far ($0.10/1k after free tier). Lower pick because of operational overhead (DNS/IAM fiddling, no dashboard worth speaking of) when the difference at our volume is single-digit dollars.
+
+---
+
+## Newsletters and the boundary
+
+Buttondown handles newsletters and program announcements; we tag users via API to send program-related emails. That stays.
+
+The split going forward:
+
+- **Announcement-shaped** (cohort kicks off, monthly digest) → Buttondown. Triggered by *us* deciding to tell a group something.
+- **Event-shaped** (you've been added to program X, your application was approved, password reset) → Postmark. Triggered by *one user doing one thing*.
+
+Buttondown is not a candidate for the Supabase auth slot — it's a newsletter platform, not a transactional SMTP backend.
+
+---
+
+## Open items for next session
+
+- [ ] Confirm Postmark as the choice (or revisit if priorities shift)
+- [ ] Provision Postmark account, verify `intentionalsociety.org` sender domain (SPF, DKIM, DMARC, Return-Path)
+- [ ] Configure Supabase Auth → SMTP with Postmark credentials
+- [ ] Bump Supabase Auth rate limit from default 30/hour for custom SMTP up to a sensible launch level
+- [ ] Decide on a "From" address (e.g. `noreply@intentionalsociety.org` vs. a human-looking address)
+- [ ] Update Supabase email templates so the body matches our voice and the footer/sender is on-brand
+- [ ] Add a `docs/devjournal.md` entry once provisioned

--- a/docs/doc-vercel.md
+++ b/docs/doc-vercel.md
@@ -13,3 +13,9 @@ Current configuration for the Vercel project as deployed. This documents setting
 - **Deployment Protection:** Vercel Authentication disabled on preview deployments, so GitHub Actions can run Playwright e2e tests against preview URLs without hitting a sign-in wall
 - **Integrations:** Axiom (Log Drain — streams all serverless function output to Axiom automatically)
 - **Environment variables:** `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`, `DATABASE_URL`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` — set in Vercel dashboard (Settings → Environment Variables), not committed to the repo
+
+---
+
+## Build times
+
+Builds normally land around **30 seconds**. The Sentry source-map upload runs after the production compile (logged as "Sending telemetry data... to Sentry") and is the main variable component — usually quick, but occasionally spikes by ~60s on Sentry ingest latency. Treat those spikes as transient noise unless they persist across consecutive builds. If build-minute overages become a concern, the highest-leverage lever is gating source-map upload to `VERCEL_ENV=production` so preview builds skip it entirely.


### PR DESCRIPTION
## Summary
- New `docs/budget.md` — monthly cost reference for app-stack services (Vercel, Supabase, Sentry, Axiom, GitHub, transactional email) with current plan, what it gets us, and the next step-up if outgrown
- New `docs/doc-email.md` — pending-provider notes for transactional email: current Supabase-default risk, Postmark as leading direction (Message Streams, deliverability), alternatives considered, and open items for next session
- `docs/doc-vercel.md` — brief "Build times" section flagging Sentry source-map upload as the main variable component, with VERCEL_ENV gating as the highest-leverage cost lever

## Test plan
- [x] Docs-only — no code paths touched; Vercel deploy auto-skipped via the `docs/**` ignore rule
- [x] Lint passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)