### PR TITLE
Add requireUser() helper for authed pages

### DIFF
--- a/src/app/invites/page.tsx
+++ b/src/app/invites/page.tsx
@@ -1,18 +1,11 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
 
-import { createClient } from "@/lib/supabase/server";
+import { requireUser } from "@/lib/api-server";
 
 import { InvitesPanel } from "./invites-panel";
 
 export default async function InvitesPage() {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) {
-    redirect("/signin");
-  }
+  await requireUser();
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,19 +42,7 @@ function LoggedOutHome() {
   );
 }
 
-export default async function Home() {
-  const me = await loadMe();
-  if (!me) {
-    return <LoggedOutHome />;
-  }
-
-  // Incomplete-profile heuristic: bio null means the member has not
-  // completed /welcome yet. bio is the one field the welcome form
-  // always collects, so it's a reliable sentinel.
-  if (me.profile && me.profile.bio === null) {
-    redirect("/welcome");
-  }
-
+function LoggedInHome() {
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
       <div className="flex flex-col items-center gap-1">
@@ -74,4 +62,20 @@ export default async function Home() {
       </Button>
     </main>
   );
+}
+
+export default async function Home() {
+  const me = await loadMe();
+  if (!me) {
+    return <LoggedOutHome />;
+  }
+
+  // Incomplete-profile heuristic: bio null means the member has not
+  // completed /welcome yet. bio is the one field the welcome form
+  // always collects, so it's a reliable sentinel.
+  if (me.profile && me.profile.bio === null) {
+    redirect("/welcome");
+  }
+
+  return <LoggedInHome />;
 }

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -1,14 +1,13 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
 
-import { loadMe } from "@/lib/api-server";
+import { requireUser } from "@/lib/api-server";
+import type { Me } from "@/lib/api-types";
 
 import { ProfileForm } from "../profile-form";
 
 export default async function EditProfilePage() {
-  const me = await loadMe();
-  if (!me || !me.profile) redirect("/signin");
-  const { profile } = me;
+  const me: Me = await requireUser();
+  const profile = me.profile!;
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,8 +1,8 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
-import { loadMe } from "@/lib/api-server";
+import { requireUser } from "@/lib/api-server";
+import type { Me } from "@/lib/api-types";
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -14,9 +14,8 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 }
 
 export default async function ProfilePage() {
-  const me = await loadMe();
-  if (!me || !me.profile) redirect("/signin");
-  const { profile } = me;
+  const me: Me = await requireUser();
+  const profile = me.profile!;
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -1,13 +1,11 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
 
-import { loadMe } from "@/lib/api-server";
+import { requireUser } from "@/lib/api-server";
 
 import { ProgramsList } from "./programs-list";
 
 export default async function ProgramsPage() {
-  const me = await loadMe();
-  if (!me) redirect("/signin");
+  await requireUser();
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,12 +1,10 @@
-import { redirect } from "next/navigation";
-
-import { loadMe } from "@/lib/api-server";
+import { requireUser } from "@/lib/api-server";
+import type { Me } from "@/lib/api-types";
 
 import { WelcomeForm } from "./welcome-form";
 
 export default async function WelcomePage() {
-  const me = await loadMe();
-  if (!me) redirect("/signin");
+  const me: Me = await requireUser();
   const profile = me.profile;
 
   return (

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { hc } from "hono/client";
 import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import { cache } from "react";
 
 import type { Me } from "@/lib/api-types";
@@ -41,3 +42,13 @@ export const loadMe = cache(async (): Promise<Me | null> => {
   if (!res.ok) throw new Error(`Failed to load /api/me: ${res.status}`);
   return res.json();
 });
+
+// Page-level auth gate. Use at the top of any Server Component that
+// requires a signed-in user; redirects to /signin otherwise. Returns a
+// non-null Me so the rest of the page can use the data without
+// narrowing.
+export const requireUser = async (): Promise<Me> => {
+  const me = await loadMe();
+  if (!me) redirect("/signin");
+  return me;
+};


### PR DESCRIPTION
## Summary
- Adds `requireUser()` to `src/lib/api-server.ts`: calls `loadMe()`, redirects to `/signin` if unauthenticated, returns a non-null `Me`.
- Migrates `/profile`, `/profile/edit`, `/programs`, `/welcome`, `/invites` to use it. `/invites` had drifted to a direct `supabase.auth.getUser()` call — back on the standard path.
- Drops the unreachable `if (!me.profile) redirect("/signin")` checks in `/profile` and `/profile/edit` (the `/api/me` self-heal guarantees the row).
- Extracts `LoggedInHome` from `/` as a named function alongside `LoggedOutHome` for symmetry.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:functional` (62 passed)
- [x] `npm run test:e2e` (15 passed)