### PR TITLE
Show friendly message instead of 500 on unknown /members/:id (#116)

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { notFound, redirect } from "next/navigation";
+import { redirect } from "next/navigation";
 
 import { serverApiClient } from "@/lib/api-server";
 import type { MemberProfile } from "@/lib/api-types";
@@ -21,10 +21,25 @@ export default async function MemberProfilePage({
   const { id } = await params;
   const res = await serverApiClient.api.members[":id"].$get({ param: { id } });
   if (res.status === 401) redirect("/signin");
-  if (res.status === 404) notFound();
-  if (!res.ok) throw new Error(`Failed to load member ${id}: ${res.status}`);
-  const { profile }: { profile: MemberProfile } = await res.json();
+  if (!res.ok && res.status !== 404) throw new Error(`Failed to load member ${id}: ${res.status}`);
 
+  if (res.status === 404) {
+    return (
+      <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+        <div className="flex w-full max-w-md items-center justify-between">
+          <h1 className="text-2xl font-bold">Member not found</h1>
+          <Link href="/" className="text-base text-muted-foreground hover:text-foreground">
+            ← Back
+          </Link>
+        </div>
+        <p className="text-muted-foreground">
+          We couldn&apos;t find a member with that ID.
+        </p>
+      </main>
+    );
+  }
+
+  const { profile }: { profile: MemberProfile } = await res.json();
   const memberSince = new Date(profile.createdAt).getFullYear();
 
   return (


### PR DESCRIPTION
## Summary
- Replaces `notFound()` with an inline "Member not found" message that stays within the app layout
- Unknown member IDs now show a clear message and a back link instead of the generic Next.js 404 or a 500
- Unexpected non-404 errors still throw so they surface in Sentry

## Test plan
- [ ] Visit `/members/foo` — see "Member not found" with a ← Back link
- [ ] Visit `/members/00000000-0000-0000-0000-000000000001` — see Aria Chen's profile as normal

Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)