### PR TITLE
Filter e2e workflow by deployment environment

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,13 @@ jobs:
   e2e:
     name: Playwright
     runs-on: ubuntu-latest
-    if: github.event.deployment_status.state == 'success'
+    # Only run for Vercel deployments. Other GitHub Deployments (e.g. the
+    # `prod-db` migration workflow) also fire `deployment_status: success`,
+    # but their `target_url` points at a GitHub Actions job, not the app —
+    # without this filter Playwright would hit github.com and fail at setup.
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      contains(fromJSON('["Production","Preview"]'), github.event.deployment_status.environment)
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -26,6 +32,19 @@ jobs:
 
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps
+
+      - name: Fail fast if base URL isn't Vercel
+        # The job-level `if:` already filters by environment, but a malformed
+        # or unexpected target_url here would still send Playwright at the
+        # wrong host (e.g. a github.com URL). Bail loudly instead.
+        run: |
+          case "$PLAYWRIGHT_BASE_URL" in
+            https://*.vercel.app*) ;;
+            https://app.intentionalsociety.org*) ;;
+            *) echo "Unexpected PLAYWRIGHT_BASE_URL: $PLAYWRIGHT_BASE_URL" >&2; exit 1 ;;
+          esac
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ github.event.deployment_status.target_url }}
 
       - name: Run Playwright tests
         run: npx playwright test

--- a/docs/doc-github.md
+++ b/docs/doc-github.md
@@ -23,7 +23,7 @@ Enforced via a GitHub Ruleset, managed as code in `scripts/update-main-branch-pr
 ## CI workflows
 
 - `.github/workflows/ci.yml` — lint + functional tests, triggers on `pull_request` to main. Spins up the full local Supabase stack via `supabase/setup-cli@v1` + `supabase start`, then applies Drizzle migrations before running Vitest. Functional tests that hit the DB (e.g. `profiles.test.ts`) run against this stack, matching the dev-box setup exactly.
-- `.github/workflows/e2e.yml` — Playwright against Vercel preview URL, triggers on `deployment_status` (fired by Vercel's GitHub integration when a preview deploy completes).
+- `.github/workflows/e2e.yml` — Playwright against Vercel preview URL, triggers on `deployment_status` (fired by Vercel's GitHub integration when a preview deploy completes). Job-level `if:` filters on `environment` ∈ {`Production`, `Preview`} so unrelated GitHub Deployments (e.g. `prod-db`) don't accidentally invoke Playwright with a github.com URL.
 - `.github/workflows/codeql.yml` — CodeQL static analysis on JS/TS and workflow YAMLs, triggers on PRs + pushes to main + weekly cron. Uses the `security-extended` query pack.
 - `.github/workflows/forward-migrate-prod-schema-expansion.yml` — `workflow_dispatch`-only. Applies additive (expand) drizzle migrations to the prod DB ahead of opening a PR, so previews can exercise new code paths against the migrated schema. Bound to the `prod-db` environment (see below) for the reviewer gate. Triggered locally via `npm run prod:db:expand` (uses the current branch). Contract migrations do NOT use this workflow — they ride the standard merge-to-main path.
 


### PR DESCRIPTION
## Summary
- `e2e.yml` was only gated on `state == 'success'`. When the new `forward-migrate-prod-schema-expansion` workflow fired its `prod-db` deployment to success earlier today, Playwright ran with `PLAYWRIGHT_BASE_URL` set to the GitHub Actions job URL and the reset endpoint returned a github.com error page. ([failing run](https://github.com/Intentional-Society/is-app/actions/runs/25514661089))
- Added an environment allowlist (`Production`, `Preview`) on the job-level `if:`, plus a `case` guard on the URL so a future shape change fails loud instead of looking like a flake.
- Updated `docs/doc-github.md` to note the filter.

## Test plan
- [ ] Vercel deploys this PR's preview → e2e.yml runs against the preview as before (proves the allowlist still admits real Vercel events).
- [ ] Next time `prod-db` runs, no e2e job appears for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)