### PR TITLE
Show local dev hint on signin page (#114)

### DIFF
--- a/docs/doc-local-setup.md
+++ b/docs/doc-local-setup.md
@@ -146,3 +146,31 @@ npm run seed:dev
 This inserts 15 member profiles, 3 programs (The Gumball Machine, Presence Pods, Thematic Crews), 24 program memberships, and 5 invites representing a realistic invite chain. All records use fixed UUIDs so E2E tests can reference known values.
 
 The script is idempotent — running it a second time produces no duplicates and reports how many rows were inserted vs skipped per table.
+
+---
+
+## Signing in locally
+
+The local Supabase database is completely separate from production. Your real IS account doesn't exist here — signing in with your production email will return "No account found for that email."
+
+**Quickest path:**
+
+1. Run `npm run seed:dev` (if you haven't already)
+2. Go to http://localhost:3000/signin
+3. Enter one of the seeded emails — e.g. `aria.chen@example.com`
+4. Leave the password field blank and click **Send sign-in link**
+5. Open **Inbucket** at http://localhost:54324, click the email, and click the magic link
+
+The signin page shows an amber banner on localhost reminding you of this and linking directly to Inbucket.
+
+**Seeded member emails** (any of these work):
+
+```
+aria.chen@example.com
+marcus.webb@example.com
+leila.osei@example.com
+tobias.keller@example.com
+priya.nair@example.com
+```
+
+The full list of 15 profiles is in `scripts/seed-dev.json`.

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -31,10 +31,6 @@ export default async function SigninPage({ searchParams }: SigninPageProps) {
   const { error } = await searchParams;
   const errorMessage = error ? ERROR_MESSAGES[error] : undefined;
 
-  const isLocalDev =
-    process.env.NEXT_PUBLIC_SUPABASE_URL?.includes("localhost") ||
-    process.env.NEXT_PUBLIC_SUPABASE_URL?.includes("127.0.0.1");
-
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
       <h1 className="text-4xl font-bold">Intentional Society</h1>
@@ -42,7 +38,7 @@ export default async function SigninPage({ searchParams }: SigninPageProps) {
         Sign in with your password, or leave it blank to receive a magic
         link by email.
       </p>
-      {isLocalDev && (
+      {process.env.NODE_ENV === "development" && (
         <p className="max-w-sm rounded border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
           <strong>Local dev:</strong> this database is separate from production.
           Use a seeded email (e.g. <code>aria.chen@example.com</code>) or run{" "}

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -31,6 +31,10 @@ export default async function SigninPage({ searchParams }: SigninPageProps) {
   const { error } = await searchParams;
   const errorMessage = error ? ERROR_MESSAGES[error] : undefined;
 
+  const isLocalDev =
+    process.env.NEXT_PUBLIC_SUPABASE_URL?.includes("localhost") ||
+    process.env.NEXT_PUBLIC_SUPABASE_URL?.includes("127.0.0.1");
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
       <h1 className="text-4xl font-bold">Intentional Society</h1>
@@ -38,6 +42,22 @@ export default async function SigninPage({ searchParams }: SigninPageProps) {
         Sign in with your password, or leave it blank to receive a magic
         link by email.
       </p>
+      {isLocalDev && (
+        <p className="max-w-sm rounded border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
+          <strong>Local dev:</strong> this database is separate from production.
+          Use a seeded email (e.g. <code>aria.chen@example.com</code>) or run{" "}
+          <code>npm run seed:dev</code> first. Magic links arrive at{" "}
+          <a
+            href="http://localhost:54324"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Inbucket
+          </a>
+          .
+        </p>
+      )}
       {errorMessage && (
         <p
           role="alert"


### PR DESCRIPTION
## Summary
- Adds an amber banner on `/signin` when running in local dev (`NODE_ENV === "development"`)
- Banner explains the local DB is separate from production, suggests `aria.chen@example.com` as a seeded email, and links to Inbucket at `http://localhost:54324`
- Compile-time gated: `NODE_ENV` is statically replaced by Next.js at build, so the banner JSX is dead-code-eliminated from production bundles — no runtime overhead, no shipped code

## Test plan
- [ ] Run `npm run dev` locally — amber banner appears on `/signin`
- [ ] Check production preview — no banner visible

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)