### PR TITLE
Add forward-migrate-prod-schema-expansion workflow tooling

### DIFF
--- a/.github/workflows/forward-migrate-prod-schema-expansion.yml
+++ b/.github/workflows/forward-migrate-prod-schema-expansion.yml
@@ -1,0 +1,38 @@
+name: Forward-migrate prod schema (expansion)
+
+# Manually triggered. Applies additive (expand) drizzle migrations to
+# the prod DB ahead of opening a PR, so previews can exercise new code
+# paths against the migrated schema (drizzle's typed schema must match
+# the DB it queries — see docs/strategy-committing.md). Contract
+# migrations do NOT use this workflow — they ride the standard
+# merge-to-main path so they only apply once the new code is live.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA whose migrations should be applied to prod"
+        required: true
+        default: main
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    name: Apply expand migrations to production DB
+    runs-on: ubuntu-latest
+    environment: prod-db    # required-reviewer gate lives here
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Run drizzle-kit migrate
+        run: node scripts/migrate.mjs
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}

--- a/.github/workflows/forward-migrate-prod-schema-expansion.yml
+++ b/.github/workflows/forward-migrate-prod-schema-expansion.yml
@@ -27,11 +27,50 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+          # Need history beyond the dispatched ref so we can diff
+          # against main for the show-migrations + destructive-guard
+          # steps below.
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
       - run: npm ci
+
+      - name: Show migrations to be applied
+        run: |
+          set -e
+          git fetch --depth=1 origin main
+          echo "## Migration files changed vs main"
+          git diff --stat origin/main...HEAD -- drizzle/ || true
+          changed=$(git diff --name-only origin/main...HEAD -- 'drizzle/*.sql')
+          if [ -z "$changed" ]; then
+            echo "No new .sql migrations vs main. Nothing to apply — failing fast."
+            exit 1
+          fi
+          echo ""
+          echo "## Migration file contents"
+          for f in $changed; do
+            echo "----- $f -----"
+            cat "$f"
+            echo ""
+          done
+
+      - name: Guard against destructive migrations
+        run: |
+          set -e
+          # Expand-only workflow. Contract migrations (DROP, RENAME, type
+          # changes) must ride the merge-to-main path so they only apply
+          # once the new code is live.
+          patterns='drop column|drop table|drop constraint|rename column|rename to|alter column.*drop'
+          matches=$(git diff origin/main...HEAD -- 'drizzle/*.sql' | grep -iE "^\+[^+].*($patterns)" || true)
+          if [ -n "$matches" ]; then
+            echo "::error::Destructive migration pattern detected. This workflow is expand-only — use the merge-to-main path for contract migrations."
+            echo "Offending lines:"
+            echo "$matches"
+            exit 1
+          fi
+
       - name: Run drizzle-kit migrate
         run: node scripts/migrate.mjs
         env:

