### PR TITLE
Add member directory at /members (#27)

### DIFF
--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+
+import { requireUser } from "@/lib/api-server";
+import { serverApiClient } from "@/lib/api-server";
+import type { MemberSummary } from "@/lib/api-types";
+
+function MemberCard({ member }: { member: MemberSummary }) {
+  return (
+    <Link
+      href={`/members/${member.id}`}
+      className="flex flex-col gap-1 rounded border border-border p-4 hover:bg-muted/50 transition-colors"
+    >
+      <span className="font-semibold">{member.displayName}</span>
+      {member.location && (
+        <span className="text-sm text-muted-foreground">{member.location}</span>
+      )}
+      {member.keywords.length > 0 && (
+        <span className="text-sm text-muted-foreground">
+          {member.keywords.slice(0, 4).join(", ")}
+          {member.keywords.length > 4 ? "…" : ""}
+        </span>
+      )}
+    </Link>
+  );
+}
+
+export default async function MembersPage() {
+  await requireUser();
+
+  const res = await serverApiClient.api.members.$get();
+  if (!res.ok) throw new Error(`Failed to load members: ${res.status}`);
+  const { members }: { members: MemberSummary[] } = await res.json();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <div className="flex w-full max-w-lg items-center justify-between">
+        <h1 className="text-2xl font-bold">Member directory</h1>
+        <Link href="/" className="text-base text-muted-foreground hover:text-foreground">
+          ← Back
+        </Link>
+      </div>
+
+      {members.length === 0 ? (
+        <p className="text-muted-foreground">No members yet.</p>
+      ) : (
+        <ul className="flex w-full max-w-lg flex-col gap-3">
+          {members.map((member) => (
+            <li key={member.id}>
+              <MemberCard member={member} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,6 +54,9 @@ function LoggedInHome() {
       <Button render={<Link href="/profile" />}>
         My profile
       </Button>
+      <Button render={<Link href="/members" />}>
+        Member directory
+      </Button>
       <Button render={<Link href="/invites" />}>
         Manage invites
       </Button>

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -14,6 +14,11 @@ export type MemberProfile = InferResponseType<
   200
 >["profile"];
 
+export type MemberSummary = InferResponseType<
+  (typeof apiClient.api.members)["$get"],
+  200
+>["members"][number];
+
 export type Me = InferResponseType<
   (typeof apiClient.api.me)["$get"],
   200

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -14,6 +14,7 @@ import {
 import {
   getProfileForMember,
   getProfileForSelf,
+  listMembers,
   parseEditableProfile,
   upsertProfile,
 } from "./profiles";
@@ -144,6 +145,10 @@ const api = new Hono<{ Variables: ApiVariables }>()
       return c.json({ valid: true, note: result.note });
     }
     return c.json({ valid: false, reason: result.reason });
+  })
+  .get("/members", async (c) => {
+    const members = await listMembers();
+    return c.json({ members });
   })
   .get("/members/:id", async (c) => {
     const memberId = c.req.param("id");

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -1,6 +1,6 @@
 import { cache } from "react";
 import type { User } from "@supabase/supabase-js";
-import { eq } from "drizzle-orm";
+import { asc, eq, isNotNull } from "drizzle-orm";
 
 import { db } from "./db";
 import { profiles } from "./schema";
@@ -164,6 +164,26 @@ export const getProfileForMember = async (
     .where(eq(profiles.id, memberId));
 
   return row ?? null;
+};
+
+export type MemberSummary = {
+  id: string;
+  displayName: string;
+  location: string | null;
+  keywords: string[];
+};
+
+export const listMembers = async (): Promise<MemberSummary[]> => {
+  return db
+    .select({
+      id: profiles.id,
+      displayName: profiles.displayName,
+      location: profiles.location,
+      keywords: profiles.keywords,
+    })
+    .from(profiles)
+    .where(isNotNull(profiles.displayName))
+    .orderBy(asc(profiles.displayName)) as Promise<MemberSummary[]>;
 };
 
 // Placeholder. Same rationale as getProfileForMember — admin tooling


### PR DESCRIPTION
## Summary
- New `listMembers()` in `src/server/profiles.ts` — returns all members with a display name, ordered alphabetically
- New `GET /api/members` endpoint (auth-gated)
- New `/members` page with clickable member cards showing name, location, and up to 4 keywords
- Each card links to the existing `/members/[id]` profile view
- Home page gains a "Member directory" button
- `MemberSummary` type added to `api-types.ts`

## Test plan
- [ ] Sign in, click "Member directory" from home
- [ ] Cards appear for all seeded members with display names
- [ ] Click a card — lands on `/members/[id]` profile view
- [ ] Unauthenticated visit to `/members` redirects to `/signin`

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)