--- a/docs/doc-github.md
+++ b/docs/doc-github.md
@@ -25,6 +25,14 @@ Enforced via a GitHub Ruleset, managed as code in `scripts/update-main-branch-pr
 - `.github/workflows/ci.yml` — lint + functional tests, triggers on `pull_request` to main. Spins up the full local Supabase stack via `supabase/setup-cli@v1` + `supabase start`, then applies Drizzle migrations before running Vitest. Functional tests that hit the DB (e.g. `profiles.test.ts`) run against this stack, matching the dev-box setup exactly.
 - `.github/workflows/e2e.yml` — Playwright against Vercel preview URL, triggers on `deployment_status` (fired by Vercel's GitHub integration when a preview deploy completes).
 - `.github/workflows/codeql.yml` — CodeQL static analysis on JS/TS and workflow YAMLs, triggers on PRs + pushes to main + weekly cron. Uses the `security-extended` query pack.
+- `.github/workflows/forward-migrate-prod-schema-expansion.yml` — `workflow_dispatch`-only. Applies additive (expand) drizzle migrations to the prod DB ahead of opening a PR, so previews can exercise new code paths against the migrated schema. Bound to the `prod-db` environment (see below) for the reviewer gate. Triggered locally via `npm run prod:db:expand` (uses the current branch). Contract migrations do NOT use this workflow — they ride the standard merge-to-main path.
+
+## Environments
+
+- **`prod-db`** — gates write access to the production Supabase database from any `workflow_dispatch` workflow. Configured in Settings → Environments.
+  - **Required reviewers:** James (self-approval permitted; this is a single-maintainer setup).
+  - **Environment secret:** `PRODUCTION_DATABASE_URL` — the prod transaction-pooler URL (same value Vercel uses on production deploys, copied from the Vercel project's env).
+  - The name is deliberately distinct from "production" to avoid visual collision with Vercel's `VERCEL_ENV=production`, which has its own meaning in `vercel.json`.
 
 ## Advanced Security
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev:db": "node scripts/check-env.mjs && node scripts/ensure-docker.mjs && node scripts/ensure-supabase.mjs && node scripts/migrate.mjs && node scripts/seed-e2e-users.mjs",
     "dev:db:stop": "npx supabase stop",
     "dev:db:reset": "npx supabase db reset && npx drizzle-kit migrate",
+    "prod:db:expand": "node scripts/forward-migrate-prod-schema-expansion.mjs",
     "seed:dev": "npx tsx scripts/seed-dev.ts",
     "build": "next build",
     "start": "next start",

--- a/scripts/forward-migrate-prod-schema-expansion.mjs
+++ b/scripts/forward-migrate-prod-schema-expansion.mjs
@@ -1,0 +1,43 @@
+// Triggers the forward-migrate-prod-schema-expansion workflow against
+// the current branch. The workflow itself pauses for review-gate
+// approval before any prod credentials are injected into the runner —
+// see .github/workflows/forward-migrate-prod-schema-expansion.yml.
+
+import { execSync } from "node:child_process";
+
+const run = (cmd, opts = {}) =>
+  execSync(cmd, { encoding: "utf8", ...opts }).trim();
+
+let branch;
+try {
+  branch = run("git rev-parse --abbrev-ref HEAD");
+} catch {
+  console.error("Failed to read git branch — are you inside a git repo?");
+  process.exit(1);
+}
+if (!branch || branch === "HEAD") {
+  console.error(
+    "Refusing to run from a detached HEAD — check out a branch first.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Dispatching forward-migrate-prod-schema-expansion against ref=${branch}`,
+);
+try {
+  execSync(
+    `gh workflow run forward-migrate-prod-schema-expansion.yml -f ref=${branch}`,
+    { stdio: "inherit" },
+  );
+} catch {
+  console.error(
+    "gh CLI failed. Is `gh` installed and authed? See docs/setup-dev-machine.md.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  "\nApprove the run at:\n" +
+    "  https://github.com/Intentional-Society/is-app/actions/workflows/forward-migrate-prod-schema-expansion.yml",
+);

--- a/scripts/forward-migrate-prod-schema-expansion.mjs
+++ b/scripts/forward-migrate-prod-schema-expansion.mjs
@@ -22,6 +22,33 @@ if (!branch || branch === "HEAD") {
   process.exit(1);
 }
 
+const dirty = run("git status --porcelain");
+if (dirty) {
+  console.error(
+    "Refusing to run with uncommitted changes — commit or stash first.\n" +
+      "The workflow runs against the remote branch state; local-only edits would be invisible.",
+  );
+  process.exit(1);
+}
+
+try {
+  run(`git fetch origin ${branch} --quiet`);
+} catch {
+  console.error(
+    `origin/${branch} not found — push the branch first so the workflow can check it out.`,
+  );
+  process.exit(1);
+}
+const localSha = run("git rev-parse HEAD");
+const remoteSha = run(`git rev-parse origin/${branch}`);
+if (localSha !== remoteSha) {
+  console.error(
+    `Local ${branch} (${localSha.slice(0, 8)}) is out of sync with origin/${branch} (${remoteSha.slice(0, 8)}).\n` +
+      "Push your latest commits before triggering the workflow.",
+  );
+  process.exit(1);
+}
+
 console.log(
   `Dispatching forward-migrate-prod-schema-expansion against ref=${branch}`,
 );


### PR DESCRIPTION
## Summary

Adds the `forward-migrate-prod-schema-expansion` GH Actions workflow + `npm run prod:db:expand` helper. Used to apply additive (expand) drizzle migrations to the prod DB ahead of opening a PR — needed because drizzle's typed schema must match the DB it queries (any column added to `schema.ts` shows up in INSERTs, breaking previews against the unmigrated prod DB).

This PR ships *only* the tooling. No schema or app changes. Safe to land first because:

- Workflow is `workflow_dispatch`-only — never auto-triggers.
- Bound to a new `prod-db` GH environment with required-reviewer gate; the prod DATABASE_URL secret never reaches a developer machine.
- Workflow has guard rails: shows pending-migration content for the reviewer to approve, and fails fast on destructive SQL patterns (DROP/RENAME/ALTER-DROP) so it can't be misused for contract migrations.
- Helper script refuses to dispatch on a dirty working tree or out-of-sync remote, so what gets run is what the developer thinks they're running.

## Why a separate PR (and why first)

`workflow_dispatch` requires the workflow file to exist on the default branch. Bundling this with the schema PR (`relationship-web` / PR #123) creates a chicken-and-egg: we'd need the workflow on main to migrate prod ahead of the schema PR's preview, but it isn't on main until the schema PR merges.

Splitting it out lets the workflow land first, then `npm run prod:db:expand` against `relationship-web` migrates prod, then the schema PR's preview runs cleanly.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (functional + e2e, all green locally)
- [ ] CI passes
- [ ] Preview deploy renders unchanged (zero app surface changes)

## Follow-up after merge

1. Confirm `prod-db` environment is set up: required reviewer + `PRODUCTION_DATABASE_URL` secret. (Already done.)
2. From `relationship-web`: `npm run prod:db:expand` → approve in GH UI → migration 0003 applies to prod.
3. Re-run e2e against PR #123's preview; should now be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)