### PR TITLE
Relations PR 2 of 4: Hono API surface

### DIFF
--- a/docs/design-relations.md
+++ b/docs/design-relations.md
@@ -40,22 +40,24 @@ A single value from a small set captures both "visible trust" and resonance, wit
 - `3` — friend.
 - `4` — deep trust and knowing.
 
-The absence of a relation is an absence of a row. There is no explicit "0 / no connection of interest" rating — un-rated candidates simply re-surface in future feeds, and at MVP scale (50–100 members) that's a non-problem. A future "intentional dissonance" value (`-1`) is also deferred — the social cost of publicly logged negative feelings wants more design care than we have lived experience to provide right now.
+The absence of a relation is an absence of a row. There is no explicit "0 / no connection of interest" rating — un-rated suggestions simply re-surface in future feeds, and at MVP scale (50–100 members) that's a non-problem. A future "intentional dissonance" value (`-1`) is also deferred — the social cost of publicly logged negative feelings wants more design care than we have lived experience to provide right now.
 
 ## Data model
 
 ### `relations`
 
-The core table. One row per directed (rater → ratee) pair. Composite PK because there is exactly one relation per direction per pair.
+The core table. One row per directed (relator → relatee) pair. Composite PK because there is exactly one relation per direction per pair.
+
+> Vocabulary note: TS-side field names (`relatorId`, `relateeId`, `relationValue`) reflect the post-PR-2 review pass. The SQL column names (`rater_id`, `ratee_id`, `creator_value`) and constraint names (`invites_creator_value_range`) still match the PR-1 migration; a rename migration will close the gap.
 
 ```ts
 export const relations = pgTable(
   "relations",
   {
-    raterId: uuid("rater_id")
+    relatorId: uuid("rater_id")
       .notNull()
       .references(() => profiles.id, { onDelete: "cascade" }),
-    rateeId: uuid("ratee_id")
+    relateeId: uuid("ratee_id")
       .notNull()
       .references(() => profiles.id, { onDelete: "cascade" }),
     value: integer("value"), // null only when isHint=true; otherwise 1..4
@@ -72,8 +74,8 @@ export const relations = pgTable(
       .$onUpdate(() => new Date()),
   },
   (table) => [
-    primaryKey({ columns: [table.raterId, table.rateeId] }),
-    check("relations_no_self", sql`${table.raterId} != ${table.rateeId}`),
+    primaryKey({ columns: [table.relatorId, table.relateeId] }),
+    check("relations_no_self", sql`${table.relatorId} != ${table.relateeId}`),
     check(
       "relations_value_range",
       sql`${table.value} IS NULL OR (${table.value} BETWEEN 1 AND 4)`,
@@ -94,11 +96,11 @@ Two valid row states:
 
 A hint becomes a confirmed rating by setting `value` and flipping `isHint` to false.
 
-Sparse representation: there is no row for "haven't been shown" or "haven't acted" — that state is `(no row in relations)`. Cost: no "deferred / ask me later" affordance — at 50–100 members the candidate pool is small enough that simply re-surfacing un-rated candidates each visit is fine. Revisit if the feed gets noisy.
+Sparse representation: there is no row for "haven't been shown" or "haven't acted" — that state is `(no row in relations)`. Cost: no "deferred / ask me later" affordance — at 50–100 members the suggestion pool is small enough that simply re-surfacing un-rated suggestions each visit is fine. Revisit if the feed gets noisy.
 
 ### `invite_hints`
 
-Hints created at invite-code creation time, materialized into `relations` rows when the invite is redeemed. Needed because the rater (the to-be-invitee) doesn't exist as a profile yet.
+Hints created at invite-code creation time, materialized into `relations` rows when the invite is redeemed. Needed because the relator (the to-be-invitee) doesn't exist as a profile yet.
 
 ```ts
 export const inviteHints = pgTable(
@@ -107,20 +109,20 @@ export const inviteHints = pgTable(
     inviteId: uuid("invite_id")
       .notNull()
       .references(() => invites.id, { onDelete: "cascade" }),
-    rateeId: uuid("ratee_id")
+    relateeId: uuid("ratee_id")
       .notNull()
       .references(() => profiles.id, { onDelete: "cascade" }),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
   },
-  (table) => [primaryKey({ columns: [table.inviteId, table.rateeId] })],
+  (table) => [primaryKey({ columns: [table.inviteId, table.relateeId] })],
 ).enableRLS();
 ```
 
-On invite redemption, for each row in `invite_hints` keyed to that invite, insert a `relations` row: `raterId = redeemer's profile`, `rateeId = inviteHints.rateeId`, `isHint = true`, `value = null`, `hintedBy = invites.createdBy`. The new member opens the app and finds their candidate feed already populated with the inviter's hypotheses — the moment of invite is the moment the inviter pre-seeds the new member's web.
+On invite redemption, for each row in `invite_hints` keyed to that invite, insert a `relations` row: `relatorId = redeemer's profile`, `relateeId = inviteHints.relateeId`, `isHint = true`, `value = null`, `hintedBy = invites.createdBy`. The new member opens the app and finds their suggestion feed already populated with the inviter's hypotheses — the moment of invite is the moment the inviter pre-seeds the new member's web.
 
-Asymmetric activation: the hint creates only the new-member→other-member row. The other member picks up the new member organically once the new member rates them, via the "people who've rated me" candidate signal.
+Asymmetric activation: the hint creates only the new-member→other-member row. The other member picks up the new member organically once the new member rates them, via the "people who've rated me" suggestion signal.
 
 Inviter UI: hints are added through a typeahead-member-search widget below the "who is this" / `creator_value` inputs on the invite form — start typing a member's name, pick from the autocomplete, accumulate hint chips. Each chip becomes one `invite_hints` row when the form submits.
 
@@ -132,25 +134,25 @@ One column added:
 lastUpdatedWeb: timestamp("last_updated_web", { withTimezone: true }),
 ```
 
-Bumped when the user clicks the **Done** button at the end of a build session (see Build/View flow below). Used by other members' "who's been recently active" candidate signal. Real-time edits to relations don't bump this — only the explicit Done click does, capturing intent rather than activity.
+Bumped when the user clicks the **Done** button at the end of a build session (see Build/View flow below). Used by other members' "who's been recently active" suggestion signal. Real-time edits to relations don't bump this — only the explicit Done click does, capturing intent rather than activity.
 
 ### `invites.creator_value`
 
 One column added to the existing `invites` table:
 
 ```ts
-creatorValue: integer("creator_value"), // 1..4 if set; null allowed for admin-issued invites
+relationValue: integer("creator_value"), // 1..4 if set; null allowed for admin-issued invites
 ```
 
 Plus a check constraint `invites_creator_value_range` enforcing `creator_value IS NULL OR creator_value BETWEEN 1 AND 4`.
 
 The inviter declares their relation to the invitee at invite-creation time, immediately after the "who is this?" input. The picker offers 1–4 (the same vocabulary as the rating dialog). A soft warn at 1 nudges the inviter to reconsider: weak-tie invites tend to make for weak community fit, and we'd rather members invite people they actually have a relation with. Admin-issued invites may leave the value null.
 
-On invite redemption, if `creator_value IS NOT NULL`, materialize a `relations` row: `raterId = invites.createdBy`, `rateeId = invites.redeemedBy`, `value = invites.creator_value`, `isHint = false`, `hintedBy = null`. The new member opens the app and finds their inviter at the top of the candidate feed via the "people who've rated me" signal — the warmest possible first interaction.
+On invite redemption, if `relationValue IS NOT NULL`, materialize a `relations` row: `relatorId = invites.createdBy`, `relateeId = invites.redeemedBy`, `value = invites.relationValue`, `isHint = false`, `hintedBy = null`. The new member opens the app and finds their inviter at the top of the suggestion feed via the "people who've rated me" signal — the warmest possible first interaction.
 
 The column doubles as a soft quality gate on invitations. The <2 soft-warn keeps the bar at "we've at least had a 1-on-1 conversation," which makes the invitation itself a more meaningful signal in the network.
 
-The redemption Hono handler performs both materializations (the `creator_value` row, plus any `invite_hints` rows) in the same database transaction as setting `redeemedBy` / `redeemedAt`. A partial redemption cannot leave the candidate feed unpopulated.
+The redemption Hono handler performs both materializations (the `relationValue` row, plus any `invite_hints` rows) in the same database transaction as setting `redeemedBy` / `redeemedAt`. A partial redemption cannot leave the suggestion feed unpopulated.
 
 ### Hint sources
 
@@ -169,28 +171,28 @@ The "welcome page" expands into a guided multi-step tour. Steps land on real app
 
 1. **Welcome.** Brief framing of IS Web and what the next ~2 minutes will set up.
 2. **Profile.** Edit the standard profile fields.
-3. **Relations: meet your candidates.** The candidate feed renders, pre-populated. The inviter sits at the top — their relation to the new member was materialized from `invites.creator_value` at redemption, so they show up as the strongest "people who've rated me" signal. Below them, the invite's hint rows. New candidates appear as ratings happen (the inviter's high-rated connections, anyone else who has already rated the new member).
+3. **Relations: meet your suggestions.** The suggestion feed renders, pre-populated. The inviter sits at the top — their relation to the new member was materialized from `invites.creator_value` at redemption, so they show up as the strongest "people who've rated me" signal. Below them, the invite's hint rows. New suggestions appear as ratings happen (the inviter's high-rated connections, anyone else who has already rated the new member).
 4. **See your web.** Personal subgraph view — the user themselves at center, their newly rated connections at one hop. The Done button transitions from edit to view mode and bumps `last_updated_web`.
 
 ### Edit mode ↔ View mode
 
 The personal subgraph is always displayed, regardless of mode — the web is the page, not a tab. Mode toggles only what surfaces around it:
 
-- **Edit mode.** Candidate feed visible below the graph (single column on mobile, grid on desktop). Cards are clickable to open the rating dialog. Edits persist in real time, and the graph re-renders optimistically as ratings happen.
-- **View mode.** Candidate feed hidden. The graph is the only content, oriented toward exploration and reading.
+- **Edit mode.** Suggestion feed visible below the graph (single column on mobile, grid on desktop). Cards are clickable to open the rating dialog. Edits persist in real time, and the graph re-renders optimistically as ratings happen.
+- **View mode.** Suggestion feed hidden. The graph is the only content, oriented toward exploration and reading.
 
-The toggle is a paired **Edit** / **Done** button — Edit in view mode, Done in edit mode. **Done** has one side effect: bumping `last_updated_web` on the user's profile — a signal of "I'm done updating for now," used by other members' "recently active" candidate signal. Real-time persistence means no batched save is happening; the button captures intent, not state. Members can re-enter edit mode any time.
+The toggle is a paired **Edit** / **Done** button — Edit in view mode, Done in edit mode. **Done** has one side effect: bumping `last_updated_web` on the user's profile — a signal of "I'm done updating for now," used by other members' "recently active" suggestion signal. Real-time persistence means no batched save is happening; the button captures intent, not state. Members can re-enter edit mode any time.
 
-### Candidate feed sources
+### Suggestion feed sources
 
 Surfaced in approximate priority order. At MVP scale (50–100 members), simpler-than-described is fine — start with one or two sources and add the rest as the feed thins out.
 
-1. **People who have rated me.** The strongest signal — a real person has unambiguously declared interest. Query: `relations.rateeId = me, value IS NOT NULL`, joined against the absence of a reciprocal row from me.
-2. **Pending hints for me.** `relations.raterId = me, isHint = true`. Includes both invite-time hints and post-signup superconnector hints. The `hintedBy` value provides the "James suggests…" attribution.
-3. **My inviter's higher-rated connections.** Rows where `rater = my profiles.referredBy` and `value >= 3`, minus people I've already rated.
+1. **People who have rated me.** The strongest signal — a real person has unambiguously declared interest. Query: `relations.relateeId = me, value IS NOT NULL`, joined against the absence of a reciprocal row from me.
+2. **Pending hints for me.** `relations.relatorId = me, isHint = true`. Includes both invite-time hints and post-signup superconnector hints. The `hintedBy` value provides the "James suggests…" attribution.
+3. **My inviter's higher-rated connections.** Rows where `relator = my profiles.referredBy` and `value >= 3`, minus people I've already rated.
 4. **Recently active members.** Profiles whose `last_updated_web > my last_updated_web`, minus people I've already rated.
 
-Each candidate carries a "reason" surfaced in the UI (`ratedYou` / `hintedBy <name>` / `via <inviter>` / `recently active`) — a hover or sub-line that grounds the suggestion in something legible.
+Each suggestion carries a "reason" surfaced in the UI (`ratedYou` / `hintedBy <name>` / `via <inviter>` / `recently active`) — a hover or sub-line that grounds the suggestion in something legible.
 
 The asymmetry-visibility ethos: when someone shows up because they rated me, I don't see their rating before responding. This is a soft UI hiding, not a hard constraint, and I see their rating on the completed two-way relation.
 
@@ -199,31 +201,31 @@ The feed is rendered in two sections:
 - **Suggestions.** Currently houses person-targeted signals (sources 1–2 — people who've rated me, pending hints). The label is broad enough to encompass both "from people" suggestions and "from the app" suggestions, so derived signals could be folded in later if it reads better. Auto-hides when empty, giving the user a small "caught up" moment once the queue is cleared.
 - **Other members.** Derived signals — sources 3–4 (inviter's high-rated connections, recently active members). Visible whenever there is anything to show in edit mode.
 
-### Rating a candidate
+### Rating a suggestion
 
-Clicking a candidate card opens a small modal:
+Clicking a suggestion card opens a small modal:
 
 - A vertical column of four buttons labeled **1**, **2**, **3**, **4**, each next to its vocabulary description. Clicking a button sets the rating and closes the dialog — no separate Save step.
 - Numeric keystrokes 1–4 are caught as a backup shortcut, equivalent to clicking the matching button.
-- Clicking outside the dialog dismisses it and cancels — no relation is created. The candidate remains un-rated and re-surfaces in a future feed cycle.
+- Clicking outside the dialog dismisses it and cancels — no relation is created. The suggestion remains un-rated and re-surfaces in a future feed cycle.
 - For hint cards (`isHint = true`), the dialog surfaces the `hintedBy` attribution ("James suggested you know this person"). Selecting any of 1–4 confirms the hint: `value` is set, `isHint` flips to false.
-- For "people who rated me" cards, the rater's value of me stays hidden in the dialog (consistent with the soft-UI-hide policy) and is revealed once I've responded.
+- For "people who rated me" cards, the relator's value of me stays hidden in the dialog (consistent with the soft-UI-hide policy) and is revealed once I've responded.
 
 On rating, the mutation goes through Hono RPC; TanStack Query optimistically updates the local cache so the graph re-renders with the new relation before the server round-trip completes. Failed mutations revert with an error toast.
 
 ### Personal subgraph view
 
-The graph is rendered with `react-flow` — chosen for native React integration, click-on-edge / click-on-node support, and clean interop with TanStack Query optimistic updates. Identical in edit and view modes; the only mode-driven difference is whether the candidate feed appears below it. Center node: the viewing member. Relations shown:
+The graph is rendered with `react-flow` — chosen for native React integration, click-on-edge / click-on-node support, and clean interop with TanStack Query optimistic updates. Identical in edit and view modes; the only mode-driven difference is whether the suggestion feed appears below it. Center node: the viewing member. Relations shown:
 
-- Outgoing relations (`rater = me`, `value IS NOT NULL`). Show value as edge thickness or label.
-- Optional toggle: Incoming relations (`ratee = me`, `value IS NOT NULL`). Asymmetry rendered as paired counter-edges, one per direction — consistent with the doubly-unidirectional model.
+- Outgoing relations (`relator = me`, `value IS NOT NULL`). Show value as edge thickness or label.
+- Optional toggle: Incoming relations (`relatee = me`, `value IS NOT NULL`). Asymmetry rendered as paired counter-edges, one per direction — consistent with the doubly-unidirectional model.
 - Optional toggle: One additional hop: relations of my first-degree connections (their relations to each other and to second-degree members).
 
-Hint rows (`value IS NULL`) are filtered out of the visualization. They live on the candidate feed instead.
+Hint rows (`value IS NULL`) are filtered out of the visualization. They live on the suggestion feed instead.
 
 **Click behavior** (same in both modes):
 
-- **Edge (relation) click** — opens the rating dialog pre-filled with the current value. Same dialog component as the candidate-feed rating flow; selecting a new 1–4 updates `value` and re-renders. Outside-click cancels with no change.
+- **Edge (relation) click** — opens the rating dialog pre-filled with the current value. Same dialog component as the suggestion-feed rating flow; selecting a new 1–4 updates `value` and re-renders. Outside-click cancels with no change.
 - **Node (person) click** — navigates to that person's profile page.
 
 **Small-N rendering.** A brand-new member's first graph has 1–3 nodes (themselves, their inviter, maybe a confirmed hint or two). The graph component must render gracefully at these sizes — a single node should look intentional. Test cases at N = 1, 2, 3 are part of the implementation acceptance criteria.
@@ -234,10 +236,10 @@ Whole-network views are out of scope at MVP. The data model permits them — any
 
 The predecessor here is SumApp + Kumu, used at Limicon 2024 and 2025. Specific pain points to design against:
 
-- **Random-ordered grid of all members.** Replaced by the candidate feed, ordered by signal (people who rated you > hints > inviter's connections > recently active).
-- **No hover detail.** Each candidate card surfaces enough profile information to make a rating decision without navigating away.
+- **Random-ordered grid of all members.** Replaced by the suggestion feed, ordered by signal (people who rated you > hints > inviter's connections > recently active).
+- **No hover detail.** Each suggestion card surfaces enough profile information to make a rating decision without navigating away.
 - **No multiselect.** Some affordance for multi-select will let you tap/click multiple people and assign them the same rating.
-- **No "what's new since last visit."** `last_updated_web` and the recently-active candidate signal address this directly.
+- **No "what's new since last visit."** `last_updated_web` and the recently-active suggestion signal address this directly.
 - **Static, no responsiveness.** Real-time RPC persistence, optimistic UI updates via TanStack Query.
 
 The design assumes a cold start from current IS Web signups. Limicon data is not imported.
@@ -249,13 +251,13 @@ These are choices made during the design interview. Each is reversible but refle
 | Decision | Rationale |
 | --- | --- |
 | One dimension, 4 values (1..4) | Capture visible-trust and resonance with the smallest possible model. Add dimensions later if needed. |
-| No explicit `0` rating | Considered and dropped. Un-rated candidates re-surface in the feed; the only state distinction is "have row, value 1..4" vs "no row." Simpler dialog, simpler check constraints, fewer affordances to design. |
+| No explicit `0` rating | Considered and dropped. Un-rated suggestions re-surface in the feed; the only state distinction is "have row, value 1..4" vs "no row." Simpler dialog, simpler check constraints, fewer affordances to design. |
 | Doubly unidirectional, no symmetrization | Asymmetry is information, and people can see it. |
 | Open data model, cozy UX layer | Members can see all relations in principle; the app's defaults make exploration deliberate. |
-| Sparse state, no `candidate_state` table | No row = no interaction. Trade-off: no "deferred / ask me later" — re-surface un-rated candidates each visit. |
+| Sparse state, no `suggestion_state` table | No row = no interaction. Trade-off: no "deferred / ask me later" — re-surface un-rated suggestions each visit. |
 | Hints are just hypothesized relations (`isHint`, `hintedBy`) | One table, one shape, two row states. Avoids a parallel `hints` table. |
-| Invite-creation hints (separate `invite_hints` table, materialized at redemption) | Inviter pre-seeds the new member's candidate feed at the moment of code generation; new members land on a populated, warm web rather than just one inviter edge. |
-| Inviter rates the invitee at invite creation (`invites.creator_value`) | Materialized as a confirmed `relations` row at redemption — the inviter is the new member's warmest first candidate via "people who've rated me." Doubles as a soft invite-quality gate; the <2 warn nudges members toward inviting people they actually have a relation with. |
+| Invite-creation hints (separate `invite_hints` table, materialized at redemption) | Inviter pre-seeds the new member's suggestion feed at the moment of code generation; new members land on a populated, warm web rather than just one inviter edge. |
+| Inviter rates the invitee at invite creation (`invites.relationValue`) | Materialized as a confirmed `relations` row at redemption — the inviter is the new member's warmest first suggestion via "people who've rated me." Doubles as a soft invite-quality gate; the <2 warn nudges members toward inviting people they actually have a relation with. |
 | Hint activation is asymmetric | One row per hint (new member → existing member); the other side picks up via "people who rated me" once the new member rates. |
 | Personal subgraph (≤2 hops) is the primary view | Whole-network is boring sparse and overwhelming dense; 2-hop subgraphs deliver the "that's neat" hit at any density. |
 | `last_updated_web` bumped on explicit Done click | Captures intent rather than real-time activity. Quiet edits stay quiet. |
@@ -275,5 +277,5 @@ These are choices made during the design interview. Each is reversible but refle
 
 ## Open questions
 
-- **Hint edit / withdrawal.** If a hint is wrong, can the rater dismiss it without rating? At MVP: any of 1–4 confirms the hint; outside-click cancels and leaves the hint in place to re-surface next visit. There is no "delete this hint" affordance for the rater. Likely fine; revisit if hints become a source of friction.
+- **Hint edit / withdrawal.** If a hint is wrong, can the relator dismiss it without rating? At MVP: any of 1–4 confirms the hint; outside-click cancels and leaves the hint in place to re-surface next visit. There is no "delete this hint" affordance for the relator. Likely fine; revisit if hints become a source of friction.
 - **Vocabulary refinement.** The 1–4 labels are a draft. Worth user-testing with a handful of members before committing.

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-08 | James | Relations API: PR 2 of the Relations ship
+
+Hono routes for the candidate feed, personal subgraph, member-rate, and admin hint create/delete; `POST /api/invites` extended with `creatorValue` + `hints`; auth callback now materializes both into `relations` rows in the same transaction as redemption. Soft-hide enforced server-side so the rater's value never reaches the client. No UI yet — that's PR 3.
+
 ## 2026-05-07 | James | Replace ESLint with Biome
 
 Why? `npm run lint` performance goes from 49 s → 0.9 s. Also we now have an automatic formatter tool (see biome.json).

--- a/docs/plan-relations.md
+++ b/docs/plan-relations.md
@@ -15,7 +15,7 @@ Ship the relations feature as described in `design-relations.md`, in four merge-
 - **Hint UX in invite form: typeahead-member-search.** Start typing a member's name, pick from autocomplete, accumulate chips; each chip becomes one `invite_hints` row on submission.
 - **Rating dialog control: button column.** Buttons labeled 1–4 next to descriptions. Numeric keystrokes 1–4 as backup. Outside-click cancels (no Save button, no Esc handling beyond outside-click).
 - **URL: `/myweb`.** First-person, consistent with the mesh philosophy (every member at center of their own graph).
-- **Component split: `WebGraph` (display) and `WebBuilder` (edit affordances).** Both compose on `/myweb`. `WebGraph` is parameterized on which member is at center and whether editing is enabled, so it can later be embedded read-only on member profile pages without rework. `WebBuilder` owns the candidate feed, rating dialog, and Edit/Done toggle.
+- **Component split: `WebGraph` (display) and `WebBuilder` (edit affordances).** Both compose on `/myweb`. `WebGraph` is parameterized on which member is at center and whether editing is enabled, so it can later be embedded read-only on member profile pages without rework. `WebBuilder` owns the suggestion feed, rating dialog, and Edit/Done toggle.
 
 ## PR breakdown
 
@@ -35,9 +35,9 @@ Tests (Vitest functional):
 
 - `relations_value_range` rejects values outside 1..4 and accepts NULL.
 - `relations_hint_state` accepts confirmed (value set, `isHint` false) and pending hint (value NULL, `isHint` true), rejects mixed states.
-- `relations_no_self` rejects rater == ratee.
+- `relations_no_self` rejects relator == relatee.
 - `invites_creator_value_range` rejects values outside 1..4 and accepts NULL.
-- Composite PKs reject duplicate (rater, ratee) and (invite, ratee) inserts.
+- Composite PKs reject duplicate (relator, relatee) and (invite, relatee) inserts.
 
 Out of scope: any code that reads or writes the new tables. Migration only.
 
@@ -46,22 +46,22 @@ Out of scope: any code that reads or writes the new tables. Migration only.
 Scope:
 
 - New routes (URL shapes are starting points — confirm during PR work):
-  - `GET /api/relations/candidates` — feed for current user, ordered per design (people who rated me → hints → inviter's high-rated → recently active), excluding self and already-rated.
+  - `GET /api/relations/suggestions` — feed for current user, ordered per design (people who rated me → hints → inviter's high-rated → recently active), excluding self and already-rated.
   - `GET /api/relations/subgraph` — current user's personal subgraph; query params for in/out/hop toggles.
-  - `PUT /api/relations/:rateeId` — create or update a confirmed rating from the current user; converts a pending hint to confirmed if one exists.
+  - `PUT /api/relations/value/:relateeId` — create or update a confirmed rating from the current user; converts a pending hint to confirmed if one exists.
   - `POST /api/relations/hint` — create a hint (admin-only at MVP — see Open questions).
   - `DELETE /api/relations/hint` — withdraw a hint (admin-only).
-- Update `POST /api/invites` to accept `creatorValue` and `hints[]` (member ids).
+- Update `POST /api/invites` to accept `relationValue` and `hints[]` (member ids).
 - Materialization logic in invite redemption handler:
-  - Insert a `relations` row from `creator_value` if set.
+  - Insert a `relations` row from `relationValue` if set.
   - Insert `relations` rows for each `invite_hints` entry.
   - All in the same transaction as setting `redeemedBy` / `redeemedAt`.
-- Soft-hide enforced server-side: candidate response strips the rater's value for "rated me" cards when the current user hasn't reciprocated. Client never sees the value, so no leakage.
+- Soft-hide enforced server-side: suggestion response strips the relator's value for "rated me" cards when the current user hasn't reciprocated. Client never sees the value, so no leakage.
 
 Tests (Vitest functional):
 
-- Candidate query returns expected ordering with seed data; excludes self and already-rated.
-- Soft-hide: candidate response surfaces attribution but not the rater's value pre-response.
+- Suggestion query returns expected ordering with seed data; excludes self and already-rated.
+- Soft-hide: suggestion response surfaces attribution but not the relator's value pre-response.
 - Invite redemption is atomic — partial failures roll back materialization.
 - Re-rating updates `value` and bumps `updatedAt` without changing the primary key.
 - Hint → confirmed transition: setting `value` flips `isHint` to false and preserves `hintedBy`.
@@ -74,7 +74,7 @@ The substantial PR. Scope:
 
 - New route at `/myweb`, composing two new components:
   - `WebGraph` — the visualization. Props for `centerMemberId` and `interactive`. `react-flow` + live `d3-force` simulation, paired counter-edges for asymmetry, click-on-edge → re-rate dialog (when interactive), click-on-node → `/members/[id]`.
-  - `WebBuilder` — the edit affordances. Owns the candidate feed (Suggestions auto-hides empty + Other members), the rating dialog (button column 1–4 + numeric keystrokes + outside-click cancel), and the Edit / Done toggle. Done bumps `last_updated_web` via API.
+  - `WebBuilder` — the edit affordances. Owns the suggestion feed (Suggestions auto-hides empty + Other members), the rating dialog (button column 1–4 + numeric keystrokes + outside-click cancel), and the Edit / Done toggle. Done bumps `last_updated_web` via API.
 - Layout on `/myweb`: graph above, builder below (single column on mobile, grid on desktop).
 - TanStack Query: feed and subgraph as queries; rating as mutation with optimistic update.
 - Small-N rendering: graceful at N = 1, 2, 3 nodes — write explicit cases.
@@ -82,7 +82,7 @@ The substantial PR. Scope:
 Tests:
 
 - Vitest for non-trivial client logic (cache update on rate, optimistic graph state).
-- Playwright e2e: rate first candidate → graph populates → toggle Edit/Done → reopen and re-rate.
+- Playwright e2e: rate first suggestion → graph populates → toggle Edit/Done → reopen and re-rate.
 
 Out of scope: invite form updates, welcome tour overlays.
 
@@ -91,7 +91,7 @@ Out of scope: invite form updates, welcome tour overlays.
 Scope:
 
 - Update the invite-creation form (`/invites` or wherever it lives now) with:
-  - `creator_value` picker (1–4) right after the "who is this" input.
+  - `relationValue` picker (1–4) right after the "who is this" input.
   - Soft warn at value 1 ("inviting someone you've only met in group settings tends to lead to weak fit — is this the right time?" — copy TBD).
   - Typeahead-member-search widget for hints — name autocomplete → chip accumulator. Each chip becomes one `invite_hints` row on submit.
 - Welcome tour using `react-joyride`:
@@ -101,8 +101,8 @@ Scope:
 
 Tests:
 
-- Vitest functional: `creator_value` validation in invite-create handler.
-- Playwright e2e: full signup-tour-flow happy path, including hints arriving as candidates and `creator_value` arriving as a "rated me" signal.
+- Vitest functional: `relationValue` validation in invite-create handler.
+- Playwright e2e: full signup-tour-flow happy path, including hints arriving as suggestions and `relationValue` arriving as a "rated me" signal.
 
 Out of scope: vocabulary refinement, view-relation detail surface, hint withdrawal UX.
 
@@ -124,7 +124,7 @@ Out of scope: vocabulary refinement, view-relation detail surface, hint withdraw
 | Layer | Tool | Cases |
 | --- | --- | --- |
 | DB constraints | Vitest | All check constraints, accept and reject paths. |
-| API | Vitest | Candidate ordering, soft-hide, redemption atomicity, hint transitions, re-rating semantics. |
+| API | Vitest | Suggestion ordering, soft-hide, redemption atomicity, hint transitions, re-rating semantics. |
 | Client logic | Vitest | Optimistic cache mutation on rate; graph state on edge / node click. |
 | End-to-end | Playwright | Signup-with-hints flow; build/view mode toggle; re-rating an existing relation. |
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -68,7 +68,7 @@ export async function GET(request: NextRequest) {
         .returning({
           inviteId: invites.id,
           inviterId: invites.createdBy,
-          creatorValue: invites.creatorValue,
+          relationValue: invites.relationValue,
         });
 
       if (rows.length === 0) {
@@ -76,11 +76,12 @@ export async function GET(request: NextRequest) {
         throw new InviteInvalid();
       }
 
-      const { inviteId, inviterId, creatorValue } = rows[0];
+      const { inviteId, inviterId, relationValue } = rows[0];
 
       await tx.update(profiles).set({ referredBy: inviterId }).where(eq(profiles.id, userId));
 
-      // Materialize any creator_value rating + invite_hints rows into
+      // Materialize the inviter→redeemer rating (from relation_value)
+      // and the redeemer→relatee hints (from invite_hints) into
       // relations rows. Same tx as the redemption itself so a failure
       // here rolls back the consumed invite — the new member never
       // ends up with a half-populated web.
@@ -88,7 +89,7 @@ export async function GET(request: NextRequest) {
         inviteId,
         inviterId,
         redeemerId: userId,
-        creatorValue,
+        relationValue,
       });
 
       return true;

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -4,6 +4,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { db } from "@/server/db";
 import { upsertProfile } from "@/server/profiles";
+import { materializeInviteRelations } from "@/server/relations";
 import { invites, profiles } from "@/server/schema";
 
 export async function GET(request: NextRequest) {
@@ -64,14 +65,31 @@ export async function GET(request: NextRequest) {
             gt(invites.expiresAt, sql`now()`),
           ),
         )
-        .returning({ inviterId: invites.createdBy });
+        .returning({
+          inviteId: invites.id,
+          inviterId: invites.createdBy,
+          creatorValue: invites.creatorValue,
+        });
 
       if (rows.length === 0) {
         // Force rollback — no partial state survives.
         throw new InviteInvalid();
       }
 
-      await tx.update(profiles).set({ referredBy: rows[0].inviterId }).where(eq(profiles.id, userId));
+      const { inviteId, inviterId, creatorValue } = rows[0];
+
+      await tx.update(profiles).set({ referredBy: inviterId }).where(eq(profiles.id, userId));
+
+      // Materialize any creator_value rating + invite_hints rows into
+      // relations rows. Same tx as the redemption itself so a failure
+      // here rolls back the consumed invite — the new member never
+      // ends up with a half-populated web.
+      await materializeInviteRelations(tx, {
+        inviteId,
+        inviterId,
+        redeemerId: userId,
+        creatorValue,
+      });
 
       return true;
     });

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -21,7 +21,6 @@ import {
   getRelationSuggestions,
   isRelationValue,
   parseOptionalRelationValue,
-  type RelationValue,
   updateRelationValue,
 } from "./relations";
 import { profiles } from "./schema";
@@ -113,15 +112,14 @@ const api = new Hono<{ Variables: ApiVariables }>()
     // relationValue and hints are optional — the form omits them for
     // admin-issued invites and for inviters who decline the picker.
     const parsed = parseOptionalRelationValue(obj.relationValue);
-    if (parsed !== null && typeof parsed === "object") {
+    if (!parsed.ok) {
       return c.json({ error: parsed.error }, 400);
     }
-    const relationValue: RelationValue | null = parsed;
 
     const result = await createInvite({
       createdBy: user.id,
       note: noteCheck,
-      relationValue,
+      relationValue: parsed.value,
       hints: obj.hints as string[] | undefined,
     });
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -14,6 +14,16 @@ import {
   upsertProfile,
 } from "./profiles";
 import { joinProgram, leaveProgram, listPrograms } from "./programs";
+import {
+  createHint,
+  deleteHint,
+  getCandidates,
+  getSubgraph,
+  isAdmin,
+  isRelationValue,
+  isUuid,
+  rateMember,
+} from "./relations";
 import { profiles } from "./schema";
 import { resetE2EUsers } from "./test-reset";
 
@@ -93,15 +103,41 @@ const api = new Hono<{ Variables: ApiVariables }>()
     if (!body || typeof body !== "object" || Array.isArray(body)) {
       return c.json({ error: "body must be a JSON object" }, 400);
     }
+    const obj = body as Record<string, unknown>;
 
-    const noteCheck = validateNote((body as Record<string, unknown>).note);
+    const noteCheck = validateNote(obj.note);
     if (typeof noteCheck !== "string") {
       return c.json({ error: noteCheck.error }, 400);
     }
 
-    const result = await createInvite({ createdBy: user.id, note: noteCheck });
+    // creatorValue and hints are optional — the form omits them for
+    // admin-issued invites and for inviters who decline the picker.
+    const rawCreatorValue = obj.creatorValue;
+    let creatorValue: 1 | 2 | 3 | 4 | null = null;
+    if (rawCreatorValue !== undefined && rawCreatorValue !== null) {
+      if (!isRelationValue(rawCreatorValue)) {
+        return c.json({ error: "creatorValue must be an integer 1..4" }, 400);
+      }
+      creatorValue = rawCreatorValue;
+    }
+
+    const result = await createInvite({
+      createdBy: user.id,
+      note: noteCheck,
+      creatorValue,
+      hints: obj.hints as string[] | undefined,
+    });
+
     if ("error" in result) {
-      return c.json({ error: "too_many_active_invites", limit: result.limit }, 429);
+      if (result.error === "too_many_active") {
+        return c.json({ error: "too_many_active_invites", limit: result.limit }, 429);
+      }
+      if (result.error === "invalid_creator_value") {
+        return c.json({ error: "creatorValue must be an integer 1..4" }, 400);
+      }
+      // invalid_hints — the reason names exactly what's wrong so the
+      // form can call out the bad chip.
+      return c.json({ error: "invalid_hints", reason: result.reason }, 400);
     }
     return c.json(result, 201);
   })
@@ -170,6 +206,100 @@ const api = new Hono<{ Variables: ApiVariables }>()
     const user = c.get("user");
     const programId = c.req.param("id");
     const result = await leaveProgram(user.id, programId);
+    if ("error" in result) {
+      return c.json({ error: "not_found" }, 404);
+    }
+    return c.json({ ok: true });
+  })
+  .get("/relations/candidates", async (c) => {
+    const user = c.get("user");
+    const feed = await getCandidates(user.id);
+    return c.json(feed);
+  })
+  .get("/relations/subgraph", async (c) => {
+    const user = c.get("user");
+    // Defaults match the design: outgoing only, one hop. Toggles can
+    // widen the view from the client.
+    const includeOutgoing = c.req.query("out") !== "false";
+    const includeIncoming = c.req.query("in") === "true";
+    const hops = c.req.query("hops") === "2" ? 2 : 1;
+
+    const subgraph = await getSubgraph({
+      centerId: user.id,
+      includeIncoming,
+      includeOutgoing,
+      hops,
+    });
+    return c.json(subgraph);
+  })
+  .put("/relations/:rateeId", async (c) => {
+    const user = c.get("user");
+    const rateeId = c.req.param("rateeId");
+    if (!isUuid(rateeId)) {
+      return c.json({ error: "rateeId must be a UUID" }, 400);
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid JSON" }, 400);
+    }
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return c.json({ error: "body must be a JSON object" }, 400);
+    }
+    const value = (body as Record<string, unknown>).value;
+    if (!isRelationValue(value)) {
+      return c.json({ error: "value must be an integer 1..4" }, 400);
+    }
+
+    const result = await rateMember({ raterId: user.id, rateeId, value });
+    if ("error" in result) {
+      if (result.error === "self_rating") return c.json({ error: "self_rating" }, 400);
+      if (result.error === "ratee_not_found") return c.json({ error: "not_found" }, 404);
+    }
+    return c.json({ ok: true });
+  })
+  .post("/relations/hint", async (c) => {
+    const user = c.get("user");
+    if (!(await isAdmin(user.id))) {
+      return c.json({ error: "forbidden" }, 403);
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid JSON" }, 400);
+    }
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return c.json({ error: "body must be a JSON object" }, 400);
+    }
+    const { raterId, rateeId } = body as Record<string, unknown>;
+    if (!isUuid(raterId) || !isUuid(rateeId)) {
+      return c.json({ error: "raterId and rateeId must be UUIDs" }, 400);
+    }
+
+    const result = await createHint({ raterId, rateeId, hintedBy: user.id });
+    if ("error" in result) {
+      if (result.error === "self_rating") return c.json({ error: "self_rating" }, 400);
+      return c.json({ error: "not_found" }, 404);
+    }
+    return c.json(result, 201);
+  })
+  .delete("/relations/hint/:raterId/:rateeId", async (c) => {
+    const user = c.get("user");
+    if (!(await isAdmin(user.id))) {
+      return c.json({ error: "forbidden" }, 403);
+    }
+
+    const raterId = c.req.param("raterId");
+    const rateeId = c.req.param("rateeId");
+    if (!isUuid(raterId) || !isUuid(rateeId)) {
+      return c.json({ error: "raterId and rateeId must be UUIDs" }, 400);
+    }
+
+    const result = await deleteHint({ raterId, rateeId });
     if ("error" in result) {
       return c.json({ error: "not_found" }, 404);
     }

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -2,7 +2,7 @@ import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { log } from "next-axiom";
 
-import { type ApiVariables, requireAuth } from "./auth-middleware";
+import { type ApiVariables, isAdmin, isUuid, requireAuth } from "./auth-middleware";
 import { db } from "./db";
 import { checkInvite, createInvite, getInvitesForCreator, revokeInvite, validateNote } from "./invites";
 import {
@@ -15,14 +15,14 @@ import {
 } from "./profiles";
 import { joinProgram, leaveProgram, listPrograms } from "./programs";
 import {
-  createHint,
-  deleteHint,
-  getCandidates,
-  getSubgraph,
-  isAdmin,
+  createRelationHint,
+  deleteRelationHint,
+  getPersonalWeb,
+  getRelationSuggestions,
   isRelationValue,
-  isUuid,
-  rateMember,
+  parseOptionalRelationValue,
+  type RelationValue,
+  updateRelationValue,
 } from "./relations";
 import { profiles } from "./schema";
 import { resetE2EUsers } from "./test-reset";
@@ -110,21 +110,18 @@ const api = new Hono<{ Variables: ApiVariables }>()
       return c.json({ error: noteCheck.error }, 400);
     }
 
-    // creatorValue and hints are optional — the form omits them for
+    // relationValue and hints are optional — the form omits them for
     // admin-issued invites and for inviters who decline the picker.
-    const rawCreatorValue = obj.creatorValue;
-    let creatorValue: 1 | 2 | 3 | 4 | null = null;
-    if (rawCreatorValue !== undefined && rawCreatorValue !== null) {
-      if (!isRelationValue(rawCreatorValue)) {
-        return c.json({ error: "creatorValue must be an integer 1..4" }, 400);
-      }
-      creatorValue = rawCreatorValue;
+    const parsed = parseOptionalRelationValue(obj.relationValue);
+    if (parsed !== null && typeof parsed === "object") {
+      return c.json({ error: parsed.error }, 400);
     }
+    const relationValue: RelationValue | null = parsed;
 
     const result = await createInvite({
       createdBy: user.id,
       note: noteCheck,
-      creatorValue,
+      relationValue,
       hints: obj.hints as string[] | undefined,
     });
 
@@ -132,8 +129,8 @@ const api = new Hono<{ Variables: ApiVariables }>()
       if (result.error === "too_many_active") {
         return c.json({ error: "too_many_active_invites", limit: result.limit }, 429);
       }
-      if (result.error === "invalid_creator_value") {
-        return c.json({ error: "creatorValue must be an integer 1..4" }, 400);
+      if (result.error === "invalid_relation_value") {
+        return c.json({ error: "relationValue must be an integer 1..4" }, 400);
       }
       // invalid_hints — the reason names exactly what's wrong so the
       // form can call out the bad chip.
@@ -149,11 +146,9 @@ const api = new Hono<{ Variables: ApiVariables }>()
   .post("/invites/:code/revoke", async (c) => {
     const user = c.get("user");
     const code = c.req.param("code");
+    const adminFlag = await isAdmin(user.id);
 
-    const [row] = await db.select({ isAdmin: profiles.isAdmin }).from(profiles).where(eq(profiles.id, user.id));
-    const isAdmin = row?.isAdmin ?? false;
-
-    const result = await revokeInvite({ code, userId: user.id, isAdmin });
+    const result = await revokeInvite({ code, userId: user.id, isAdmin: adminFlag });
     if ("error" in result) {
       if (result.error === "not_found") {
         return c.json({ error: "not_found" }, 404);
@@ -213,18 +208,18 @@ const api = new Hono<{ Variables: ApiVariables }>()
   })
   .get("/relations/candidates", async (c) => {
     const user = c.get("user");
-    const feed = await getCandidates(user.id);
+    const feed = await getRelationSuggestions(user.id);
     return c.json(feed);
   })
   .get("/relations/subgraph", async (c) => {
     const user = c.get("user");
-    // Defaults match the design: outgoing only, one hop. Toggles can
-    // widen the view from the client.
+    // Defaults match the design: outgoing only, two hops. Toggles can
+    // narrow or widen the view from the client.
     const includeOutgoing = c.req.query("out") !== "false";
     const includeIncoming = c.req.query("in") === "true";
-    const hops = c.req.query("hops") === "2" ? 2 : 1;
+    const hops = c.req.query("hops") === "1" ? 1 : 2;
 
-    const subgraph = await getSubgraph({
+    const subgraph = await getPersonalWeb({
       centerId: user.id,
       includeIncoming,
       includeOutgoing,
@@ -232,11 +227,11 @@ const api = new Hono<{ Variables: ApiVariables }>()
     });
     return c.json(subgraph);
   })
-  .put("/relations/:rateeId", async (c) => {
+  .put("/relations/value/:relateeId", async (c) => {
     const user = c.get("user");
-    const rateeId = c.req.param("rateeId");
-    if (!isUuid(rateeId)) {
-      return c.json({ error: "rateeId must be a UUID" }, 400);
+    const relateeId = c.req.param("relateeId");
+    if (!isUuid(relateeId)) {
+      return c.json({ error: "relateeId must be a UUID" }, 400);
     }
 
     let body: unknown;
@@ -253,10 +248,10 @@ const api = new Hono<{ Variables: ApiVariables }>()
       return c.json({ error: "value must be an integer 1..4" }, 400);
     }
 
-    const result = await rateMember({ raterId: user.id, rateeId, value });
+    const result = await updateRelationValue({ relatorId: user.id, relateeId, value });
     if ("error" in result) {
-      if (result.error === "self_rating") return c.json({ error: "self_rating" }, 400);
-      if (result.error === "ratee_not_found") return c.json({ error: "not_found" }, 404);
+      if (result.error === "self_relating") return c.json({ error: "self_relating" }, 400);
+      if (result.error === "relatee_not_found") return c.json({ error: "not_found" }, 404);
     }
     return c.json({ ok: true });
   })
@@ -275,31 +270,31 @@ const api = new Hono<{ Variables: ApiVariables }>()
     if (!body || typeof body !== "object" || Array.isArray(body)) {
       return c.json({ error: "body must be a JSON object" }, 400);
     }
-    const { raterId, rateeId } = body as Record<string, unknown>;
-    if (!isUuid(raterId) || !isUuid(rateeId)) {
-      return c.json({ error: "raterId and rateeId must be UUIDs" }, 400);
+    const { relatorId, relateeId } = body as Record<string, unknown>;
+    if (!isUuid(relatorId) || !isUuid(relateeId)) {
+      return c.json({ error: "relatorId and relateeId must be UUIDs" }, 400);
     }
 
-    const result = await createHint({ raterId, rateeId, hintedBy: user.id });
+    const result = await createRelationHint({ relatorId, relateeId, hintedBy: user.id });
     if ("error" in result) {
-      if (result.error === "self_rating") return c.json({ error: "self_rating" }, 400);
+      if (result.error === "self_relating") return c.json({ error: "self_relating" }, 400);
       return c.json({ error: "not_found" }, 404);
     }
     return c.json(result, 201);
   })
-  .delete("/relations/hint/:raterId/:rateeId", async (c) => {
+  .delete("/relations/hint/:relatorId/:relateeId", async (c) => {
     const user = c.get("user");
     if (!(await isAdmin(user.id))) {
       return c.json({ error: "forbidden" }, 403);
     }
 
-    const raterId = c.req.param("raterId");
-    const rateeId = c.req.param("rateeId");
-    if (!isUuid(raterId) || !isUuid(rateeId)) {
-      return c.json({ error: "raterId and rateeId must be UUIDs" }, 400);
+    const relatorId = c.req.param("relatorId");
+    const relateeId = c.req.param("relateeId");
+    if (!isUuid(relatorId) || !isUuid(relateeId)) {
+      return c.json({ error: "relatorId and relateeId must be UUIDs" }, 400);
     }
 
-    const result = await deleteHint({ raterId, rateeId });
+    const result = await deleteRelationHint({ relatorId, relateeId });
     if ("error" in result) {
       return c.json({ error: "not_found" }, 404);
     }

--- a/src/server/auth-middleware.ts
+++ b/src/server/auth-middleware.ts
@@ -1,8 +1,29 @@
 import { createServerClient } from "@supabase/ssr";
 import type { User } from "@supabase/supabase-js";
+import { eq } from "drizzle-orm";
 import type { MiddlewareHandler } from "hono";
 
+import { db } from "./db";
+import { profiles } from "./schema";
+
 export type ApiVariables = { user: User };
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// UUID predicate, used at API boundaries that take an id from a path
+// or body. Lives in the auth/middleware layer because it's part of
+// the request-shape validators that gate every route, not anything
+// domain-specific.
+export const isUuid = (v: unknown): v is string => typeof v === "string" && UUID_RE.test(v);
+
+// Resolves the admin flag for a given user id with one DB roundtrip.
+// Routes that need an admin gate call this; the alternative would be
+// to attach the flag to the auth-middleware context alongside `user`,
+// which is a fair next step once enough routes care.
+export const isAdmin = async (userId: string): Promise<boolean> => {
+  const [row] = await db.select({ isAdmin: profiles.isAdmin }).from(profiles).where(eq(profiles.id, userId));
+  return row?.isAdmin ?? false;
+};
 
 // Routes that bypass auth. Keep this tight — the regression guard in
 // auth-middleware.test.ts asserts nothing else is public.

--- a/src/server/invites.ts
+++ b/src/server/invites.ts
@@ -1,6 +1,7 @@
 import { and, count, desc, eq, gt, isNull, sql } from "drizzle-orm";
 
 import { db } from "./db";
+import { insertInviteHints, isRelationValue, type RelationValue, validateInviteHints } from "./relations";
 import { invites } from "./schema";
 
 // Alphabet: 23 uppercase letters (no I, O — visually confusable with 1/0)
@@ -67,10 +68,29 @@ export const countActiveInvitesForCreator = async (createdBy: string): Promise<n
 };
 
 export type CreateInviteResult =
-  | { code: string; note: string; expiresAt: Date }
-  | { error: "too_many_active"; limit: number };
+  | { code: string; note: string; expiresAt: Date; creatorValue: RelationValue | null; hintCount: number }
+  | { error: "too_many_active"; limit: number }
+  | { error: "invalid_creator_value" }
+  | { error: "invalid_hints"; reason: "not_an_array" | "non_uuid" | "self" | "duplicate" | "too_many" | "not_a_member" };
 
-export const createInvite = async (params: { createdBy: string; note: string }): Promise<CreateInviteResult> => {
+export const createInvite = async (params: {
+  createdBy: string;
+  note: string;
+  creatorValue?: RelationValue | null;
+  hints?: string[];
+}): Promise<CreateInviteResult> => {
+  const creatorValue = params.creatorValue ?? null;
+  if (creatorValue !== null && !isRelationValue(creatorValue)) {
+    return { error: "invalid_creator_value" };
+  }
+
+  // Validate hints up front so we don't burn an invite-code slot on a
+  // payload that's about to be rejected.
+  const hintCheck = await validateInviteHints({ hints: params.hints, inviterId: params.createdBy });
+  if ("error" in hintCheck) {
+    return { error: "invalid_hints", reason: hintCheck.reason };
+  }
+
   const active = await countActiveInvitesForCreator(params.createdBy);
   if (active >= MAX_ACTIVE_INVITES_PER_USER) {
     return { error: "too_many_active", limit: MAX_ACTIVE_INVITES_PER_USER };
@@ -79,24 +99,38 @@ export const createInvite = async (params: { createdBy: string; note: string }):
   // Retry loop guards against the astronomically-unlikely collision.
   // Three attempts is more than enough — collision probability at 10
   // chars over a 31-char alphabet is negligible even with millions of
-  // rows.
+  // rows. Each attempt runs in its own tx so the invite_hints insert
+  // rolls back with a code collision.
   for (let attempt = 0; attempt < 3; attempt++) {
     const code = generateInviteCode();
     try {
-      const [row] = await db
-        .insert(invites)
-        .values({
-          code,
-          createdBy: params.createdBy,
-          note: params.note,
-          expiresAt: sql`now() + interval '${sql.raw(String(INVITE_LIFETIME_DAYS))} days'`,
-        })
-        .returning({
-          code: invites.code,
-          note: invites.note,
-          expiresAt: invites.expiresAt,
-        });
-      return row;
+      const row = await db.transaction(async (tx) => {
+        const [inserted] = await tx
+          .insert(invites)
+          .values({
+            code,
+            createdBy: params.createdBy,
+            note: params.note,
+            expiresAt: sql`now() + interval '${sql.raw(String(INVITE_LIFETIME_DAYS))} days'`,
+            creatorValue,
+          })
+          .returning({
+            id: invites.id,
+            code: invites.code,
+            note: invites.note,
+            expiresAt: invites.expiresAt,
+            creatorValue: invites.creatorValue,
+          });
+        await insertInviteHints(tx, { inviteId: inserted.id, rateeIds: hintCheck.ids });
+        return inserted;
+      });
+      return {
+        code: row.code,
+        note: row.note,
+        expiresAt: row.expiresAt,
+        creatorValue: row.creatorValue as RelationValue | null,
+        hintCount: hintCheck.ids.length,
+      };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (!msg.includes("invites_code_unique") && !msg.includes("duplicate")) {

--- a/src/server/invites.ts
+++ b/src/server/invites.ts
@@ -68,20 +68,20 @@ export const countActiveInvitesForCreator = async (createdBy: string): Promise<n
 };
 
 export type CreateInviteResult =
-  | { code: string; note: string; expiresAt: Date; creatorValue: RelationValue | null; hintCount: number }
+  | { code: string; note: string; expiresAt: Date; relationValue: RelationValue | null; hintCount: number }
   | { error: "too_many_active"; limit: number }
-  | { error: "invalid_creator_value" }
+  | { error: "invalid_relation_value" }
   | { error: "invalid_hints"; reason: "not_an_array" | "non_uuid" | "self" | "duplicate" | "too_many" | "not_a_member" };
 
 export const createInvite = async (params: {
   createdBy: string;
   note: string;
-  creatorValue?: RelationValue | null;
+  relationValue?: RelationValue | null;
   hints?: string[];
 }): Promise<CreateInviteResult> => {
-  const creatorValue = params.creatorValue ?? null;
-  if (creatorValue !== null && !isRelationValue(creatorValue)) {
-    return { error: "invalid_creator_value" };
+  const relationValue = params.relationValue ?? null;
+  if (relationValue !== null && !isRelationValue(relationValue)) {
+    return { error: "invalid_relation_value" };
   }
 
   // Validate hints up front so we don't burn an invite-code slot on a
@@ -112,23 +112,23 @@ export const createInvite = async (params: {
             createdBy: params.createdBy,
             note: params.note,
             expiresAt: sql`now() + interval '${sql.raw(String(INVITE_LIFETIME_DAYS))} days'`,
-            creatorValue,
+            relationValue,
           })
           .returning({
             id: invites.id,
             code: invites.code,
             note: invites.note,
             expiresAt: invites.expiresAt,
-            creatorValue: invites.creatorValue,
+            relationValue: invites.relationValue,
           });
-        await insertInviteHints(tx, { inviteId: inserted.id, rateeIds: hintCheck.ids });
+        await insertInviteHints(tx, { inviteId: inserted.id, relateeIds: hintCheck.ids });
         return inserted;
       });
       return {
         code: row.code,
         note: row.note,
         expiresAt: row.expiresAt,
-        creatorValue: row.creatorValue as RelationValue | null,
+        relationValue: row.relationValue as RelationValue | null,
         hintCount: hintCheck.ids.length,
       };
     } catch (err) {

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -2,6 +2,7 @@ import type { User } from "@supabase/supabase-js";
 import { asc, eq, isNotNull, or } from "drizzle-orm";
 import { cache } from "react";
 
+import { isUuid } from "./auth-middleware";
 import { db } from "./db";
 import { profiles } from "./schema";
 
@@ -143,13 +144,11 @@ export type ProfileForMember = {
   createdAt: Date;
 };
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 // Accepts either a UUID or a slug so /members/aria-chen and
 // /members/<uuid> both work. UUID-shaped strings go straight to the id
 // column; anything else is treated as a slug lookup.
 export const getProfileForMember = async (idOrSlug: string): Promise<ProfileForMember | null> => {
-  const where = UUID_RE.test(idOrSlug)
+  const where = isUuid(idOrSlug)
     ? or(eq(profiles.id, idOrSlug), eq(profiles.slug, idOrSlug))
     : eq(profiles.slug, idOrSlug);
 

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -1,10 +1,8 @@
 import { and, eq, sql } from "drizzle-orm";
 
+import { isUuid } from "./auth-middleware";
 import { db } from "./db";
 import { profilePrograms, profiles, programs } from "./schema";
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const isValidUuid = (s: string): boolean => UUID_RE.test(s);
 
 export type ProgramWithMembership = {
   id: string;
@@ -62,7 +60,7 @@ export const joinProgram = async (
   userId: string,
   programId: string,
 ): Promise<{ ok: true } | { error: "not_found" | "already_joined" }> => {
-  if (!isValidUuid(programId)) return { error: "not_found" };
+  if (!isUuid(programId)) return { error: "not_found" };
 
   // Verify program exists
   const [program] = await db.select({ id: programs.id }).from(programs).where(eq(programs.id, programId));
@@ -88,7 +86,7 @@ export const leaveProgram = async (
   userId: string,
   programId: string,
 ): Promise<{ ok: true } | { error: "not_found" }> => {
-  if (!isValidUuid(programId)) return { error: "not_found" };
+  if (!isUuid(programId)) return { error: "not_found" };
 
   const result = await db
     .delete(profilePrograms)

--- a/src/server/relations.ts
+++ b/src/server/relations.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNotNull, ne, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, type InferSelectModel, isNotNull, ne, or, type SQLWrapper, sql } from "drizzle-orm";
 import type { PgTransaction } from "drizzle-orm/pg-core";
 
 import { isUuid } from "./auth-middleware";
@@ -6,37 +6,21 @@ import { db } from "./db";
 import { inviteHints, invites, profiles, relations } from "./schema";
 
 // 1..4 vocabulary lives in design-relations.md. The DB enforces the
-// range via relations_value_range and invites_creator_value_range; this
-// file's runtime validators repeat the check at the API edge so we can
-// return clean 400s before round-tripping to a constraint violation.
+// range via check constraints; this validator runs at the API edge so
+// callers get a 400 instead of a constraint violation.
 export type RelationValue = 1 | 2 | 3 | 4;
 
 export const isRelationValue = (v: unknown): v is RelationValue =>
   typeof v === "number" && Number.isInteger(v) && v >= 1 && v <= 4;
 
-// Body-shape parser shared between POST /api/invites (where the
-// inviter declares their relation to the invitee) and any other route
-// that accepts an optional 1..4 value. Mirrors validateNote's shape:
-// happy value or `{error}` envelope.
-export const parseOptionalRelationValue = (raw: unknown): RelationValue | null | { error: string } => {
-  if (raw === undefined || raw === null) return null;
-  if (!isRelationValue(raw)) return { error: "relationValue must be an integer 1..4" };
-  return raw;
-};
+// Validates the optional `relationValue` body field shared by POST
+// /api/invites and any future route that accepts an optional 1..4.
+export type ParsedRelationValue = { ok: true; value: RelationValue | null } | { ok: false; error: string };
 
-// One suggestion in the relation-suggestion feed. The fields here are
-// what the rating-decision UI needs without navigating away — the
-// design's "enough profile information to make a rating decision"
-// requirement.
-export type RelationSuggestion = {
-  id: string;
-  slug: string | null;
-  displayName: string | null;
-  avatarUrl: string | null;
-  bio: string | null;
-  keywords: string[];
-  location: string | null;
-  reason: RelationSuggestionReason;
+export const parseOptionalRelationValue = (raw: unknown): ParsedRelationValue => {
+  if (raw === undefined || raw === null) return { ok: true, value: null };
+  if (!isRelationValue(raw)) return { ok: false, error: "relationValue must be an integer 1..4" };
+  return { ok: true, value: raw };
 };
 
 // Soft-hide is enforced here: the "ratedYou" reason carries no value
@@ -48,11 +32,19 @@ export type RelationSuggestionReason =
   | { type: "viaInviter"; inviter: { id: string; displayName: string | null; slug: string | null } }
   | { type: "recentlyActive" };
 
+// Card payload for the rating-decision UI. Fields are chosen so a
+// member can decide without navigating away from the suggestion feed.
+export type RelationSuggestion = SuggestionCardColumns & { reason: RelationSuggestionReason };
+
 export type RelationSuggestionFeed = {
   suggestions: RelationSuggestion[];
   otherMembers: RelationSuggestion[];
 };
 
+// Drizzle select-shape for the card; SuggestionCardColumns is the row type that
+// comes back from a select shaped like this. Both names refer to the
+// same seven profile fields — kept in sync via Pick<> on the inferred
+// row so a future column rename in schema.ts breaks both sites at once.
 const cardColumns = {
   id: profiles.id,
   slug: profiles.slug,
@@ -63,28 +55,43 @@ const cardColumns = {
   location: profiles.location,
 };
 
-type CardColumns = {
-  id: string;
-  slug: string | null;
-  displayName: string | null;
-  avatarUrl: string | null;
-  bio: string | null;
-  keywords: string[];
-  location: string | null;
+type SuggestionCardColumns = Pick<
+  InferSelectModel<typeof profiles>,
+  "id" | "slug" | "displayName" | "avatarUrl" | "bio" | "keywords" | "location"
+>;
+
+const toCard = (row: SuggestionCardColumns, reason: RelationSuggestionReason): RelationSuggestion => ({ ...row, reason });
+
+// SQL fragment for "the current user has no row in relations pointing
+// at this relatee" — used to exclude already-acted-on people from the
+// suggestion sources.
+const noRelationFromUserTo = (userId: string, relateeRef: SQLWrapper) =>
+  sql`NOT EXISTS (SELECT 1 FROM relations rev WHERE rev.rater_id = ${userId} AND rev.ratee_id = ${relateeRef})`;
+
+const collectInto = <T extends { id: string }>(
+  target: RelationSuggestion[],
+  seen: Set<string>,
+  rows: T[],
+  build: (row: T) => RelationSuggestion,
+): void => {
+  for (const row of rows) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    target.push(build(row));
+  }
 };
 
-const toCard = (row: CardColumns, reason: RelationSuggestionReason): RelationSuggestion => ({ ...row, reason });
-
-// Candidate feed sources are enumerated in design-relations.md
-// "Candidate feed sources." Each person appears at most once, in the
-// highest-priority source where they qualify; downstream sources skip
-// IDs already collected. At MVP scale the four-query approach is fine —
-// none of these touch more than ~hundreds of rows.
+// Sources 1–4 are enumerated in design-relations.md "Suggestion feed
+// sources." Each person appears at most once, in the highest-priority
+// source where they qualify; downstream sources skip already-collected
+// IDs via `seen`.
 export const getRelationSuggestions = async (userId: string): Promise<RelationSuggestionFeed> => {
   const seen = new Set<string>([userId]);
+  const suggestions: RelationSuggestion[] = [];
+  const otherMembers: RelationSuggestion[] = [];
 
-  // Source 1 — people who rated me (with a value), where I have no row
-  // back to them at all (no rating, no hint).
+  // Source 1 — people who rated me (with a value) and whom I haven't
+  // touched back, with a rating or a hint.
   const ratedMe = await db
     .select(cardColumns)
     .from(relations)
@@ -93,28 +100,18 @@ export const getRelationSuggestions = async (userId: string): Promise<RelationSu
       and(
         eq(relations.relateeId, userId),
         isNotNull(relations.value),
-        sql`NOT EXISTS (SELECT 1 FROM relations rev WHERE rev.rater_id = ${userId} AND rev.ratee_id = ${relations.relatorId})`,
+        noRelationFromUserTo(userId, relations.relatorId),
       ),
     )
     .orderBy(desc(relations.updatedAt));
 
-  const suggestions: RelationSuggestion[] = [];
-  for (const row of ratedMe) {
-    if (seen.has(row.id)) continue;
-    seen.add(row.id);
-    suggestions.push(toCard(row, { type: "ratedYou" }));
-  }
+  collectInto(suggestions, seen, ratedMe, (row) => toCard(row, { type: "ratedYou" }));
 
-  // Source 2 — pending hints for me (relator=me, isHint=true, value=null).
-  // Two queries: hint rows (with relatee profile), then a batch lookup
-  // for hinter profiles. Aliasing profiles twice in one Drizzle query
-  // is more code than this at our scale.
+  // Source 2 — pending hints for me. Two queries instead of one
+  // self-joined query: aliasing `profiles` twice in Drizzle for the
+  // hinter side is more code than this.
   const hintRows = await db
-    .select({
-      ...cardColumns,
-      hintedBy: relations.hintedBy,
-      updatedAt: relations.updatedAt,
-    })
+    .select({ ...cardColumns, hintedBy: relations.hintedBy })
     .from(relations)
     .innerJoin(profiles, eq(profiles.id, relations.relateeId))
     .where(and(eq(relations.relatorId, userId), eq(relations.isHint, true)))
@@ -130,36 +127,21 @@ export const getRelationSuggestions = async (userId: string): Promise<RelationSu
       : [];
   const hinterById = new Map(hinters.map((h) => [h.id, h]));
 
-  for (const row of hintRows) {
-    if (seen.has(row.id)) continue;
-    seen.add(row.id);
-    const hintedBy = row.hintedBy ? hinterById.get(row.hintedBy) ?? null : null;
-    const card: CardColumns = {
-      id: row.id,
-      slug: row.slug,
-      displayName: row.displayName,
-      avatarUrl: row.avatarUrl,
-      bio: row.bio,
-      keywords: row.keywords,
-      location: row.location,
-    };
-    suggestions.push(toCard(card, { type: "hint", hintedBy }));
-  }
+  collectInto(suggestions, seen, hintRows, ({ hintedBy, ...card }) => {
+    const hinter = hintedBy ? hinterById.get(hintedBy) ?? null : null;
+    return toCard(card, { type: "hint", hintedBy: hinter });
+  });
 
-  const otherMembers: RelationSuggestion[] = [];
-
-  // Source 3 — my inviter's higher-rated connections. Only fires when
-  // I have a referredBy and that inviter has confirmed ratings ≥ 3.
+  // `me` is needed by sources 3 (referredBy) and 4 (lastUpdatedWeb).
   const [me] = await db
-    .select({
-      referredBy: profiles.referredBy,
-      lastUpdatedWeb: profiles.lastUpdatedWeb,
-    })
+    .select({ referredBy: profiles.referredBy, lastUpdatedWeb: profiles.lastUpdatedWeb })
     .from(profiles)
     .where(eq(profiles.id, userId));
 
+  // Source 3 — my inviter's higher-rated connections. Only fires when
+  // I have a referredBy and that inviter has confirmed ratings ≥ 3.
   if (me?.referredBy) {
-    const inviterId: string = me.referredBy;
+    const inviterId = me.referredBy;
     const [inviter] = await db
       .select({ id: profiles.id, displayName: profiles.displayName, slug: profiles.slug })
       .from(profiles)
@@ -176,22 +158,17 @@ export const getRelationSuggestions = async (userId: string): Promise<RelationSu
             isNotNull(relations.value),
             sql`${relations.value} >= 3`,
             ne(relations.relateeId, userId),
-            sql`NOT EXISTS (SELECT 1 FROM relations rev WHERE rev.rater_id = ${userId} AND rev.ratee_id = ${relations.relateeId})`,
+            noRelationFromUserTo(userId, relations.relateeId),
           ),
         )
         .orderBy(desc(relations.value), desc(relations.updatedAt));
 
-      for (const row of inviterConnections) {
-        if (seen.has(row.id)) continue;
-        seen.add(row.id);
-        otherMembers.push(toCard(row, { type: "viaInviter", inviter }));
-      }
+      collectInto(otherMembers, seen, inviterConnections, (row) => toCard(row, { type: "viaInviter", inviter }));
     }
   }
 
-  // Source 4 — members whose last_updated_web is more recent than mine
-  // (or any value, if mine is null). Excludes self and anyone I've
-  // already touched.
+  // Source 4 — members whose last_updated_web is more recent than
+  // mine (or any value, if mine is null).
   const myLastUpdated = me?.lastUpdatedWeb ?? null;
   const recentlyActive = await db
     .select(cardColumns)
@@ -200,7 +177,7 @@ export const getRelationSuggestions = async (userId: string): Promise<RelationSu
       and(
         isNotNull(profiles.lastUpdatedWeb),
         ne(profiles.id, userId),
-        sql`NOT EXISTS (SELECT 1 FROM relations rev WHERE rev.rater_id = ${userId} AND rev.ratee_id = ${profiles.id})`,
+        noRelationFromUserTo(userId, profiles.id),
         myLastUpdated
           ? sql`${profiles.lastUpdatedWeb} > ${myLastUpdated.toISOString()}`
           : sql`true`,
@@ -208,20 +185,11 @@ export const getRelationSuggestions = async (userId: string): Promise<RelationSu
     )
     .orderBy(desc(profiles.lastUpdatedWeb));
 
-  for (const row of recentlyActive) {
-    if (seen.has(row.id)) continue;
-    seen.add(row.id);
-    otherMembers.push(toCard(row, { type: "recentlyActive" }));
-  }
+  collectInto(otherMembers, seen, recentlyActive, (row) => toCard(row, { type: "recentlyActive" }));
 
   return { suggestions, otherMembers };
 };
 
-// PersonalWeb payload for the WebGraph component. centerId is whoever
-// the graph is rendered around — in the MVP that's always the
-// requesting user, but the component is parameterized for the future
-// profile-page embed (see design-relations.md "Embedded subgraph
-// displays").
 export type SubgraphNode = {
   id: string;
   slug: string | null;
@@ -248,8 +216,12 @@ const nodeColumns = {
   avatarUrl: profiles.avatarUrl,
 };
 
-// One-hop or two-hop personal subgraph. Hints (value IS NULL) are never
-// rendered; they live in the relation-suggestion feed.
+const edgeKey = (e: { relatorId: string; relateeId: string }): string => `${e.relatorId}:${e.relateeId}`;
+
+// Hints (value IS NULL) are filtered out — they live in the suggestion
+// feed, not the rendered web. centerId is parameterized so the same
+// component can later embed read-only on member profile pages (see
+// design-relations.md "Embedded subgraph displays").
 export const getPersonalWeb = async (params: {
   centerId: string;
   includeIncoming: boolean;
@@ -286,14 +258,13 @@ export const getPersonalWeb = async (params: {
   const edges: SubgraphEdge[] = firstHop.map((e) => ({
     relatorId: e.relatorId,
     relateeId: e.relateeId,
-    // Drizzle's value column is nullable in the type; we filtered on
-    // IS NOT NULL above, so the runtime value is guaranteed numeric.
+    // value is filtered IS NOT NULL in the WHERE, so the runtime cast is safe.
     value: e.value as number,
   }));
 
-  // Second hop — relations among the first-hop neighbors (and to other
-  // members they point at). Per design, this surfaces "their relations
-  // to each other and to second-degree members" when the toggle is on.
+  // Second hop — relations among the first-hop neighbors and to other
+  // members they point at. Surfaces "their relations to each other and
+  // to second-degree members" when hops=2.
   if (hops === 2) {
     const firstHopIds = [...nodeIds].filter((id) => id !== centerId);
     if (firstHopIds.length > 0) {
@@ -311,10 +282,11 @@ export const getPersonalWeb = async (params: {
             ne(relations.relateeId, centerId),
           ),
         );
+      const seen = new Set(edges.map(edgeKey));
       for (const e of secondHop) {
-        if (edges.some((existing) => existing.relatorId === e.relatorId && existing.relateeId === e.relateeId)) {
-          continue;
-        }
+        const key = edgeKey(e);
+        if (seen.has(key)) continue;
+        seen.add(key);
         nodeIds.add(e.relateeId);
         edges.push({ relatorId: e.relatorId, relateeId: e.relateeId, value: e.value as number });
       }
@@ -329,11 +301,15 @@ export const getPersonalWeb = async (params: {
   return { centerId, nodes: nodeRows, edges };
 };
 
-// updateRelationValue: create or update the (relator, relatee) row with
-// a confirmed value. If a pending hint exists, this transition flips
-// isHint to false while preserving hintedBy. The check constraint
-// relations_hint_state means we have to set both columns in the same
-// statement.
+// Postgres error code 23503 = foreign_key_violation. In
+// updateRelationValue the only FK that can fail at insert time is
+// relations.ratee_id → profiles.id, so we can safely map any 23503
+// to relatee_not_found.
+const isForeignKeyViolation = (err: unknown): boolean => {
+  if (!err || typeof err !== "object" || !("cause" in err)) return false;
+  return (err as { cause?: { code?: string } }).cause?.code === "23503";
+};
+
 export type UpdateRelationValueResult = { ok: true } | { error: "self_relating" | "relatee_not_found" };
 
 export const updateRelationValue = async (params: {
@@ -343,34 +319,34 @@ export const updateRelationValue = async (params: {
 }): Promise<UpdateRelationValueResult> => {
   if (params.relatorId === params.relateeId) return { error: "self_relating" };
 
-  const [exists] = await db.select({ id: profiles.id }).from(profiles).where(eq(profiles.id, params.relateeId));
-  if (!exists) return { error: "relatee_not_found" };
-
-  await db
-    .insert(relations)
-    .values({
-      relatorId: params.relatorId,
-      relateeId: params.relateeId,
-      value: params.value,
-      isHint: false,
-    })
-    .onConflictDoUpdate({
-      target: [relations.relatorId, relations.relateeId],
-      set: {
+  // The `relations_hint_state` check requires value and isHint to move
+  // together; a pending hint converting to a confirmed rating must set
+  // both in the same statement.
+  try {
+    await db
+      .insert(relations)
+      .values({
+        relatorId: params.relatorId,
+        relateeId: params.relateeId,
         value: params.value,
         isHint: false,
-        updatedAt: sql`now()`,
-      },
-    });
+      })
+      .onConflictDoUpdate({
+        target: [relations.relatorId, relations.relateeId],
+        set: {
+          value: params.value,
+          isHint: false,
+          updatedAt: sql`now()`,
+        },
+      });
+  } catch (err) {
+    if (isForeignKeyViolation(err)) return { error: "relatee_not_found" };
+    throw err;
+  }
 
   return { ok: true };
 };
 
-// createRelationHint: admin-only path. Inserts a pending hint row
-// (value NULL, isHint true, hintedBy set). Ignored silently if a row
-// already exists — admins shouldn't get a hard error from re-clicking
-// a hint button, and the relator's existing state is more
-// authoritative than a re-hint.
 export type CreateRelationHintResult =
   | { ok: true; created: boolean }
   | { error: "self_relating" | "relator_not_found" | "relatee_not_found" };
@@ -390,6 +366,9 @@ export const createRelationHint = async (params: {
   if (!ids.has(params.relatorId)) return { error: "relator_not_found" };
   if (!ids.has(params.relateeId)) return { error: "relatee_not_found" };
 
+  // Silent no-op on conflict: an admin re-clicking a hint button
+  // shouldn't error, and the relator's existing row is more
+  // authoritative than a re-hint anyway.
   const result = await db
     .insert(relations)
     .values({
@@ -405,11 +384,10 @@ export const createRelationHint = async (params: {
   return { ok: true, created: result.length > 0 };
 };
 
-// deleteRelationHint: admin-only withdraw. Only deletes when the row
-// is in the pending-hint state — refuses to clobber a confirmed
-// rating, even if the admin asked for it.
 export type DeleteRelationHintResult = { ok: true } | { error: "not_found" };
 
+// Refuses to delete a confirmed rating — the isHint = true predicate
+// scopes the delete to pending hints only.
 export const deleteRelationHint = async (params: {
   relatorId: string;
   relateeId: string;
@@ -429,9 +407,6 @@ export const deleteRelationHint = async (params: {
   return { ok: true };
 };
 
-// Hint validation for the invite-creation form. Returns either the
-// deduplicated UUID list or a structured error code the API surfaces
-// as a 400.
 export const HINTS_PER_INVITE_LIMIT = 10;
 
 export type ValidateHintsResult =
@@ -462,13 +437,12 @@ export const validateInviteHints = async (params: {
   return { ok: true, ids };
 };
 
-// Materialization called from the auth-callback transaction. The
-// caller passes the active tx so the relations rows land or roll back
-// with the rest of the redemption.
+// Tx | typeof db lets the materializer run inside the auth-callback
+// transaction or, in tests, directly against the connection.
 type Tx = PgTransaction<
-  // biome-ignore lint/suspicious/noExplicitAny: this is the public
-  // postgres-js transaction type, and Drizzle's exposed shape needs
-  // the generic surface to compile against `db.transaction(...)`.
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle's published
+  // postgres-js transaction type is genuinely `PgTransaction<any, any, any>`
+  // for consumers; the wide generic surface is unavoidable here.
   any,
   any,
   any
@@ -483,7 +457,6 @@ export const materializeInviteRelations = async (
     relationValue: number | null;
   },
 ): Promise<void> => {
-  // relation_value → confirmed inviter→redeemer rating.
   if (params.inviterId && params.relationValue !== null) {
     await tx
       .insert(relations)
@@ -496,7 +469,6 @@ export const materializeInviteRelations = async (
       .onConflictDoNothing({ target: [relations.relatorId, relations.relateeId] });
   }
 
-  // invite_hints → pending redeemer→relatee hints, hintedBy=inviter.
   const hints = await tx
     .select({ relateeId: inviteHints.relateeId })
     .from(inviteHints)
@@ -504,10 +476,9 @@ export const materializeInviteRelations = async (
 
   if (hints.length === 0) return;
 
-  // Defensive filter: skip any hint pointing at the redeemer themselves
-  // (would violate relations_no_self). Shouldn't happen via normal
-  // flows, but the auth callback shouldn't fail because of upstream
-  // data weirdness.
+  // Skip any hint pointing at the redeemer themselves — would violate
+  // relations_no_self. Shouldn't happen via normal flows, but the auth
+  // callback can't fail because of upstream data weirdness.
   const rows = hints
     .filter((h) => h.relateeId !== params.redeemerId)
     .map((h) => ({
@@ -526,9 +497,6 @@ export const materializeInviteRelations = async (
     .onConflictDoNothing({ target: [relations.relatorId, relations.relateeId] });
 };
 
-// Helper for invite creation — writes invite_hints rows in the same
-// transaction as the invite itself. Caller has already validated the
-// hint list via validateInviteHints.
 export const insertInviteHints = async (
   tx: Tx | typeof db,
   params: { inviteId: string; relateeIds: string[] },

--- a/src/server/relations.ts
+++ b/src/server/relations.ts
@@ -1,6 +1,7 @@
-import { and, asc, desc, eq, inArray, isNotNull, isNull, ne, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, ne, or, sql } from "drizzle-orm";
 import type { PgTransaction } from "drizzle-orm/pg-core";
 
+import { isUuid } from "./auth-middleware";
 import { db } from "./db";
 import { inviteHints, invites, profiles, relations } from "./schema";
 
@@ -13,13 +14,21 @@ export type RelationValue = 1 | 2 | 3 | 4;
 export const isRelationValue = (v: unknown): v is RelationValue =>
   typeof v === "number" && Number.isInteger(v) && v >= 1 && v <= 4;
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-export const isUuid = (v: unknown): v is string => typeof v === "string" && UUID_RE.test(v);
+// Body-shape parser shared between POST /api/invites (where the
+// inviter declares their relation to the invitee) and any other route
+// that accepts an optional 1..4 value. Mirrors validateNote's shape:
+// happy value or `{error}` envelope.
+export const parseOptionalRelationValue = (raw: unknown): RelationValue | null | { error: string } => {
+  if (raw === undefined || raw === null) return null;
+  if (!isRelationValue(raw)) return { error: "relationValue must be an integer 1..4" };
+  return raw;
+};
 
-// Card payload returned in the candidate feed. The fields here are what
-// the rating-decision UI needs without navigating away — the design's
-// "enough profile information to make a rating decision" requirement.
-export type CandidateCard = {
+// One suggestion in the relation-suggestion feed. The fields here are
+// what the rating-decision UI needs without navigating away — the
+// design's "enough profile information to make a rating decision"
+// requirement.
+export type RelationSuggestion = {
   id: string;
   slug: string | null;
   displayName: string | null;
@@ -27,21 +36,21 @@ export type CandidateCard = {
   bio: string | null;
   keywords: string[];
   location: string | null;
-  reason: CandidateReason;
+  reason: RelationSuggestionReason;
 };
 
 // Soft-hide is enforced here: the "ratedYou" reason carries no value
 // field, even though the source row has one. The client cannot leak
 // what it never sees.
-export type CandidateReason =
+export type RelationSuggestionReason =
   | { type: "ratedYou" }
   | { type: "hint"; hintedBy: { id: string; displayName: string | null; slug: string | null } | null }
   | { type: "viaInviter"; inviter: { id: string; displayName: string | null; slug: string | null } }
   | { type: "recentlyActive" };
 
-export type CandidateFeed = {
-  suggestions: CandidateCard[];
-  otherMembers: CandidateCard[];
+export type RelationSuggestionFeed = {
+  suggestions: RelationSuggestion[];
+  otherMembers: RelationSuggestion[];
 };
 
 const cardColumns = {
@@ -64,41 +73,40 @@ type CardColumns = {
   location: string | null;
 };
 
-const toCard = (row: CardColumns, reason: CandidateReason): CandidateCard => ({ ...row, reason });
+const toCard = (row: CardColumns, reason: RelationSuggestionReason): RelationSuggestion => ({ ...row, reason });
 
 // Candidate feed sources are enumerated in design-relations.md
 // "Candidate feed sources." Each person appears at most once, in the
 // highest-priority source where they qualify; downstream sources skip
 // IDs already collected. At MVP scale the four-query approach is fine —
 // none of these touch more than ~hundreds of rows.
-export const getCandidates = async (userId: string): Promise<CandidateFeed> => {
+export const getRelationSuggestions = async (userId: string): Promise<RelationSuggestionFeed> => {
   const seen = new Set<string>([userId]);
 
   // Source 1 — people who rated me (with a value), where I have no row
   // back to them at all (no rating, no hint).
-  const ratedMeAlias = relations;
   const ratedMe = await db
     .select(cardColumns)
-    .from(ratedMeAlias)
-    .innerJoin(profiles, eq(profiles.id, ratedMeAlias.raterId))
+    .from(relations)
+    .innerJoin(profiles, eq(profiles.id, relations.relatorId))
     .where(
       and(
-        eq(ratedMeAlias.rateeId, userId),
-        isNotNull(ratedMeAlias.value),
-        sql`NOT EXISTS (SELECT 1 FROM relations rev WHERE rev.rater_id = ${userId} AND rev.ratee_id = ${ratedMeAlias.raterId})`,
+        eq(relations.relateeId, userId),
+        isNotNull(relations.value),
+        sql`NOT EXISTS (SELECT 1 FROM relations rev WHERE rev.rater_id = ${userId} AND rev.ratee_id = ${relations.relatorId})`,
       ),
     )
-    .orderBy(desc(ratedMeAlias.updatedAt));
+    .orderBy(desc(relations.updatedAt));
 
-  const suggestions: CandidateCard[] = [];
+  const suggestions: RelationSuggestion[] = [];
   for (const row of ratedMe) {
     if (seen.has(row.id)) continue;
     seen.add(row.id);
     suggestions.push(toCard(row, { type: "ratedYou" }));
   }
 
-  // Source 2 — pending hints for me (rater=me, isHint=true, value=null).
-  // Two queries: hint rows (with ratee profile), then a batch lookup
+  // Source 2 — pending hints for me (relator=me, isHint=true, value=null).
+  // Two queries: hint rows (with relatee profile), then a batch lookup
   // for hinter profiles. Aliasing profiles twice in one Drizzle query
   // is more code than this at our scale.
   const hintRows = await db
@@ -108,8 +116,8 @@ export const getCandidates = async (userId: string): Promise<CandidateFeed> => {
       updatedAt: relations.updatedAt,
     })
     .from(relations)
-    .innerJoin(profiles, eq(profiles.id, relations.rateeId))
-    .where(and(eq(relations.raterId, userId), eq(relations.isHint, true)))
+    .innerJoin(profiles, eq(profiles.id, relations.relateeId))
+    .where(and(eq(relations.relatorId, userId), eq(relations.isHint, true)))
     .orderBy(desc(relations.updatedAt));
 
   const hintIds = hintRows.map((r) => r.hintedBy).filter((x): x is string => !!x);
@@ -138,7 +146,7 @@ export const getCandidates = async (userId: string): Promise<CandidateFeed> => {
     suggestions.push(toCard(card, { type: "hint", hintedBy }));
   }
 
-  const otherMembers: CandidateCard[] = [];
+  const otherMembers: RelationSuggestion[] = [];
 
   // Source 3 — my inviter's higher-rated connections. Only fires when
   // I have a referredBy and that inviter has confirmed ratings ≥ 3.
@@ -161,14 +169,14 @@ export const getCandidates = async (userId: string): Promise<CandidateFeed> => {
       const inviterConnections = await db
         .select(cardColumns)
         .from(relations)
-        .innerJoin(profiles, eq(profiles.id, relations.rateeId))
+        .innerJoin(profiles, eq(profiles.id, relations.relateeId))
         .where(
           and(
-            eq(relations.raterId, inviterId),
+            eq(relations.relatorId, inviterId),
             isNotNull(relations.value),
             sql`${relations.value} >= 3`,
-            ne(relations.rateeId, userId),
-            sql`NOT EXISTS (SELECT 1 FROM relations rev WHERE rev.rater_id = ${userId} AND rev.ratee_id = ${relations.rateeId})`,
+            ne(relations.relateeId, userId),
+            sql`NOT EXISTS (SELECT 1 FROM relations rev WHERE rev.rater_id = ${userId} AND rev.ratee_id = ${relations.relateeId})`,
           ),
         )
         .orderBy(desc(relations.value), desc(relations.updatedAt));
@@ -209,10 +217,11 @@ export const getCandidates = async (userId: string): Promise<CandidateFeed> => {
   return { suggestions, otherMembers };
 };
 
-// Subgraph payload for the WebGraph component. centerId is whoever the
-// graph is rendered around — in the MVP that's always the requesting
-// user, but the component is parameterized for the future profile-page
-// embed (see design-relations.md "Embedded subgraph displays").
+// PersonalWeb payload for the WebGraph component. centerId is whoever
+// the graph is rendered around — in the MVP that's always the
+// requesting user, but the component is parameterized for the future
+// profile-page embed (see design-relations.md "Embedded subgraph
+// displays").
 export type SubgraphNode = {
   id: string;
   slug: string | null;
@@ -221,8 +230,8 @@ export type SubgraphNode = {
 };
 
 export type SubgraphEdge = {
-  raterId: string;
-  rateeId: string;
+  relatorId: string;
+  relateeId: string;
   value: number;
 };
 
@@ -240,8 +249,8 @@ const nodeColumns = {
 };
 
 // One-hop or two-hop personal subgraph. Hints (value IS NULL) are never
-// rendered; they live in the candidate feed.
-export const getSubgraph = async (params: {
+// rendered; they live in the relation-suggestion feed.
+export const getPersonalWeb = async (params: {
   centerId: string;
   includeIncoming: boolean;
   includeOutgoing: boolean;
@@ -252,17 +261,17 @@ export const getSubgraph = async (params: {
   // First hop — direct relations involving centerId.
   const firstHopWhere = (() => {
     if (includeIncoming && includeOutgoing) {
-      return or(eq(relations.raterId, centerId), eq(relations.rateeId, centerId));
+      return or(eq(relations.relatorId, centerId), eq(relations.relateeId, centerId));
     }
-    if (includeOutgoing) return eq(relations.raterId, centerId);
-    if (includeIncoming) return eq(relations.rateeId, centerId);
+    if (includeOutgoing) return eq(relations.relatorId, centerId);
+    if (includeIncoming) return eq(relations.relateeId, centerId);
     return sql`false`;
   })();
 
   const firstHop = await db
     .select({
-      raterId: relations.raterId,
-      rateeId: relations.rateeId,
+      relatorId: relations.relatorId,
+      relateeId: relations.relateeId,
       value: relations.value,
     })
     .from(relations)
@@ -270,13 +279,13 @@ export const getSubgraph = async (params: {
 
   const nodeIds = new Set<string>([centerId]);
   for (const e of firstHop) {
-    nodeIds.add(e.raterId);
-    nodeIds.add(e.rateeId);
+    nodeIds.add(e.relatorId);
+    nodeIds.add(e.relateeId);
   }
 
   const edges: SubgraphEdge[] = firstHop.map((e) => ({
-    raterId: e.raterId,
-    rateeId: e.rateeId,
+    relatorId: e.relatorId,
+    relateeId: e.relateeId,
     // Drizzle's value column is nullable in the type; we filtered on
     // IS NOT NULL above, so the runtime value is guaranteed numeric.
     value: e.value as number,
@@ -290,24 +299,24 @@ export const getSubgraph = async (params: {
     if (firstHopIds.length > 0) {
       const secondHop = await db
         .select({
-          raterId: relations.raterId,
-          rateeId: relations.rateeId,
+          relatorId: relations.relatorId,
+          relateeId: relations.relateeId,
           value: relations.value,
         })
         .from(relations)
         .where(
           and(
             isNotNull(relations.value),
-            inArray(relations.raterId, firstHopIds),
-            ne(relations.rateeId, centerId),
+            inArray(relations.relatorId, firstHopIds),
+            ne(relations.relateeId, centerId),
           ),
         );
       for (const e of secondHop) {
-        if (edges.some((existing) => existing.raterId === e.raterId && existing.rateeId === e.rateeId)) {
+        if (edges.some((existing) => existing.relatorId === e.relatorId && existing.relateeId === e.relateeId)) {
           continue;
         }
-        nodeIds.add(e.rateeId);
-        edges.push({ raterId: e.raterId, rateeId: e.rateeId, value: e.value as number });
+        nodeIds.add(e.relateeId);
+        edges.push({ relatorId: e.relatorId, relateeId: e.relateeId, value: e.value as number });
       }
     }
   }
@@ -320,33 +329,33 @@ export const getSubgraph = async (params: {
   return { centerId, nodes: nodeRows, edges };
 };
 
-// rateMember: create or update the (rater, ratee) row with a confirmed
-// value. If a pending hint exists, this transition flips isHint to
-// false while preserving hintedBy. The check constraint
+// updateRelationValue: create or update the (relator, relatee) row with
+// a confirmed value. If a pending hint exists, this transition flips
+// isHint to false while preserving hintedBy. The check constraint
 // relations_hint_state means we have to set both columns in the same
 // statement.
-export type RateMemberResult = { ok: true } | { error: "self_rating" | "ratee_not_found" };
+export type UpdateRelationValueResult = { ok: true } | { error: "self_relating" | "relatee_not_found" };
 
-export const rateMember = async (params: {
-  raterId: string;
-  rateeId: string;
+export const updateRelationValue = async (params: {
+  relatorId: string;
+  relateeId: string;
   value: RelationValue;
-}): Promise<RateMemberResult> => {
-  if (params.raterId === params.rateeId) return { error: "self_rating" };
+}): Promise<UpdateRelationValueResult> => {
+  if (params.relatorId === params.relateeId) return { error: "self_relating" };
 
-  const [exists] = await db.select({ id: profiles.id }).from(profiles).where(eq(profiles.id, params.rateeId));
-  if (!exists) return { error: "ratee_not_found" };
+  const [exists] = await db.select({ id: profiles.id }).from(profiles).where(eq(profiles.id, params.relateeId));
+  if (!exists) return { error: "relatee_not_found" };
 
   await db
     .insert(relations)
     .values({
-      raterId: params.raterId,
-      rateeId: params.rateeId,
+      relatorId: params.relatorId,
+      relateeId: params.relateeId,
       value: params.value,
       isHint: false,
     })
     .onConflictDoUpdate({
-      target: [relations.raterId, relations.rateeId],
+      target: [relations.relatorId, relations.relateeId],
       set: {
         value: params.value,
         isHint: false,
@@ -357,63 +366,64 @@ export const rateMember = async (params: {
   return { ok: true };
 };
 
-// createHint: admin-only path. Inserts a pending hint row (value NULL,
-// isHint true, hintedBy set). Ignored silently if a row already exists
-// — admins shouldn't get a hard error from re-clicking a hint button,
-// and the rater's existing state is more authoritative than a re-hint.
-export type CreateHintResult =
+// createRelationHint: admin-only path. Inserts a pending hint row
+// (value NULL, isHint true, hintedBy set). Ignored silently if a row
+// already exists — admins shouldn't get a hard error from re-clicking
+// a hint button, and the relator's existing state is more
+// authoritative than a re-hint.
+export type CreateRelationHintResult =
   | { ok: true; created: boolean }
-  | { error: "self_rating" | "rater_not_found" | "ratee_not_found" };
+  | { error: "self_relating" | "relator_not_found" | "relatee_not_found" };
 
-export const createHint = async (params: {
-  raterId: string;
-  rateeId: string;
+export const createRelationHint = async (params: {
+  relatorId: string;
+  relateeId: string;
   hintedBy: string;
-}): Promise<CreateHintResult> => {
-  if (params.raterId === params.rateeId) return { error: "self_rating" };
+}): Promise<CreateRelationHintResult> => {
+  if (params.relatorId === params.relateeId) return { error: "self_relating" };
 
   const found = await db
     .select({ id: profiles.id })
     .from(profiles)
-    .where(inArray(profiles.id, [params.raterId, params.rateeId]));
+    .where(inArray(profiles.id, [params.relatorId, params.relateeId]));
   const ids = new Set(found.map((r) => r.id));
-  if (!ids.has(params.raterId)) return { error: "rater_not_found" };
-  if (!ids.has(params.rateeId)) return { error: "ratee_not_found" };
+  if (!ids.has(params.relatorId)) return { error: "relator_not_found" };
+  if (!ids.has(params.relateeId)) return { error: "relatee_not_found" };
 
   const result = await db
     .insert(relations)
     .values({
-      raterId: params.raterId,
-      rateeId: params.rateeId,
+      relatorId: params.relatorId,
+      relateeId: params.relateeId,
       value: null,
       isHint: true,
       hintedBy: params.hintedBy,
     })
-    .onConflictDoNothing({ target: [relations.raterId, relations.rateeId] })
-    .returning({ raterId: relations.raterId });
+    .onConflictDoNothing({ target: [relations.relatorId, relations.relateeId] })
+    .returning({ relatorId: relations.relatorId });
 
   return { ok: true, created: result.length > 0 };
 };
 
-// deleteHint: admin-only withdraw. Only deletes when the row is in the
-// pending-hint state — refuses to clobber a confirmed rating, even if
-// the admin asked for it.
-export type DeleteHintResult = { ok: true } | { error: "not_found" };
+// deleteRelationHint: admin-only withdraw. Only deletes when the row
+// is in the pending-hint state — refuses to clobber a confirmed
+// rating, even if the admin asked for it.
+export type DeleteRelationHintResult = { ok: true } | { error: "not_found" };
 
-export const deleteHint = async (params: {
-  raterId: string;
-  rateeId: string;
-}): Promise<DeleteHintResult> => {
+export const deleteRelationHint = async (params: {
+  relatorId: string;
+  relateeId: string;
+}): Promise<DeleteRelationHintResult> => {
   const result = await db
     .delete(relations)
     .where(
       and(
-        eq(relations.raterId, params.raterId),
-        eq(relations.rateeId, params.rateeId),
+        eq(relations.relatorId, params.relatorId),
+        eq(relations.relateeId, params.relateeId),
         eq(relations.isHint, true),
       ),
     )
-    .returning({ raterId: relations.raterId });
+    .returning({ relatorId: relations.relatorId });
 
   if (result.length === 0) return { error: "not_found" };
   return { ok: true };
@@ -470,25 +480,25 @@ export const materializeInviteRelations = async (
     inviteId: string;
     inviterId: string | null;
     redeemerId: string;
-    creatorValue: number | null;
+    relationValue: number | null;
   },
 ): Promise<void> => {
-  // creator_value → confirmed inviter→redeemer rating.
-  if (params.inviterId && params.creatorValue !== null) {
+  // relation_value → confirmed inviter→redeemer rating.
+  if (params.inviterId && params.relationValue !== null) {
     await tx
       .insert(relations)
       .values({
-        raterId: params.inviterId,
-        rateeId: params.redeemerId,
-        value: params.creatorValue,
+        relatorId: params.inviterId,
+        relateeId: params.redeemerId,
+        value: params.relationValue,
         isHint: false,
       })
-      .onConflictDoNothing({ target: [relations.raterId, relations.rateeId] });
+      .onConflictDoNothing({ target: [relations.relatorId, relations.relateeId] });
   }
 
-  // invite_hints → pending redeemer→ratee hints, hintedBy=inviter.
+  // invite_hints → pending redeemer→relatee hints, hintedBy=inviter.
   const hints = await tx
-    .select({ rateeId: inviteHints.rateeId })
+    .select({ relateeId: inviteHints.relateeId })
     .from(inviteHints)
     .where(eq(inviteHints.inviteId, params.inviteId));
 
@@ -499,10 +509,10 @@ export const materializeInviteRelations = async (
   // flows, but the auth callback shouldn't fail because of upstream
   // data weirdness.
   const rows = hints
-    .filter((h) => h.rateeId !== params.redeemerId)
+    .filter((h) => h.relateeId !== params.redeemerId)
     .map((h) => ({
-      raterId: params.redeemerId,
-      rateeId: h.rateeId,
+      relatorId: params.redeemerId,
+      relateeId: h.relateeId,
       value: null,
       isHint: true,
       hintedBy: params.inviterId,
@@ -513,7 +523,7 @@ export const materializeInviteRelations = async (
   await tx
     .insert(relations)
     .values(rows)
-    .onConflictDoNothing({ target: [relations.raterId, relations.rateeId] });
+    .onConflictDoNothing({ target: [relations.relatorId, relations.relateeId] });
 };
 
 // Helper for invite creation — writes invite_hints rows in the same
@@ -521,21 +531,8 @@ export const materializeInviteRelations = async (
 // hint list via validateInviteHints.
 export const insertInviteHints = async (
   tx: Tx | typeof db,
-  params: { inviteId: string; rateeIds: string[] },
+  params: { inviteId: string; relateeIds: string[] },
 ): Promise<void> => {
-  if (params.rateeIds.length === 0) return;
-  await tx.insert(inviteHints).values(params.rateeIds.map((rateeId) => ({ inviteId: params.inviteId, rateeId })));
+  if (params.relateeIds.length === 0) return;
+  await tx.insert(inviteHints).values(params.relateeIds.map((relateeId) => ({ inviteId: params.inviteId, relateeId })));
 };
-
-// Convenience wrapper for the API: fetches and parses the admin flag,
-// returns 403 sentinel if the caller isn't an admin. Non-admins still
-// get to call hint endpoints to discover them — admin-gated routes
-// return 403 (not 404) because admin-ness isn't a secret.
-export const isAdmin = async (userId: string): Promise<boolean> => {
-  const [row] = await db.select({ isAdmin: profiles.isAdmin }).from(profiles).where(eq(profiles.id, userId));
-  return row?.isAdmin ?? false;
-};
-
-// Re-export check used by API for self-rating short-circuit before
-// the DB constraint triggers.
-export const sameId = (a: string, b: string): boolean => a === b;

--- a/src/server/relations.ts
+++ b/src/server/relations.ts
@@ -1,0 +1,541 @@
+import { and, asc, desc, eq, inArray, isNotNull, isNull, ne, or, sql } from "drizzle-orm";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+
+import { db } from "./db";
+import { inviteHints, invites, profiles, relations } from "./schema";
+
+// 1..4 vocabulary lives in design-relations.md. The DB enforces the
+// range via relations_value_range and invites_creator_value_range; this
+// file's runtime validators repeat the check at the API edge so we can
+// return clean 400s before round-tripping to a constraint violation.
+export type RelationValue = 1 | 2 | 3 | 4;
+
+export const isRelationValue = (v: unknown): v is RelationValue =>
+  typeof v === "number" && Number.isInteger(v) && v >= 1 && v <= 4;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export const isUuid = (v: unknown): v is string => typeof v === "string" && UUID_RE.test(v);
+
+// Card payload returned in the candidate feed. The fields here are what
+// the rating-decision UI needs without navigating away — the design's
+// "enough profile information to make a rating decision" requirement.
+export type CandidateCard = {
+  id: string;
+  slug: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  bio: string | null;
+  keywords: string[];
+  location: string | null;
+  reason: CandidateReason;
+};
+
+// Soft-hide is enforced here: the "ratedYou" reason carries no value
+// field, even though the source row has one. The client cannot leak
+// what it never sees.
+export type CandidateReason =
+  | { type: "ratedYou" }
+  | { type: "hint"; hintedBy: { id: string; displayName: string | null; slug: string | null } | null }
+  | { type: "viaInviter"; inviter: { id: string; displayName: string | null; slug: string | null } }
+  | { type: "recentlyActive" };
+
+export type CandidateFeed = {
+  suggestions: CandidateCard[];
+  otherMembers: CandidateCard[];
+};
+
+const cardColumns = {
+  id: profiles.id,
+  slug: profiles.slug,
+  displayName: profiles.displayName,
+  avatarUrl: profiles.avatarUrl,
+  bio: profiles.bio,
+  keywords: profiles.keywords,
+  location: profiles.location,
+};
+
+type CardColumns = {
+  id: string;
+  slug: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  bio: string | null;
+  keywords: string[];
+  location: string | null;
+};
+
+const toCard = (row: CardColumns, reason: CandidateReason): CandidateCard => ({ ...row, reason });
+
+// Candidate feed sources are enumerated in design-relations.md
+// "Candidate feed sources." Each person appears at most once, in the
+// highest-priority source where they qualify; downstream sources skip
+// IDs already collected. At MVP scale the four-query approach is fine —
+// none of these touch more than ~hundreds of rows.
+export const getCandidates = async (userId: string): Promise<CandidateFeed> => {
+  const seen = new Set<string>([userId]);
+
+  // Source 1 — people who rated me (with a value), where I have no row
+  // back to them at all (no rating, no hint).
+  const ratedMeAlias = relations;
+  const ratedMe = await db
+    .select(cardColumns)
+    .from(ratedMeAlias)
+    .innerJoin(profiles, eq(profiles.id, ratedMeAlias.raterId))
+    .where(
+      and(
+        eq(ratedMeAlias.rateeId, userId),
+        isNotNull(ratedMeAlias.value),
+        sql`NOT EXISTS (SELECT 1 FROM relations rev WHERE rev.rater_id = ${userId} AND rev.ratee_id = ${ratedMeAlias.raterId})`,
+      ),
+    )
+    .orderBy(desc(ratedMeAlias.updatedAt));
+
+  const suggestions: CandidateCard[] = [];
+  for (const row of ratedMe) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    suggestions.push(toCard(row, { type: "ratedYou" }));
+  }
+
+  // Source 2 — pending hints for me (rater=me, isHint=true, value=null).
+  // Two queries: hint rows (with ratee profile), then a batch lookup
+  // for hinter profiles. Aliasing profiles twice in one Drizzle query
+  // is more code than this at our scale.
+  const hintRows = await db
+    .select({
+      ...cardColumns,
+      hintedBy: relations.hintedBy,
+      updatedAt: relations.updatedAt,
+    })
+    .from(relations)
+    .innerJoin(profiles, eq(profiles.id, relations.rateeId))
+    .where(and(eq(relations.raterId, userId), eq(relations.isHint, true)))
+    .orderBy(desc(relations.updatedAt));
+
+  const hintIds = hintRows.map((r) => r.hintedBy).filter((x): x is string => !!x);
+  const hinters =
+    hintIds.length > 0
+      ? await db
+          .select({ id: profiles.id, displayName: profiles.displayName, slug: profiles.slug })
+          .from(profiles)
+          .where(inArray(profiles.id, hintIds))
+      : [];
+  const hinterById = new Map(hinters.map((h) => [h.id, h]));
+
+  for (const row of hintRows) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    const hintedBy = row.hintedBy ? hinterById.get(row.hintedBy) ?? null : null;
+    const card: CardColumns = {
+      id: row.id,
+      slug: row.slug,
+      displayName: row.displayName,
+      avatarUrl: row.avatarUrl,
+      bio: row.bio,
+      keywords: row.keywords,
+      location: row.location,
+    };
+    suggestions.push(toCard(card, { type: "hint", hintedBy }));
+  }
+
+  const otherMembers: CandidateCard[] = [];
+
+  // Source 3 — my inviter's higher-rated connections. Only fires when
+  // I have a referredBy and that inviter has confirmed ratings ≥ 3.
+  const [me] = await db
+    .select({
+      referredBy: profiles.referredBy,
+      lastUpdatedWeb: profiles.lastUpdatedWeb,
+    })
+    .from(profiles)
+    .where(eq(profiles.id, userId));
+
+  if (me?.referredBy) {
+    const inviterId: string = me.referredBy;
+    const [inviter] = await db
+      .select({ id: profiles.id, displayName: profiles.displayName, slug: profiles.slug })
+      .from(profiles)
+      .where(eq(profiles.id, inviterId));
+
+    if (inviter) {
+      const inviterConnections = await db
+        .select(cardColumns)
+        .from(relations)
+        .innerJoin(profiles, eq(profiles.id, relations.rateeId))
+        .where(
+          and(
+            eq(relations.raterId, inviterId),
+            isNotNull(relations.value),
+            sql`${relations.value} >= 3`,
+            ne(relations.rateeId, userId),
+            sql`NOT EXISTS (SELECT 1 FROM relations rev WHERE rev.rater_id = ${userId} AND rev.ratee_id = ${relations.rateeId})`,
+          ),
+        )
+        .orderBy(desc(relations.value), desc(relations.updatedAt));
+
+      for (const row of inviterConnections) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        otherMembers.push(toCard(row, { type: "viaInviter", inviter }));
+      }
+    }
+  }
+
+  // Source 4 — members whose last_updated_web is more recent than mine
+  // (or any value, if mine is null). Excludes self and anyone I've
+  // already touched.
+  const myLastUpdated = me?.lastUpdatedWeb ?? null;
+  const recentlyActive = await db
+    .select(cardColumns)
+    .from(profiles)
+    .where(
+      and(
+        isNotNull(profiles.lastUpdatedWeb),
+        ne(profiles.id, userId),
+        sql`NOT EXISTS (SELECT 1 FROM relations rev WHERE rev.rater_id = ${userId} AND rev.ratee_id = ${profiles.id})`,
+        myLastUpdated
+          ? sql`${profiles.lastUpdatedWeb} > ${myLastUpdated.toISOString()}`
+          : sql`true`,
+      ),
+    )
+    .orderBy(desc(profiles.lastUpdatedWeb));
+
+  for (const row of recentlyActive) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    otherMembers.push(toCard(row, { type: "recentlyActive" }));
+  }
+
+  return { suggestions, otherMembers };
+};
+
+// Subgraph payload for the WebGraph component. centerId is whoever the
+// graph is rendered around — in the MVP that's always the requesting
+// user, but the component is parameterized for the future profile-page
+// embed (see design-relations.md "Embedded subgraph displays").
+export type SubgraphNode = {
+  id: string;
+  slug: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+};
+
+export type SubgraphEdge = {
+  raterId: string;
+  rateeId: string;
+  value: number;
+};
+
+export type Subgraph = {
+  centerId: string;
+  nodes: SubgraphNode[];
+  edges: SubgraphEdge[];
+};
+
+const nodeColumns = {
+  id: profiles.id,
+  slug: profiles.slug,
+  displayName: profiles.displayName,
+  avatarUrl: profiles.avatarUrl,
+};
+
+// One-hop or two-hop personal subgraph. Hints (value IS NULL) are never
+// rendered; they live in the candidate feed.
+export const getSubgraph = async (params: {
+  centerId: string;
+  includeIncoming: boolean;
+  includeOutgoing: boolean;
+  hops: 1 | 2;
+}): Promise<Subgraph> => {
+  const { centerId, includeIncoming, includeOutgoing, hops } = params;
+
+  // First hop — direct relations involving centerId.
+  const firstHopWhere = (() => {
+    if (includeIncoming && includeOutgoing) {
+      return or(eq(relations.raterId, centerId), eq(relations.rateeId, centerId));
+    }
+    if (includeOutgoing) return eq(relations.raterId, centerId);
+    if (includeIncoming) return eq(relations.rateeId, centerId);
+    return sql`false`;
+  })();
+
+  const firstHop = await db
+    .select({
+      raterId: relations.raterId,
+      rateeId: relations.rateeId,
+      value: relations.value,
+    })
+    .from(relations)
+    .where(and(firstHopWhere, isNotNull(relations.value)));
+
+  const nodeIds = new Set<string>([centerId]);
+  for (const e of firstHop) {
+    nodeIds.add(e.raterId);
+    nodeIds.add(e.rateeId);
+  }
+
+  const edges: SubgraphEdge[] = firstHop.map((e) => ({
+    raterId: e.raterId,
+    rateeId: e.rateeId,
+    // Drizzle's value column is nullable in the type; we filtered on
+    // IS NOT NULL above, so the runtime value is guaranteed numeric.
+    value: e.value as number,
+  }));
+
+  // Second hop — relations among the first-hop neighbors (and to other
+  // members they point at). Per design, this surfaces "their relations
+  // to each other and to second-degree members" when the toggle is on.
+  if (hops === 2) {
+    const firstHopIds = [...nodeIds].filter((id) => id !== centerId);
+    if (firstHopIds.length > 0) {
+      const secondHop = await db
+        .select({
+          raterId: relations.raterId,
+          rateeId: relations.rateeId,
+          value: relations.value,
+        })
+        .from(relations)
+        .where(
+          and(
+            isNotNull(relations.value),
+            inArray(relations.raterId, firstHopIds),
+            ne(relations.rateeId, centerId),
+          ),
+        );
+      for (const e of secondHop) {
+        if (edges.some((existing) => existing.raterId === e.raterId && existing.rateeId === e.rateeId)) {
+          continue;
+        }
+        nodeIds.add(e.rateeId);
+        edges.push({ raterId: e.raterId, rateeId: e.rateeId, value: e.value as number });
+      }
+    }
+  }
+
+  const nodeRows =
+    nodeIds.size > 0
+      ? await db.select(nodeColumns).from(profiles).where(inArray(profiles.id, [...nodeIds])).orderBy(asc(profiles.displayName))
+      : [];
+
+  return { centerId, nodes: nodeRows, edges };
+};
+
+// rateMember: create or update the (rater, ratee) row with a confirmed
+// value. If a pending hint exists, this transition flips isHint to
+// false while preserving hintedBy. The check constraint
+// relations_hint_state means we have to set both columns in the same
+// statement.
+export type RateMemberResult = { ok: true } | { error: "self_rating" | "ratee_not_found" };
+
+export const rateMember = async (params: {
+  raterId: string;
+  rateeId: string;
+  value: RelationValue;
+}): Promise<RateMemberResult> => {
+  if (params.raterId === params.rateeId) return { error: "self_rating" };
+
+  const [exists] = await db.select({ id: profiles.id }).from(profiles).where(eq(profiles.id, params.rateeId));
+  if (!exists) return { error: "ratee_not_found" };
+
+  await db
+    .insert(relations)
+    .values({
+      raterId: params.raterId,
+      rateeId: params.rateeId,
+      value: params.value,
+      isHint: false,
+    })
+    .onConflictDoUpdate({
+      target: [relations.raterId, relations.rateeId],
+      set: {
+        value: params.value,
+        isHint: false,
+        updatedAt: sql`now()`,
+      },
+    });
+
+  return { ok: true };
+};
+
+// createHint: admin-only path. Inserts a pending hint row (value NULL,
+// isHint true, hintedBy set). Ignored silently if a row already exists
+// — admins shouldn't get a hard error from re-clicking a hint button,
+// and the rater's existing state is more authoritative than a re-hint.
+export type CreateHintResult =
+  | { ok: true; created: boolean }
+  | { error: "self_rating" | "rater_not_found" | "ratee_not_found" };
+
+export const createHint = async (params: {
+  raterId: string;
+  rateeId: string;
+  hintedBy: string;
+}): Promise<CreateHintResult> => {
+  if (params.raterId === params.rateeId) return { error: "self_rating" };
+
+  const found = await db
+    .select({ id: profiles.id })
+    .from(profiles)
+    .where(inArray(profiles.id, [params.raterId, params.rateeId]));
+  const ids = new Set(found.map((r) => r.id));
+  if (!ids.has(params.raterId)) return { error: "rater_not_found" };
+  if (!ids.has(params.rateeId)) return { error: "ratee_not_found" };
+
+  const result = await db
+    .insert(relations)
+    .values({
+      raterId: params.raterId,
+      rateeId: params.rateeId,
+      value: null,
+      isHint: true,
+      hintedBy: params.hintedBy,
+    })
+    .onConflictDoNothing({ target: [relations.raterId, relations.rateeId] })
+    .returning({ raterId: relations.raterId });
+
+  return { ok: true, created: result.length > 0 };
+};
+
+// deleteHint: admin-only withdraw. Only deletes when the row is in the
+// pending-hint state — refuses to clobber a confirmed rating, even if
+// the admin asked for it.
+export type DeleteHintResult = { ok: true } | { error: "not_found" };
+
+export const deleteHint = async (params: {
+  raterId: string;
+  rateeId: string;
+}): Promise<DeleteHintResult> => {
+  const result = await db
+    .delete(relations)
+    .where(
+      and(
+        eq(relations.raterId, params.raterId),
+        eq(relations.rateeId, params.rateeId),
+        eq(relations.isHint, true),
+      ),
+    )
+    .returning({ raterId: relations.raterId });
+
+  if (result.length === 0) return { error: "not_found" };
+  return { ok: true };
+};
+
+// Hint validation for the invite-creation form. Returns either the
+// deduplicated UUID list or a structured error code the API surfaces
+// as a 400.
+export const HINTS_PER_INVITE_LIMIT = 10;
+
+export type ValidateHintsResult =
+  | { ok: true; ids: string[] }
+  | { error: "invalid"; reason: "not_an_array" | "non_uuid" | "self" | "duplicate" | "too_many" | "not_a_member" };
+
+export const validateInviteHints = async (params: {
+  hints: unknown;
+  inviterId: string;
+}): Promise<ValidateHintsResult> => {
+  if (params.hints === undefined || params.hints === null) return { ok: true, ids: [] };
+  if (!Array.isArray(params.hints)) return { error: "invalid", reason: "not_an_array" };
+  if (params.hints.length === 0) return { ok: true, ids: [] };
+  if (params.hints.length > HINTS_PER_INVITE_LIMIT) return { error: "invalid", reason: "too_many" };
+
+  const seen = new Set<string>();
+  for (const h of params.hints) {
+    if (!isUuid(h)) return { error: "invalid", reason: "non_uuid" };
+    if (h === params.inviterId) return { error: "invalid", reason: "self" };
+    if (seen.has(h)) return { error: "invalid", reason: "duplicate" };
+    seen.add(h);
+  }
+
+  const ids = [...seen];
+  const found = await db.select({ id: profiles.id }).from(profiles).where(inArray(profiles.id, ids));
+  if (found.length !== ids.length) return { error: "invalid", reason: "not_a_member" };
+
+  return { ok: true, ids };
+};
+
+// Materialization called from the auth-callback transaction. The
+// caller passes the active tx so the relations rows land or roll back
+// with the rest of the redemption.
+type Tx = PgTransaction<
+  // biome-ignore lint/suspicious/noExplicitAny: this is the public
+  // postgres-js transaction type, and Drizzle's exposed shape needs
+  // the generic surface to compile against `db.transaction(...)`.
+  any,
+  any,
+  any
+>;
+
+export const materializeInviteRelations = async (
+  tx: Tx | typeof db,
+  params: {
+    inviteId: string;
+    inviterId: string | null;
+    redeemerId: string;
+    creatorValue: number | null;
+  },
+): Promise<void> => {
+  // creator_value → confirmed inviter→redeemer rating.
+  if (params.inviterId && params.creatorValue !== null) {
+    await tx
+      .insert(relations)
+      .values({
+        raterId: params.inviterId,
+        rateeId: params.redeemerId,
+        value: params.creatorValue,
+        isHint: false,
+      })
+      .onConflictDoNothing({ target: [relations.raterId, relations.rateeId] });
+  }
+
+  // invite_hints → pending redeemer→ratee hints, hintedBy=inviter.
+  const hints = await tx
+    .select({ rateeId: inviteHints.rateeId })
+    .from(inviteHints)
+    .where(eq(inviteHints.inviteId, params.inviteId));
+
+  if (hints.length === 0) return;
+
+  // Defensive filter: skip any hint pointing at the redeemer themselves
+  // (would violate relations_no_self). Shouldn't happen via normal
+  // flows, but the auth callback shouldn't fail because of upstream
+  // data weirdness.
+  const rows = hints
+    .filter((h) => h.rateeId !== params.redeemerId)
+    .map((h) => ({
+      raterId: params.redeemerId,
+      rateeId: h.rateeId,
+      value: null,
+      isHint: true,
+      hintedBy: params.inviterId,
+    }));
+
+  if (rows.length === 0) return;
+
+  await tx
+    .insert(relations)
+    .values(rows)
+    .onConflictDoNothing({ target: [relations.raterId, relations.rateeId] });
+};
+
+// Helper for invite creation — writes invite_hints rows in the same
+// transaction as the invite itself. Caller has already validated the
+// hint list via validateInviteHints.
+export const insertInviteHints = async (
+  tx: Tx | typeof db,
+  params: { inviteId: string; rateeIds: string[] },
+): Promise<void> => {
+  if (params.rateeIds.length === 0) return;
+  await tx.insert(inviteHints).values(params.rateeIds.map((rateeId) => ({ inviteId: params.inviteId, rateeId })));
+};
+
+// Convenience wrapper for the API: fetches and parses the admin flag,
+// returns 403 sentinel if the caller isn't an admin. Non-admins still
+// get to call hint endpoints to discover them — admin-gated routes
+// return 403 (not 404) because admin-ness isn't a secret.
+export const isAdmin = async (userId: string): Promise<boolean> => {
+  const [row] = await db.select({ isAdmin: profiles.isAdmin }).from(profiles).where(eq(profiles.id, userId));
+  return row?.isAdmin ?? false;
+};
+
+// Re-export check used by API for self-rating short-circuit before
+// the DB constraint triggers.
+export const sameId = (a: string, b: string): boolean => a === b;

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -90,22 +90,26 @@ export const invites = pgTable(
     }),
     redeemedAt: timestamp("redeemed_at", { withTimezone: true }),
     revokedAt: timestamp("revoked_at", { withTimezone: true }),
-    creatorValue: integer("creator_value"),
+    // SQL column stays "creator_value" until a rename migration lands;
+    // the TS-side name follows the post-review vocabulary.
+    relationValue: integer("creator_value"),
   },
   (table) => [
     check("invites_redemption_pair", sql`(${table.redeemedBy} IS NULL) = (${table.redeemedAt} IS NULL)`),
     check("invites_expires_after_created", sql`${table.expiresAt} > ${table.createdAt}`),
-    check("invites_creator_value_range", sql`${table.creatorValue} IS NULL OR (${table.creatorValue} BETWEEN 1 AND 4)`),
+    check("invites_creator_value_range", sql`${table.relationValue} IS NULL OR (${table.relationValue} BETWEEN 1 AND 4)`),
   ],
 ).enableRLS();
 
 export const relations = pgTable(
   "relations",
   {
-    raterId: uuid("rater_id")
+    // SQL columns stay rater_id / ratee_id until a rename migration
+    // lands; TS-side names follow the post-review vocabulary.
+    relatorId: uuid("rater_id")
       .notNull()
       .references(() => profiles.id, { onDelete: "cascade" }),
-    rateeId: uuid("ratee_id")
+    relateeId: uuid("ratee_id")
       .notNull()
       .references(() => profiles.id, { onDelete: "cascade" }),
     value: integer("value"),
@@ -120,8 +124,8 @@ export const relations = pgTable(
       .$onUpdate(() => new Date()),
   },
   (table) => [
-    primaryKey({ columns: [table.raterId, table.rateeId] }),
-    check("relations_no_self", sql`${table.raterId} != ${table.rateeId}`),
+    primaryKey({ columns: [table.relatorId, table.relateeId] }),
+    check("relations_no_self", sql`${table.relatorId} != ${table.relateeId}`),
     check("relations_value_range", sql`${table.value} IS NULL OR (${table.value} BETWEEN 1 AND 4)`),
     check(
       "relations_hint_state",
@@ -137,10 +141,10 @@ export const inviteHints = pgTable(
     inviteId: uuid("invite_id")
       .notNull()
       .references(() => invites.id, { onDelete: "cascade" }),
-    rateeId: uuid("ratee_id")
+    relateeId: uuid("ratee_id")
       .notNull()
       .references(() => profiles.id, { onDelete: "cascade" }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [primaryKey({ columns: [table.inviteId, table.rateeId] })],
+  (table) => [primaryKey({ columns: [table.inviteId, table.relateeId] })],
 ).enableRLS();

--- a/tests/functional/server/invites.test.ts
+++ b/tests/functional/server/invites.test.ts
@@ -19,7 +19,7 @@ import {
   redeemInvite,
   revokeInvite,
 } from "@/server/invites";
-import { invites, profiles } from "@/server/schema";
+import { inviteHints, invites, profiles, relations } from "@/server/schema";
 
 const mockCreateServerClient = vi.mocked(createServerClient);
 
@@ -53,6 +53,8 @@ const insertUserAndProfile = async (id: string, isAdmin = false) => {
 };
 
 const deleteUserAndProfile = async (id: string) => {
+  await db.delete(relations).where(eq(relations.raterId, id));
+  await db.delete(relations).where(eq(relations.rateeId, id));
   await db.delete(invites).where(eq(invites.createdBy, id));
   await db.delete(profiles).where(eq(profiles.id, id));
   await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
@@ -319,6 +321,68 @@ describe("POST /api/invites", () => {
       body: "{not json",
     });
     expect(res.status).toBe(400);
+  });
+
+  it("accepts creatorValue and persists it", async () => {
+    const res = await post({ note: "with creator value picker", creatorValue: 3 });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.creatorValue).toBe(3);
+    const [row] = await db.select({ creatorValue: invites.creatorValue }).from(invites).where(eq(invites.code, body.code));
+    expect(row.creatorValue).toBe(3);
+  });
+
+  it("rejects creatorValue outside 1..4", async () => {
+    const res = await post({ note: "creator value out of range", creatorValue: 5 });
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts hints and writes invite_hints rows", async () => {
+    const h1 = randomUUID();
+    const h2 = randomUUID();
+    await insertUserAndProfile(h1);
+    await insertUserAndProfile(h2);
+    try {
+      const res = await post({ note: "with hint chips attached", hints: [h1, h2] });
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.hintCount).toBe(2);
+      const [invRow] = await db.select({ id: invites.id }).from(invites).where(eq(invites.code, body.code));
+      const hintRows = await db.select().from(inviteHints).where(eq(inviteHints.inviteId, invRow.id));
+      expect(hintRows.map((r) => r.rateeId).sort()).toEqual([h1, h2].sort());
+    } finally {
+      await deleteUserAndProfile(h1);
+      await deleteUserAndProfile(h2);
+    }
+  });
+
+  it("rejects hints with self in the list", async () => {
+    const res = await post({ note: "self hint should be rejected", hints: [userId] });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_hints");
+    expect(body.reason).toBe("self");
+  });
+
+  it("rejects hints pointing at non-members", async () => {
+    const res = await post({ note: "non-member hint should be rejected", hints: [randomUUID()] });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_hints");
+    expect(body.reason).toBe("not_a_member");
+  });
+
+  it("rejects duplicate ids in the hints list", async () => {
+    const h = randomUUID();
+    await insertUserAndProfile(h);
+    try {
+      const res = await post({ note: "duplicate hint should be rejected", hints: [h, h] });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.reason).toBe("duplicate");
+    } finally {
+      await deleteUserAndProfile(h);
+    }
   });
 
   it("returns 429 when the user is already at the active cap", async () => {

--- a/tests/functional/server/invites.test.ts
+++ b/tests/functional/server/invites.test.ts
@@ -53,8 +53,8 @@ const insertUserAndProfile = async (id: string, isAdmin = false) => {
 };
 
 const deleteUserAndProfile = async (id: string) => {
-  await db.delete(relations).where(eq(relations.raterId, id));
-  await db.delete(relations).where(eq(relations.rateeId, id));
+  await db.delete(relations).where(eq(relations.relatorId, id));
+  await db.delete(relations).where(eq(relations.relateeId, id));
   await db.delete(invites).where(eq(invites.createdBy, id));
   await db.delete(profiles).where(eq(profiles.id, id));
   await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
@@ -323,17 +323,17 @@ describe("POST /api/invites", () => {
     expect(res.status).toBe(400);
   });
 
-  it("accepts creatorValue and persists it", async () => {
-    const res = await post({ note: "with creator value picker", creatorValue: 3 });
+  it("accepts relationValue and persists it", async () => {
+    const res = await post({ note: "with relation value picker", relationValue: 3 });
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.creatorValue).toBe(3);
-    const [row] = await db.select({ creatorValue: invites.creatorValue }).from(invites).where(eq(invites.code, body.code));
-    expect(row.creatorValue).toBe(3);
+    expect(body.relationValue).toBe(3);
+    const [row] = await db.select({ relationValue: invites.relationValue }).from(invites).where(eq(invites.code, body.code));
+    expect(row.relationValue).toBe(3);
   });
 
-  it("rejects creatorValue outside 1..4", async () => {
-    const res = await post({ note: "creator value out of range", creatorValue: 5 });
+  it("rejects relationValue outside 1..4", async () => {
+    const res = await post({ note: "relation value out of range", relationValue: 5 });
     expect(res.status).toBe(400);
   });
 
@@ -349,7 +349,7 @@ describe("POST /api/invites", () => {
       expect(body.hintCount).toBe(2);
       const [invRow] = await db.select({ id: invites.id }).from(invites).where(eq(invites.code, body.code));
       const hintRows = await db.select().from(inviteHints).where(eq(inviteHints.inviteId, invRow.id));
-      expect(hintRows.map((r) => r.rateeId).sort()).toEqual([h1, h2].sort());
+      expect(hintRows.map((r) => r.relateeId).sort()).toEqual([h1, h2].sort());
     } finally {
       await deleteUserAndProfile(h1);
       await deleteUserAndProfile(h2);

--- a/tests/functional/server/relations-schema.test.ts
+++ b/tests/functional/server/relations-schema.test.ts
@@ -31,76 +31,76 @@ const deleteUserAndProfile = async (id: string) => {
 };
 
 describe("relations table constraints", () => {
-  let raterId: string;
-  let rateeId: string;
+  let relatorId: string;
+  let relateeId: string;
 
   beforeEach(async () => {
-    raterId = randomUUID();
-    rateeId = randomUUID();
-    await insertUserAndProfile(raterId);
-    await insertUserAndProfile(rateeId);
+    relatorId = randomUUID();
+    relateeId = randomUUID();
+    await insertUserAndProfile(relatorId);
+    await insertUserAndProfile(relateeId);
   });
 
   afterEach(async () => {
-    await db.delete(relations).where(eq(relations.raterId, raterId));
-    await db.delete(relations).where(eq(relations.raterId, rateeId));
-    await deleteUserAndProfile(raterId);
-    await deleteUserAndProfile(rateeId);
+    await db.delete(relations).where(eq(relations.relatorId, relatorId));
+    await db.delete(relations).where(eq(relations.relatorId, relateeId));
+    await deleteUserAndProfile(relatorId);
+    await deleteUserAndProfile(relateeId);
   });
 
   it("accepts a confirmed rating in the 1..4 range", async () => {
-    await db.insert(relations).values({ raterId, rateeId, value: 3 });
-    const [row] = await db.select().from(relations).where(eq(relations.raterId, raterId));
+    await db.insert(relations).values({ relatorId, relateeId, value: 3 });
+    const [row] = await db.select().from(relations).where(eq(relations.relatorId, relatorId));
     expect(row.value).toBe(3);
     expect(row.isHint).toBe(false);
   });
 
   it("accepts each of 1, 2, 3, 4 as a value", async () => {
     for (const value of [1, 2, 3, 4]) {
-      const otherRatee = randomUUID();
-      await insertUserAndProfile(otherRatee);
+      const otherRelatee = randomUUID();
+      await insertUserAndProfile(otherRelatee);
       try {
-        await db.insert(relations).values({ raterId, rateeId: otherRatee, value });
+        await db.insert(relations).values({ relatorId, relateeId: otherRelatee, value });
       } finally {
-        await db.delete(relations).where(eq(relations.rateeId, otherRatee));
-        await deleteUserAndProfile(otherRatee);
+        await db.delete(relations).where(eq(relations.relateeId, otherRelatee));
+        await deleteUserAndProfile(otherRelatee);
       }
     }
   });
 
   it("rejects value 0 (relations_value_range)", async () => {
     await expectConstraintViolation(
-      db.insert(relations).values({ raterId, rateeId, value: 0 }),
+      db.insert(relations).values({ relatorId, relateeId, value: 0 }),
       "relations_value_range",
     );
   });
 
   it("rejects value 5 (relations_value_range)", async () => {
     await expectConstraintViolation(
-      db.insert(relations).values({ raterId, rateeId, value: 5 }),
+      db.insert(relations).values({ relatorId, relateeId, value: 5 }),
       "relations_value_range",
     );
   });
 
   it("accepts a pending hint (value NULL, isHint true)", async () => {
     await db.insert(relations).values({
-      raterId,
-      rateeId,
+      relatorId,
+      relateeId,
       value: null,
       isHint: true,
-      hintedBy: rateeId,
+      hintedBy: relateeId,
     });
-    const [row] = await db.select().from(relations).where(eq(relations.raterId, raterId));
+    const [row] = await db.select().from(relations).where(eq(relations.relatorId, relatorId));
     expect(row.value).toBeNull();
     expect(row.isHint).toBe(true);
-    expect(row.hintedBy).toBe(rateeId);
+    expect(row.hintedBy).toBe(relateeId);
   });
 
   it("rejects mixed state: value set with isHint true (relations_hint_state)", async () => {
     await expectConstraintViolation(
       db.insert(relations).values({
-        raterId,
-        rateeId,
+        relatorId,
+        relateeId,
         value: 2,
         isHint: true,
       }),
@@ -111,8 +111,8 @@ describe("relations table constraints", () => {
   it("rejects mixed state: value NULL with isHint false (relations_hint_state)", async () => {
     await expectConstraintViolation(
       db.insert(relations).values({
-        raterId,
-        rateeId,
+        relatorId,
+        relateeId,
         value: null,
         isHint: false,
       }),
@@ -120,27 +120,27 @@ describe("relations table constraints", () => {
     );
   });
 
-  it("rejects rater == ratee (relations_no_self)", async () => {
+  it("rejects relator == relatee (relations_no_self)", async () => {
     await expectConstraintViolation(
-      db.insert(relations).values({ raterId, rateeId: raterId, value: 3 }),
+      db.insert(relations).values({ relatorId, relateeId: relatorId, value: 3 }),
       "relations_no_self",
     );
   });
 
-  it("rejects duplicate (rater, ratee) pair (composite PK)", async () => {
-    await db.insert(relations).values({ raterId, rateeId, value: 3 });
-    await expect(db.insert(relations).values({ raterId, rateeId, value: 4 })).rejects.toThrow();
+  it("rejects duplicate (relator, relatee) pair (composite PK)", async () => {
+    await db.insert(relations).values({ relatorId, relateeId, value: 3 });
+    await expect(db.insert(relations).values({ relatorId, relateeId, value: 4 })).rejects.toThrow();
   });
 
   it("permits the reverse direction as a separate row", async () => {
-    await db.insert(relations).values({ raterId, rateeId, value: 3 });
-    await db.insert(relations).values({ raterId: rateeId, rateeId: raterId, value: 2 });
+    await db.insert(relations).values({ relatorId, relateeId, value: 3 });
+    await db.insert(relations).values({ relatorId: relateeId, relateeId: relatorId, value: 2 });
     const rows = await db.select().from(relations);
     const pairs = rows
       .filter(
-        (r) => (r.raterId === raterId && r.rateeId === rateeId) || (r.raterId === rateeId && r.rateeId === raterId),
+        (r) => (r.relatorId === relatorId && r.relateeId === relateeId) || (r.relatorId === relateeId && r.relateeId === relatorId),
       )
-      .map((r) => ({ raterId: r.raterId, rateeId: r.rateeId, value: r.value }));
+      .map((r) => ({ relatorId: r.relatorId, relateeId: r.relateeId, value: r.value }));
     expect(pairs).toHaveLength(2);
   });
 });
@@ -163,8 +163,8 @@ describe("invites.creator_value range", () => {
       note: "creator value null is fine",
     });
     if ("error" in r) throw new Error("seed failed");
-    const [row] = await db.select({ creatorValue: invites.creatorValue }).from(invites).where(eq(invites.code, r.code));
-    expect(row.creatorValue).toBeNull();
+    const [row] = await db.select({ relationValue: invites.relationValue }).from(invites).where(eq(invites.code, r.code));
+    expect(row.relationValue).toBeNull();
   });
 
   it("accepts each of 1, 2, 3, 4", async () => {
@@ -174,7 +174,7 @@ describe("invites.creator_value range", () => {
         note: `creator value ${value} accepted`,
       });
       if ("error" in r) throw new Error("seed failed");
-      await db.update(invites).set({ creatorValue: value }).where(eq(invites.code, r.code));
+      await db.update(invites).set({ relationValue: value }).where(eq(invites.code, r.code));
     }
   });
 
@@ -185,7 +185,7 @@ describe("invites.creator_value range", () => {
     });
     if ("error" in r) throw new Error("seed failed");
     await expectConstraintViolation(
-      db.update(invites).set({ creatorValue: 0 }).where(eq(invites.code, r.code)),
+      db.update(invites).set({ relationValue: 0 }).where(eq(invites.code, r.code)),
       "invites_creator_value_range",
     );
   });
@@ -197,7 +197,7 @@ describe("invites.creator_value range", () => {
     });
     if ("error" in r) throw new Error("seed failed");
     await expectConstraintViolation(
-      db.update(invites).set({ creatorValue: 5 }).where(eq(invites.code, r.code)),
+      db.update(invites).set({ relationValue: 5 }).where(eq(invites.code, r.code)),
       "invites_creator_value_range",
     );
   });
@@ -205,14 +205,14 @@ describe("invites.creator_value range", () => {
 
 describe("invite_hints table constraints", () => {
   let creatorId: string;
-  let rateeId: string;
+  let relateeId: string;
   let inviteId: string;
 
   beforeEach(async () => {
     creatorId = randomUUID();
-    rateeId = randomUUID();
+    relateeId = randomUUID();
     await insertUserAndProfile(creatorId);
-    await insertUserAndProfile(rateeId);
+    await insertUserAndProfile(relateeId);
     const r = await createInvite({
       createdBy: creatorId,
       note: "invite_hints constraint test invite",
@@ -225,27 +225,27 @@ describe("invite_hints table constraints", () => {
   afterEach(async () => {
     await db.delete(inviteHints).where(eq(inviteHints.inviteId, inviteId));
     await deleteUserAndProfile(creatorId);
-    await deleteUserAndProfile(rateeId);
+    await deleteUserAndProfile(relateeId);
   });
 
-  it("rejects duplicate (invite, ratee) pair (composite PK)", async () => {
-    await db.insert(inviteHints).values({ inviteId, rateeId });
-    await expect(db.insert(inviteHints).values({ inviteId, rateeId })).rejects.toThrow();
+  it("rejects duplicate (invite, relatee) pair (composite PK)", async () => {
+    await db.insert(inviteHints).values({ inviteId, relateeId });
+    await expect(db.insert(inviteHints).values({ inviteId, relateeId })).rejects.toThrow();
   });
 
-  it("permits the same ratee across different invites", async () => {
-    await db.insert(inviteHints).values({ inviteId, rateeId });
+  it("permits the same relatee across different invites", async () => {
+    await db.insert(inviteHints).values({ inviteId, relateeId });
     const r2 = await createInvite({
       createdBy: creatorId,
       note: "second invite for cross-invite hint",
     });
     if ("error" in r2) throw new Error("seed failed");
     const [row2] = await db.select({ id: invites.id }).from(invites).where(eq(invites.code, r2.code));
-    await db.insert(inviteHints).values({ inviteId: row2.id, rateeId });
+    await db.insert(inviteHints).values({ inviteId: row2.id, relateeId });
   });
 
   it("cascades to invite_hints when the invite is deleted", async () => {
-    await db.insert(inviteHints).values({ inviteId, rateeId });
+    await db.insert(inviteHints).values({ inviteId, relateeId });
     await db.delete(invites).where(eq(invites.id, inviteId));
     const remaining = await db.select().from(inviteHints).where(eq(inviteHints.inviteId, inviteId));
     expect(remaining).toHaveLength(0);

--- a/tests/functional/server/relations.test.ts
+++ b/tests/functional/server/relations.test.ts
@@ -12,7 +12,7 @@ import { createServerClient } from "@supabase/ssr";
 import app from "@/server/api";
 import { db } from "@/server/db";
 import { createInvite } from "@/server/invites";
-import { getCandidates, getSubgraph, materializeInviteRelations, rateMember } from "@/server/relations";
+import { getPersonalWeb, getRelationSuggestions, materializeInviteRelations, updateRelationValue } from "@/server/relations";
 import { inviteHints, invites, profiles, relations } from "@/server/schema";
 
 const mockCreateServerClient = vi.mocked(createServerClient);
@@ -51,46 +51,46 @@ const insertUserAndProfile = async (id: string, opts: { displayName?: string; is
 };
 
 const deleteUserAndProfile = async (id: string) => {
-  await db.delete(relations).where(eq(relations.raterId, id));
-  await db.delete(relations).where(eq(relations.rateeId, id));
+  await db.delete(relations).where(eq(relations.relatorId, id));
+  await db.delete(relations).where(eq(relations.relateeId, id));
   await db.delete(invites).where(eq(invites.createdBy, id));
   await db.delete(profiles).where(eq(profiles.id, id));
   await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
 };
 
-describe("rateMember", () => {
-  let raterId: string;
-  let rateeId: string;
+describe("updateRelationValue", () => {
+  let relatorId: string;
+  let relateeId: string;
 
   beforeEach(async () => {
-    raterId = randomUUID();
-    rateeId = randomUUID();
-    await insertUserAndProfile(raterId);
-    await insertUserAndProfile(rateeId);
+    relatorId = randomUUID();
+    relateeId = randomUUID();
+    await insertUserAndProfile(relatorId);
+    await insertUserAndProfile(relateeId);
   });
 
   afterEach(async () => {
-    await deleteUserAndProfile(raterId);
-    await deleteUserAndProfile(rateeId);
+    await deleteUserAndProfile(relatorId);
+    await deleteUserAndProfile(relateeId);
   });
 
   it("creates a confirmed rating row", async () => {
-    const r = await rateMember({ raterId, rateeId, value: 3 });
+    const r = await updateRelationValue({ relatorId, relateeId, value: 3 });
     expect(r).toEqual({ ok: true });
 
-    const [row] = await db.select().from(relations).where(eq(relations.raterId, raterId));
+    const [row] = await db.select().from(relations).where(eq(relations.relatorId, relatorId));
     expect(row.value).toBe(3);
     expect(row.isHint).toBe(false);
   });
 
   it("re-rating updates value and bumps updatedAt without changing the primary key", async () => {
-    await rateMember({ raterId, rateeId, value: 2 });
-    const [first] = await db.select().from(relations).where(eq(relations.raterId, raterId));
+    await updateRelationValue({ relatorId, relateeId, value: 2 });
+    const [first] = await db.select().from(relations).where(eq(relations.relatorId, relatorId));
 
     await new Promise((r) => setTimeout(r, 10));
-    await rateMember({ raterId, rateeId, value: 4 });
+    await updateRelationValue({ relatorId, relateeId, value: 4 });
 
-    const rows = await db.select().from(relations).where(eq(relations.raterId, raterId));
+    const rows = await db.select().from(relations).where(eq(relations.relatorId, relatorId));
     expect(rows).toHaveLength(1);
     expect(rows[0].value).toBe(4);
     expect(rows[0].updatedAt.getTime()).toBeGreaterThan(first.updatedAt.getTime());
@@ -101,17 +101,17 @@ describe("rateMember", () => {
     await insertUserAndProfile(hinterId);
     try {
       await db.insert(relations).values({
-        raterId,
-        rateeId,
+        relatorId,
+        relateeId,
         value: null,
         isHint: true,
         hintedBy: hinterId,
       });
 
-      const r = await rateMember({ raterId, rateeId, value: 2 });
+      const r = await updateRelationValue({ relatorId, relateeId, value: 2 });
       expect(r).toEqual({ ok: true });
 
-      const [row] = await db.select().from(relations).where(eq(relations.raterId, raterId));
+      const [row] = await db.select().from(relations).where(eq(relations.relatorId, relatorId));
       expect(row.value).toBe(2);
       expect(row.isHint).toBe(false);
       expect(row.hintedBy).toBe(hinterId);
@@ -121,17 +121,17 @@ describe("rateMember", () => {
   });
 
   it("rejects self-rating before hitting the DB constraint", async () => {
-    const r = await rateMember({ raterId, rateeId: raterId, value: 3 });
-    expect(r).toEqual({ error: "self_rating" });
+    const r = await updateRelationValue({ relatorId, relateeId: relatorId, value: 3 });
+    expect(r).toEqual({ error: "self_relating" });
   });
 
   it("rejects rating a non-existent ratee", async () => {
-    const r = await rateMember({ raterId, rateeId: randomUUID(), value: 3 });
-    expect(r).toEqual({ error: "ratee_not_found" });
+    const r = await updateRelationValue({ relatorId, relateeId: randomUUID(), value: 3 });
+    expect(r).toEqual({ error: "relatee_not_found" });
   });
 });
 
-describe("getCandidates", () => {
+describe("getRelationSuggestions", () => {
   let me: string;
 
   beforeEach(async () => {
@@ -144,7 +144,7 @@ describe("getCandidates", () => {
   });
 
   it("returns an empty feed for a fresh user with no signals", async () => {
-    const feed = await getCandidates(me);
+    const feed = await getRelationSuggestions(me);
     expect(feed.suggestions).toEqual([]);
     expect(feed.otherMembers).toEqual([]);
   });
@@ -153,8 +153,8 @@ describe("getCandidates", () => {
     const them = randomUUID();
     await insertUserAndProfile(them, { displayName: "Them" });
     try {
-      await rateMember({ raterId: them, rateeId: me, value: 4 });
-      const feed = await getCandidates(me);
+      await updateRelationValue({ relatorId: them, relateeId: me, value: 4 });
+      const feed = await getRelationSuggestions(me);
       expect(feed.suggestions).toHaveLength(1);
       expect(feed.suggestions[0].id).toBe(them);
       expect(feed.suggestions[0].reason).toEqual({ type: "ratedYou" });
@@ -169,9 +169,9 @@ describe("getCandidates", () => {
     const them = randomUUID();
     await insertUserAndProfile(them, { displayName: "Them" });
     try {
-      await rateMember({ raterId: them, rateeId: me, value: 3 });
-      await rateMember({ raterId: me, rateeId: them, value: 2 });
-      const feed = await getCandidates(me);
+      await updateRelationValue({ relatorId: them, relateeId: me, value: 3 });
+      await updateRelationValue({ relatorId: me, relateeId: them, value: 2 });
+      const feed = await getRelationSuggestions(me);
       expect(feed.suggestions).toEqual([]);
     } finally {
       await deleteUserAndProfile(them);
@@ -185,13 +185,13 @@ describe("getCandidates", () => {
     await insertUserAndProfile(hinter, { displayName: "Hinter" });
     try {
       await db.insert(relations).values({
-        raterId: me,
-        rateeId: target,
+        relatorId: me,
+        relateeId: target,
         value: null,
         isHint: true,
         hintedBy: hinter,
       });
-      const feed = await getCandidates(me);
+      const feed = await getRelationSuggestions(me);
       expect(feed.suggestions).toHaveLength(1);
       expect(feed.suggestions[0].id).toBe(target);
       expect(feed.suggestions[0].reason).toEqual({
@@ -213,10 +213,10 @@ describe("getCandidates", () => {
     await insertUserAndProfile(acquaintance, { displayName: "Acquaintance" });
     try {
       await db.update(profiles).set({ referredBy: inviter }).where(eq(profiles.id, me));
-      await rateMember({ raterId: inviter, rateeId: friend, value: 4 });
-      await rateMember({ raterId: inviter, rateeId: acquaintance, value: 2 });
+      await updateRelationValue({ relatorId: inviter, relateeId: friend, value: 4 });
+      await updateRelationValue({ relatorId: inviter, relateeId: acquaintance, value: 2 });
 
-      const feed = await getCandidates(me);
+      const feed = await getRelationSuggestions(me);
       // Suggestions empty (acquaintance value < 3 doesn't qualify).
       const ids = feed.otherMembers.map((c) => c.id);
       expect(ids).toContain(friend);
@@ -252,7 +252,7 @@ describe("getCandidates", () => {
         .set({ lastUpdatedWeb: sql`now() - interval '7 days'` })
         .where(eq(profiles.id, stale));
 
-      const feed = await getCandidates(me);
+      const feed = await getRelationSuggestions(me);
       const ids = feed.otherMembers.map((c) => c.id);
       expect(ids).toContain(recent);
       expect(ids).not.toContain(stale);
@@ -268,7 +268,7 @@ describe("getCandidates", () => {
     await insertUserAndProfile(them, { displayName: "Them" });
     try {
       // They rated me (source 1).
-      await rateMember({ raterId: them, rateeId: me, value: 4 });
+      await updateRelationValue({ relatorId: them, relateeId: me, value: 4 });
       // And they're recently active (source 4).
       await db
         .update(profiles)
@@ -279,7 +279,7 @@ describe("getCandidates", () => {
         .set({ lastUpdatedWeb: sql`now() - interval '1 day'` })
         .where(eq(profiles.id, me));
 
-      const feed = await getCandidates(me);
+      const feed = await getRelationSuggestions(me);
       const allCards = [...feed.suggestions, ...feed.otherMembers];
       const occurrences = allCards.filter((c) => c.id === them).length;
       expect(occurrences).toBe(1);
@@ -296,12 +296,12 @@ describe("getCandidates", () => {
       .update(profiles)
       .set({ lastUpdatedWeb: sql`now()` })
       .where(eq(profiles.id, me));
-    const feed = await getCandidates(me);
+    const feed = await getRelationSuggestions(me);
     expect([...feed.suggestions, ...feed.otherMembers].map((c) => c.id)).not.toContain(me);
   });
 });
 
-describe("getSubgraph", () => {
+describe("getPersonalWeb", () => {
   let center: string;
   let a: string;
   let b: string;
@@ -322,46 +322,46 @@ describe("getSubgraph", () => {
   });
 
   it("hops=1, outgoing only, no edges → just the center node", async () => {
-    const sub = await getSubgraph({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 1 });
+    const sub = await getPersonalWeb({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 1 });
     expect(sub.nodes.map((n) => n.id)).toEqual([center]);
     expect(sub.edges).toEqual([]);
   });
 
   it("hops=1, outgoing only — returns my ratings", async () => {
-    await rateMember({ raterId: center, rateeId: a, value: 3 });
-    await rateMember({ raterId: center, rateeId: b, value: 2 });
-    const sub = await getSubgraph({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 1 });
+    await updateRelationValue({ relatorId: center, relateeId: a, value: 3 });
+    await updateRelationValue({ relatorId: center, relateeId: b, value: 2 });
+    const sub = await getPersonalWeb({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 1 });
     expect(new Set(sub.nodes.map((n) => n.id))).toEqual(new Set([center, a, b]));
     expect(sub.edges).toHaveLength(2);
-    expect(sub.edges.every((e) => e.raterId === center)).toBe(true);
+    expect(sub.edges.every((e) => e.relatorId === center)).toBe(true);
   });
 
   it("hops=1, incoming only — returns ratings of me", async () => {
-    await rateMember({ raterId: a, rateeId: center, value: 3 });
-    const sub = await getSubgraph({ centerId: center, includeIncoming: true, includeOutgoing: false, hops: 1 });
+    await updateRelationValue({ relatorId: a, relateeId: center, value: 3 });
+    const sub = await getPersonalWeb({ centerId: center, includeIncoming: true, includeOutgoing: false, hops: 1 });
     expect(new Set(sub.nodes.map((n) => n.id))).toEqual(new Set([center, a]));
     expect(sub.edges).toHaveLength(1);
-    expect(sub.edges[0]).toMatchObject({ raterId: a, rateeId: center, value: 3 });
+    expect(sub.edges[0]).toMatchObject({ relatorId: a, relateeId: center, value: 3 });
   });
 
   it("paired counter-edges render asymmetry as two rows", async () => {
-    await rateMember({ raterId: center, rateeId: a, value: 3 });
-    await rateMember({ raterId: a, rateeId: center, value: 1 });
-    const sub = await getSubgraph({ centerId: center, includeIncoming: true, includeOutgoing: true, hops: 1 });
+    await updateRelationValue({ relatorId: center, relateeId: a, value: 3 });
+    await updateRelationValue({ relatorId: a, relateeId: center, value: 1 });
+    const sub = await getPersonalWeb({ centerId: center, includeIncoming: true, includeOutgoing: true, hops: 1 });
     expect(sub.edges).toHaveLength(2);
-    const values = sub.edges.map((e) => `${e.raterId === center ? "out" : "in"}:${e.value}`).sort();
+    const values = sub.edges.map((e) => `${e.relatorId === center ? "out" : "in"}:${e.value}`).sort();
     expect(values).toEqual(["in:1", "out:3"]);
   });
 
   it("filters out hint rows entirely", async () => {
     await db.insert(relations).values({
-      raterId: center,
-      rateeId: a,
+      relatorId: center,
+      relateeId: a,
       value: null,
       isHint: true,
       hintedBy: b,
     });
-    const sub = await getSubgraph({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 1 });
+    const sub = await getPersonalWeb({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 1 });
     expect(sub.edges).toEqual([]);
     expect(sub.nodes.map((n) => n.id)).toEqual([center]);
   });
@@ -370,19 +370,19 @@ describe("getSubgraph", () => {
     const c = randomUUID();
     await insertUserAndProfile(c, { displayName: "C" });
     try {
-      await rateMember({ raterId: center, rateeId: a, value: 3 });
-      await rateMember({ raterId: a, rateeId: c, value: 4 });
-      const sub = await getSubgraph({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 2 });
+      await updateRelationValue({ relatorId: center, relateeId: a, value: 3 });
+      await updateRelationValue({ relatorId: a, relateeId: c, value: 4 });
+      const sub = await getPersonalWeb({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 2 });
       const nodeIds = new Set(sub.nodes.map((n) => n.id));
       expect(nodeIds.has(c)).toBe(true);
-      expect(sub.edges.some((e) => e.raterId === a && e.rateeId === c)).toBe(true);
+      expect(sub.edges.some((e) => e.relatorId === a && e.relateeId === c)).toBe(true);
     } finally {
       await deleteUserAndProfile(c);
     }
   });
 
   it("renders gracefully at N=1 (just self, no edges)", async () => {
-    const sub = await getSubgraph({ centerId: center, includeIncoming: true, includeOutgoing: true, hops: 2 });
+    const sub = await getPersonalWeb({ centerId: center, includeIncoming: true, includeOutgoing: true, hops: 2 });
     expect(sub.nodes).toHaveLength(1);
     expect(sub.edges).toEqual([]);
   });
@@ -421,13 +421,13 @@ describe("materializeInviteRelations", () => {
       inviteId: row.id,
       inviterId: inviter,
       redeemerId: redeemer,
-      creatorValue: 3,
+      relationValue: 3,
     });
 
     const [rel] = await db
       .select()
       .from(relations)
-      .where(and(eq(relations.raterId, inviter), eq(relations.rateeId, redeemer)));
+      .where(and(eq(relations.relatorId, inviter), eq(relations.relateeId, redeemer)));
     expect(rel.value).toBe(3);
     expect(rel.isHint).toBe(false);
   });
@@ -447,16 +447,16 @@ describe("materializeInviteRelations", () => {
       inviteId: row.id,
       inviterId: inviter,
       redeemerId: redeemer,
-      creatorValue: null,
+      relationValue: null,
     });
 
-    const rels = await db.select().from(relations).where(eq(relations.raterId, redeemer));
+    const rels = await db.select().from(relations).where(eq(relations.relatorId, redeemer));
     expect(rels).toHaveLength(2);
     for (const rel of rels) {
       expect(rel.isHint).toBe(true);
       expect(rel.value).toBeNull();
       expect(rel.hintedBy).toBe(inviter);
-      expect([h1, h2]).toContain(rel.rateeId);
+      expect([h1, h2]).toContain(rel.relateeId);
     }
   });
 
@@ -469,13 +469,13 @@ describe("materializeInviteRelations", () => {
       inviteId: row.id,
       inviterId: inviter,
       redeemerId: redeemer,
-      creatorValue: null,
+      relationValue: null,
     });
 
     const rels = await db
       .select()
       .from(relations)
-      .where(eq(relations.raterId, redeemer));
+      .where(eq(relations.relatorId, redeemer));
     expect(rels).toEqual([]);
   });
 
@@ -484,18 +484,18 @@ describe("materializeInviteRelations", () => {
     if ("error" in r) throw new Error("seed failed");
     const [row] = await db.select({ id: invites.id }).from(invites).where(eq(invites.code, r.code));
     // Bypass the API validator to construct the pathological row.
-    await db.insert(inviteHints).values({ inviteId: row.id, rateeId: redeemer });
+    await db.insert(inviteHints).values({ inviteId: row.id, relateeId: redeemer });
 
     await expect(
       materializeInviteRelations(db, {
         inviteId: row.id,
         inviterId: inviter,
         redeemerId: redeemer,
-        creatorValue: null,
+        relationValue: null,
       }),
     ).resolves.toBeUndefined();
 
-    const rels = await db.select().from(relations).where(eq(relations.raterId, redeemer));
+    const rels = await db.select().from(relations).where(eq(relations.relatorId, redeemer));
     expect(rels).toEqual([]);
   });
 
@@ -514,18 +514,18 @@ describe("materializeInviteRelations", () => {
           inviteId: row.id,
           inviterId: inviter,
           redeemerId: redeemer,
-          creatorValue: 3,
+          relationValue: 3,
         });
         // Sanity: the rows are visible inside the open tx.
-        const inside = await tx.select().from(relations).where(eq(relations.rateeId, redeemer));
+        const inside = await tx.select().from(relations).where(eq(relations.relateeId, redeemer));
         expect(inside.length).toBeGreaterThan(0);
         throw new Error("simulated failure after materialization");
       }),
     ).rejects.toThrow("simulated failure");
 
     // After rollback, none of the materialized rows are visible.
-    const after = await db.select().from(relations).where(eq(relations.rateeId, redeemer));
-    const fromRedeemer = await db.select().from(relations).where(eq(relations.raterId, redeemer));
+    const after = await db.select().from(relations).where(eq(relations.relateeId, redeemer));
+    const fromRedeemer = await db.select().from(relations).where(eq(relations.relatorId, redeemer));
     expect(after).toEqual([]);
     expect(fromRedeemer).toEqual([]);
   });
@@ -539,15 +539,15 @@ describe("materializeInviteRelations", () => {
       inviteId: row.id,
       inviterId: null,
       redeemerId: redeemer,
-      creatorValue: 3,
+      relationValue: 3,
     });
 
-    const rels = await db.select().from(relations).where(eq(relations.rateeId, redeemer));
+    const rels = await db.select().from(relations).where(eq(relations.relateeId, redeemer));
     expect(rels).toEqual([]);
   });
 });
 
-describe("PUT /api/relations/:rateeId", () => {
+describe("PUT /api/relations/value/:relateeId", () => {
   let me: string;
   let other: string;
 
@@ -565,8 +565,8 @@ describe("PUT /api/relations/:rateeId", () => {
     await deleteUserAndProfile(other);
   });
 
-  const put = (rateeId: string, body: unknown) =>
-    app.request(`/api/relations/${rateeId}`, {
+  const put = (relateeId: string, body: unknown) =>
+    app.request(`/api/relations/value/${relateeId}`, {
       method: "PUT",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
@@ -576,7 +576,7 @@ describe("PUT /api/relations/:rateeId", () => {
     const res = await put(other, { value: 3 });
     expect(res.status).toBe(200);
 
-    const [row] = await db.select().from(relations).where(eq(relations.raterId, me));
+    const [row] = await db.select().from(relations).where(eq(relations.relatorId, me));
     expect(row.value).toBe(3);
   });
 
@@ -589,7 +589,7 @@ describe("PUT /api/relations/:rateeId", () => {
   it("rejects self-rating", async () => {
     const res = await put(me, { value: 3 });
     expect(res.status).toBe(400);
-    expect((await res.json()).error).toBe("self_rating");
+    expect((await res.json()).error).toBe("self_relating");
   });
 
   it("404s on non-existent ratee", async () => {
@@ -622,7 +622,7 @@ describe("GET /api/relations/candidates", () => {
   });
 
   it("returns the soft-hidden ratedYou attribution", async () => {
-    await rateMember({ raterId: them, rateeId: me, value: 4 });
+    await updateRelationValue({ relatorId: them, relateeId: me, value: 4 });
     const res = await app.request("/api/relations/candidates");
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -651,18 +651,18 @@ describe("GET /api/relations/subgraph", () => {
   });
 
   it("default returns my outgoing first-hop subgraph", async () => {
-    await rateMember({ raterId: me, rateeId: other, value: 2 });
+    await updateRelationValue({ relatorId: me, relateeId: other, value: 2 });
     const res = await app.request("/api/relations/subgraph");
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.centerId).toBe(me);
     expect(body.edges).toHaveLength(1);
-    expect(body.edges[0]).toMatchObject({ raterId: me, rateeId: other, value: 2 });
+    expect(body.edges[0]).toMatchObject({ relatorId: me, relateeId: other, value: 2 });
   });
 
   it("query params widen the view", async () => {
-    await rateMember({ raterId: me, rateeId: other, value: 2 });
-    await rateMember({ raterId: other, rateeId: me, value: 4 });
+    await updateRelationValue({ relatorId: me, relateeId: other, value: 2 });
+    await updateRelationValue({ relatorId: other, relateeId: me, value: 4 });
     const res = await app.request("/api/relations/subgraph?in=true&hops=1");
     const body = await res.json();
     expect(body.edges).toHaveLength(2);
@@ -673,17 +673,17 @@ describe("POST /api/relations/hint (admin-only)", () => {
   let admin: string;
   let nonAdmin: string;
   let target: string;
-  let rater: string;
+  let relator: string;
 
   beforeEach(async () => {
     admin = randomUUID();
     nonAdmin = randomUUID();
     target = randomUUID();
-    rater = randomUUID();
+    relator = randomUUID();
     await insertUserAndProfile(admin, { isAdmin: true });
     await insertUserAndProfile(nonAdmin);
     await insertUserAndProfile(target);
-    await insertUserAndProfile(rater);
+    await insertUserAndProfile(relator);
   });
 
   afterEach(async () => {
@@ -691,7 +691,7 @@ describe("POST /api/relations/hint (admin-only)", () => {
     await deleteUserAndProfile(admin);
     await deleteUserAndProfile(nonAdmin);
     await deleteUserAndProfile(target);
-    await deleteUserAndProfile(rater);
+    await deleteUserAndProfile(relator);
   });
 
   const post = (body: unknown) =>
@@ -703,9 +703,9 @@ describe("POST /api/relations/hint (admin-only)", () => {
 
   it("creates a hint when admin", async () => {
     authAs(admin);
-    const res = await post({ raterId: rater, rateeId: target });
+    const res = await post({ relatorId: relator, relateeId: target });
     expect(res.status).toBe(201);
-    const [row] = await db.select().from(relations).where(eq(relations.raterId, rater));
+    const [row] = await db.select().from(relations).where(eq(relations.relatorId, relator));
     expect(row.isHint).toBe(true);
     expect(row.value).toBeNull();
     expect(row.hintedBy).toBe(admin);
@@ -713,37 +713,37 @@ describe("POST /api/relations/hint (admin-only)", () => {
 
   it("403s when non-admin", async () => {
     authAs(nonAdmin);
-    const res = await post({ raterId: rater, rateeId: target });
+    const res = await post({ relatorId: relator, relateeId: target });
     expect(res.status).toBe(403);
   });
 
   it("400 on self-rating", async () => {
     authAs(admin);
-    const res = await post({ raterId: rater, rateeId: rater });
+    const res = await post({ relatorId: relator, relateeId: relator });
     expect(res.status).toBe(400);
   });
 
-  it("404 when rater or ratee profile missing", async () => {
+  it("404 when relator or relatee profile missing", async () => {
     authAs(admin);
-    const res = await post({ raterId: randomUUID(), rateeId: target });
+    const res = await post({ relatorId: randomUUID(), relateeId: target });
     expect(res.status).toBe(404);
   });
 });
 
-describe("DELETE /api/relations/hint/:raterId/:rateeId (admin-only)", () => {
+describe("DELETE /api/relations/hint/:relatorId/:relateeId (admin-only)", () => {
   let admin: string;
   let nonAdmin: string;
-  let rater: string;
+  let relator: string;
   let target: string;
 
   beforeEach(async () => {
     admin = randomUUID();
     nonAdmin = randomUUID();
-    rater = randomUUID();
+    relator = randomUUID();
     target = randomUUID();
     await insertUserAndProfile(admin, { isAdmin: true });
     await insertUserAndProfile(nonAdmin);
-    await insertUserAndProfile(rater);
+    await insertUserAndProfile(relator);
     await insertUserAndProfile(target);
   });
 
@@ -751,44 +751,44 @@ describe("DELETE /api/relations/hint/:raterId/:rateeId (admin-only)", () => {
     mockCreateServerClient.mockReset();
     await deleteUserAndProfile(admin);
     await deleteUserAndProfile(nonAdmin);
-    await deleteUserAndProfile(rater);
+    await deleteUserAndProfile(relator);
     await deleteUserAndProfile(target);
   });
 
   it("deletes a hint when admin", async () => {
     await db.insert(relations).values({
-      raterId: rater,
-      rateeId: target,
+      relatorId: relator,
+      relateeId: target,
       value: null,
       isHint: true,
       hintedBy: admin,
     });
     authAs(admin);
-    const res = await app.request(`/api/relations/hint/${rater}/${target}`, { method: "DELETE" });
+    const res = await app.request(`/api/relations/hint/${relator}/${target}`, { method: "DELETE" });
     expect(res.status).toBe(200);
-    const rows = await db.select().from(relations).where(eq(relations.raterId, rater));
+    const rows = await db.select().from(relations).where(eq(relations.relatorId, relator));
     expect(rows).toEqual([]);
   });
 
   it("refuses to delete a confirmed rating (404)", async () => {
-    await rateMember({ raterId: rater, rateeId: target, value: 3 });
+    await updateRelationValue({ relatorId: relator, relateeId: target, value: 3 });
     authAs(admin);
-    const res = await app.request(`/api/relations/hint/${rater}/${target}`, { method: "DELETE" });
+    const res = await app.request(`/api/relations/hint/${relator}/${target}`, { method: "DELETE" });
     expect(res.status).toBe(404);
-    const rows = await db.select().from(relations).where(eq(relations.raterId, rater));
+    const rows = await db.select().from(relations).where(eq(relations.relatorId, relator));
     expect(rows).toHaveLength(1);
   });
 
   it("403s when non-admin", async () => {
     await db.insert(relations).values({
-      raterId: rater,
-      rateeId: target,
+      relatorId: relator,
+      relateeId: target,
       value: null,
       isHint: true,
       hintedBy: admin,
     });
     authAs(nonAdmin);
-    const res = await app.request(`/api/relations/hint/${rater}/${target}`, { method: "DELETE" });
+    const res = await app.request(`/api/relations/hint/${relator}/${target}`, { method: "DELETE" });
     expect(res.status).toBe(403);
   });
 });

--- a/tests/functional/server/relations.test.ts
+++ b/tests/functional/server/relations.test.ts
@@ -1,0 +1,794 @@
+import { randomUUID } from "node:crypto";
+import type { User } from "@supabase/supabase-js";
+import { and, eq, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+import { createServerClient } from "@supabase/ssr";
+
+import app from "@/server/api";
+import { db } from "@/server/db";
+import { createInvite } from "@/server/invites";
+import { getCandidates, getSubgraph, materializeInviteRelations, rateMember } from "@/server/relations";
+import { inviteHints, invites, profiles, relations } from "@/server/schema";
+
+const mockCreateServerClient = vi.mocked(createServerClient);
+
+const fakeUser = (id: string): User =>
+  ({
+    id,
+    email: `${id}@testfake.local`,
+    user_metadata: {},
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+  }) as User;
+
+const authAs = (userId: string) => {
+  mockCreateServerClient.mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: fakeUser(userId) },
+        error: null,
+      }),
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test mock shape
+  } as any);
+};
+
+const insertUserAndProfile = async (id: string, opts: { displayName?: string; isAdmin?: boolean } = {}) => {
+  await db.execute(
+    sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${id}::uuid, ${`${id}@testfake.local`}, false, false)`,
+  );
+  await db.insert(profiles).values({
+    id,
+    displayName: opts.displayName ?? null,
+    isAdmin: opts.isAdmin ?? false,
+  });
+};
+
+const deleteUserAndProfile = async (id: string) => {
+  await db.delete(relations).where(eq(relations.raterId, id));
+  await db.delete(relations).where(eq(relations.rateeId, id));
+  await db.delete(invites).where(eq(invites.createdBy, id));
+  await db.delete(profiles).where(eq(profiles.id, id));
+  await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+};
+
+describe("rateMember", () => {
+  let raterId: string;
+  let rateeId: string;
+
+  beforeEach(async () => {
+    raterId = randomUUID();
+    rateeId = randomUUID();
+    await insertUserAndProfile(raterId);
+    await insertUserAndProfile(rateeId);
+  });
+
+  afterEach(async () => {
+    await deleteUserAndProfile(raterId);
+    await deleteUserAndProfile(rateeId);
+  });
+
+  it("creates a confirmed rating row", async () => {
+    const r = await rateMember({ raterId, rateeId, value: 3 });
+    expect(r).toEqual({ ok: true });
+
+    const [row] = await db.select().from(relations).where(eq(relations.raterId, raterId));
+    expect(row.value).toBe(3);
+    expect(row.isHint).toBe(false);
+  });
+
+  it("re-rating updates value and bumps updatedAt without changing the primary key", async () => {
+    await rateMember({ raterId, rateeId, value: 2 });
+    const [first] = await db.select().from(relations).where(eq(relations.raterId, raterId));
+
+    await new Promise((r) => setTimeout(r, 10));
+    await rateMember({ raterId, rateeId, value: 4 });
+
+    const rows = await db.select().from(relations).where(eq(relations.raterId, raterId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].value).toBe(4);
+    expect(rows[0].updatedAt.getTime()).toBeGreaterThan(first.updatedAt.getTime());
+  });
+
+  it("flips isHint to false on confirmation while preserving hintedBy", async () => {
+    const hinterId = randomUUID();
+    await insertUserAndProfile(hinterId);
+    try {
+      await db.insert(relations).values({
+        raterId,
+        rateeId,
+        value: null,
+        isHint: true,
+        hintedBy: hinterId,
+      });
+
+      const r = await rateMember({ raterId, rateeId, value: 2 });
+      expect(r).toEqual({ ok: true });
+
+      const [row] = await db.select().from(relations).where(eq(relations.raterId, raterId));
+      expect(row.value).toBe(2);
+      expect(row.isHint).toBe(false);
+      expect(row.hintedBy).toBe(hinterId);
+    } finally {
+      await deleteUserAndProfile(hinterId);
+    }
+  });
+
+  it("rejects self-rating before hitting the DB constraint", async () => {
+    const r = await rateMember({ raterId, rateeId: raterId, value: 3 });
+    expect(r).toEqual({ error: "self_rating" });
+  });
+
+  it("rejects rating a non-existent ratee", async () => {
+    const r = await rateMember({ raterId, rateeId: randomUUID(), value: 3 });
+    expect(r).toEqual({ error: "ratee_not_found" });
+  });
+});
+
+describe("getCandidates", () => {
+  let me: string;
+
+  beforeEach(async () => {
+    me = randomUUID();
+    await insertUserAndProfile(me, { displayName: "Me" });
+  });
+
+  afterEach(async () => {
+    await deleteUserAndProfile(me);
+  });
+
+  it("returns an empty feed for a fresh user with no signals", async () => {
+    const feed = await getCandidates(me);
+    expect(feed.suggestions).toEqual([]);
+    expect(feed.otherMembers).toEqual([]);
+  });
+
+  it("source 1 — surfaces people who rated me, without their value (soft-hide)", async () => {
+    const them = randomUUID();
+    await insertUserAndProfile(them, { displayName: "Them" });
+    try {
+      await rateMember({ raterId: them, rateeId: me, value: 4 });
+      const feed = await getCandidates(me);
+      expect(feed.suggestions).toHaveLength(1);
+      expect(feed.suggestions[0].id).toBe(them);
+      expect(feed.suggestions[0].reason).toEqual({ type: "ratedYou" });
+      // No value field anywhere on the card.
+      expect(JSON.stringify(feed.suggestions[0])).not.toContain('"value"');
+    } finally {
+      await deleteUserAndProfile(them);
+    }
+  });
+
+  it("source 1 — excludes anyone I've already rated", async () => {
+    const them = randomUUID();
+    await insertUserAndProfile(them, { displayName: "Them" });
+    try {
+      await rateMember({ raterId: them, rateeId: me, value: 3 });
+      await rateMember({ raterId: me, rateeId: them, value: 2 });
+      const feed = await getCandidates(me);
+      expect(feed.suggestions).toEqual([]);
+    } finally {
+      await deleteUserAndProfile(them);
+    }
+  });
+
+  it("source 2 — surfaces pending hints with hintedBy attribution", async () => {
+    const target = randomUUID();
+    const hinter = randomUUID();
+    await insertUserAndProfile(target, { displayName: "Target" });
+    await insertUserAndProfile(hinter, { displayName: "Hinter" });
+    try {
+      await db.insert(relations).values({
+        raterId: me,
+        rateeId: target,
+        value: null,
+        isHint: true,
+        hintedBy: hinter,
+      });
+      const feed = await getCandidates(me);
+      expect(feed.suggestions).toHaveLength(1);
+      expect(feed.suggestions[0].id).toBe(target);
+      expect(feed.suggestions[0].reason).toEqual({
+        type: "hint",
+        hintedBy: { id: hinter, displayName: "Hinter", slug: null },
+      });
+    } finally {
+      await deleteUserAndProfile(hinter);
+      await deleteUserAndProfile(target);
+    }
+  });
+
+  it("source 3 — surfaces my inviter's higher-rated connections via attribution", async () => {
+    const inviter = randomUUID();
+    const friend = randomUUID();
+    const acquaintance = randomUUID();
+    await insertUserAndProfile(inviter, { displayName: "Inviter" });
+    await insertUserAndProfile(friend, { displayName: "Friend" });
+    await insertUserAndProfile(acquaintance, { displayName: "Acquaintance" });
+    try {
+      await db.update(profiles).set({ referredBy: inviter }).where(eq(profiles.id, me));
+      await rateMember({ raterId: inviter, rateeId: friend, value: 4 });
+      await rateMember({ raterId: inviter, rateeId: acquaintance, value: 2 });
+
+      const feed = await getCandidates(me);
+      // Suggestions empty (acquaintance value < 3 doesn't qualify).
+      const ids = feed.otherMembers.map((c) => c.id);
+      expect(ids).toContain(friend);
+      expect(ids).not.toContain(acquaintance);
+      const friendCard = feed.otherMembers.find((c) => c.id === friend);
+      expect(friendCard?.reason).toEqual({
+        type: "viaInviter",
+        inviter: { id: inviter, displayName: "Inviter", slug: null },
+      });
+    } finally {
+      await deleteUserAndProfile(friend);
+      await deleteUserAndProfile(acquaintance);
+      await deleteUserAndProfile(inviter);
+    }
+  });
+
+  it("source 4 — surfaces members with last_updated_web more recent than mine", async () => {
+    const recent = randomUUID();
+    const stale = randomUUID();
+    await insertUserAndProfile(recent, { displayName: "Recent" });
+    await insertUserAndProfile(stale, { displayName: "Stale" });
+    try {
+      await db
+        .update(profiles)
+        .set({ lastUpdatedWeb: sql`now() - interval '1 day'` })
+        .where(eq(profiles.id, me));
+      await db
+        .update(profiles)
+        .set({ lastUpdatedWeb: sql`now()` })
+        .where(eq(profiles.id, recent));
+      await db
+        .update(profiles)
+        .set({ lastUpdatedWeb: sql`now() - interval '7 days'` })
+        .where(eq(profiles.id, stale));
+
+      const feed = await getCandidates(me);
+      const ids = feed.otherMembers.map((c) => c.id);
+      expect(ids).toContain(recent);
+      expect(ids).not.toContain(stale);
+      expect(feed.otherMembers.find((c) => c.id === recent)?.reason).toEqual({ type: "recentlyActive" });
+    } finally {
+      await deleteUserAndProfile(recent);
+      await deleteUserAndProfile(stale);
+    }
+  });
+
+  it("a single person never appears twice — highest-priority source wins", async () => {
+    const them = randomUUID();
+    await insertUserAndProfile(them, { displayName: "Them" });
+    try {
+      // They rated me (source 1).
+      await rateMember({ raterId: them, rateeId: me, value: 4 });
+      // And they're recently active (source 4).
+      await db
+        .update(profiles)
+        .set({ lastUpdatedWeb: sql`now()` })
+        .where(eq(profiles.id, them));
+      await db
+        .update(profiles)
+        .set({ lastUpdatedWeb: sql`now() - interval '1 day'` })
+        .where(eq(profiles.id, me));
+
+      const feed = await getCandidates(me);
+      const allCards = [...feed.suggestions, ...feed.otherMembers];
+      const occurrences = allCards.filter((c) => c.id === them).length;
+      expect(occurrences).toBe(1);
+      // Source 1 wins.
+      expect(feed.suggestions[0].id).toBe(them);
+      expect(feed.suggestions[0].reason).toEqual({ type: "ratedYou" });
+    } finally {
+      await deleteUserAndProfile(them);
+    }
+  });
+
+  it("excludes self under all sources", async () => {
+    await db
+      .update(profiles)
+      .set({ lastUpdatedWeb: sql`now()` })
+      .where(eq(profiles.id, me));
+    const feed = await getCandidates(me);
+    expect([...feed.suggestions, ...feed.otherMembers].map((c) => c.id)).not.toContain(me);
+  });
+});
+
+describe("getSubgraph", () => {
+  let center: string;
+  let a: string;
+  let b: string;
+
+  beforeEach(async () => {
+    center = randomUUID();
+    a = randomUUID();
+    b = randomUUID();
+    await insertUserAndProfile(center, { displayName: "Center" });
+    await insertUserAndProfile(a, { displayName: "A" });
+    await insertUserAndProfile(b, { displayName: "B" });
+  });
+
+  afterEach(async () => {
+    await deleteUserAndProfile(center);
+    await deleteUserAndProfile(a);
+    await deleteUserAndProfile(b);
+  });
+
+  it("hops=1, outgoing only, no edges → just the center node", async () => {
+    const sub = await getSubgraph({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 1 });
+    expect(sub.nodes.map((n) => n.id)).toEqual([center]);
+    expect(sub.edges).toEqual([]);
+  });
+
+  it("hops=1, outgoing only — returns my ratings", async () => {
+    await rateMember({ raterId: center, rateeId: a, value: 3 });
+    await rateMember({ raterId: center, rateeId: b, value: 2 });
+    const sub = await getSubgraph({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 1 });
+    expect(new Set(sub.nodes.map((n) => n.id))).toEqual(new Set([center, a, b]));
+    expect(sub.edges).toHaveLength(2);
+    expect(sub.edges.every((e) => e.raterId === center)).toBe(true);
+  });
+
+  it("hops=1, incoming only — returns ratings of me", async () => {
+    await rateMember({ raterId: a, rateeId: center, value: 3 });
+    const sub = await getSubgraph({ centerId: center, includeIncoming: true, includeOutgoing: false, hops: 1 });
+    expect(new Set(sub.nodes.map((n) => n.id))).toEqual(new Set([center, a]));
+    expect(sub.edges).toHaveLength(1);
+    expect(sub.edges[0]).toMatchObject({ raterId: a, rateeId: center, value: 3 });
+  });
+
+  it("paired counter-edges render asymmetry as two rows", async () => {
+    await rateMember({ raterId: center, rateeId: a, value: 3 });
+    await rateMember({ raterId: a, rateeId: center, value: 1 });
+    const sub = await getSubgraph({ centerId: center, includeIncoming: true, includeOutgoing: true, hops: 1 });
+    expect(sub.edges).toHaveLength(2);
+    const values = sub.edges.map((e) => `${e.raterId === center ? "out" : "in"}:${e.value}`).sort();
+    expect(values).toEqual(["in:1", "out:3"]);
+  });
+
+  it("filters out hint rows entirely", async () => {
+    await db.insert(relations).values({
+      raterId: center,
+      rateeId: a,
+      value: null,
+      isHint: true,
+      hintedBy: b,
+    });
+    const sub = await getSubgraph({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 1 });
+    expect(sub.edges).toEqual([]);
+    expect(sub.nodes.map((n) => n.id)).toEqual([center]);
+  });
+
+  it("hops=2 includes second-degree neighbors and their edges", async () => {
+    const c = randomUUID();
+    await insertUserAndProfile(c, { displayName: "C" });
+    try {
+      await rateMember({ raterId: center, rateeId: a, value: 3 });
+      await rateMember({ raterId: a, rateeId: c, value: 4 });
+      const sub = await getSubgraph({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 2 });
+      const nodeIds = new Set(sub.nodes.map((n) => n.id));
+      expect(nodeIds.has(c)).toBe(true);
+      expect(sub.edges.some((e) => e.raterId === a && e.rateeId === c)).toBe(true);
+    } finally {
+      await deleteUserAndProfile(c);
+    }
+  });
+
+  it("renders gracefully at N=1 (just self, no edges)", async () => {
+    const sub = await getSubgraph({ centerId: center, includeIncoming: true, includeOutgoing: true, hops: 2 });
+    expect(sub.nodes).toHaveLength(1);
+    expect(sub.edges).toEqual([]);
+  });
+});
+
+describe("materializeInviteRelations", () => {
+  let inviter: string;
+  let redeemer: string;
+  let h1: string;
+  let h2: string;
+
+  beforeEach(async () => {
+    inviter = randomUUID();
+    redeemer = randomUUID();
+    h1 = randomUUID();
+    h2 = randomUUID();
+    await insertUserAndProfile(inviter, { displayName: "Inviter" });
+    await insertUserAndProfile(redeemer, { displayName: "Redeemer" });
+    await insertUserAndProfile(h1, { displayName: "H1" });
+    await insertUserAndProfile(h2, { displayName: "H2" });
+  });
+
+  afterEach(async () => {
+    await deleteUserAndProfile(inviter);
+    await deleteUserAndProfile(redeemer);
+    await deleteUserAndProfile(h1);
+    await deleteUserAndProfile(h2);
+  });
+
+  it("inserts a confirmed inviter→redeemer rating from creator_value", async () => {
+    const r = await createInvite({ createdBy: inviter, note: "creator value materialization" });
+    if ("error" in r) throw new Error("seed failed");
+    const [row] = await db.select({ id: invites.id }).from(invites).where(eq(invites.code, r.code));
+
+    await materializeInviteRelations(db, {
+      inviteId: row.id,
+      inviterId: inviter,
+      redeemerId: redeemer,
+      creatorValue: 3,
+    });
+
+    const [rel] = await db
+      .select()
+      .from(relations)
+      .where(and(eq(relations.raterId, inviter), eq(relations.rateeId, redeemer)));
+    expect(rel.value).toBe(3);
+    expect(rel.isHint).toBe(false);
+  });
+
+  it("inserts pending hint rows for each invite_hints row, redeemer→ratee, hintedBy=inviter", async () => {
+    const r = await createInvite({
+      createdBy: inviter,
+      note: "hint materialization happy path",
+      hints: [h1, h2],
+    });
+    if ("error" in r) throw new Error("seed failed");
+    expect(r.hintCount).toBe(2);
+
+    const [row] = await db.select({ id: invites.id }).from(invites).where(eq(invites.code, r.code));
+
+    await materializeInviteRelations(db, {
+      inviteId: row.id,
+      inviterId: inviter,
+      redeemerId: redeemer,
+      creatorValue: null,
+    });
+
+    const rels = await db.select().from(relations).where(eq(relations.raterId, redeemer));
+    expect(rels).toHaveLength(2);
+    for (const rel of rels) {
+      expect(rel.isHint).toBe(true);
+      expect(rel.value).toBeNull();
+      expect(rel.hintedBy).toBe(inviter);
+      expect([h1, h2]).toContain(rel.rateeId);
+    }
+  });
+
+  it("does nothing when creator_value is null and there are no hints", async () => {
+    const r = await createInvite({ createdBy: inviter, note: "no materialization payload" });
+    if ("error" in r) throw new Error("seed failed");
+    const [row] = await db.select({ id: invites.id }).from(invites).where(eq(invites.code, r.code));
+
+    await materializeInviteRelations(db, {
+      inviteId: row.id,
+      inviterId: inviter,
+      redeemerId: redeemer,
+      creatorValue: null,
+    });
+
+    const rels = await db
+      .select()
+      .from(relations)
+      .where(eq(relations.raterId, redeemer));
+    expect(rels).toEqual([]);
+  });
+
+  it("skips hint rows that point at the redeemer (no relations_no_self violation)", async () => {
+    const r = await createInvite({ createdBy: inviter, note: "self-hint defensive skip" });
+    if ("error" in r) throw new Error("seed failed");
+    const [row] = await db.select({ id: invites.id }).from(invites).where(eq(invites.code, r.code));
+    // Bypass the API validator to construct the pathological row.
+    await db.insert(inviteHints).values({ inviteId: row.id, rateeId: redeemer });
+
+    await expect(
+      materializeInviteRelations(db, {
+        inviteId: row.id,
+        inviterId: inviter,
+        redeemerId: redeemer,
+        creatorValue: null,
+      }),
+    ).resolves.toBeUndefined();
+
+    const rels = await db.select().from(relations).where(eq(relations.raterId, redeemer));
+    expect(rels).toEqual([]);
+  });
+
+  it("rolls back materialized rows when the surrounding transaction fails", async () => {
+    const r = await createInvite({
+      createdBy: inviter,
+      note: "atomic rollback verification",
+      hints: [h1, h2],
+    });
+    if ("error" in r) throw new Error("seed failed");
+    const [row] = await db.select({ id: invites.id }).from(invites).where(eq(invites.code, r.code));
+
+    await expect(
+      db.transaction(async (tx) => {
+        await materializeInviteRelations(tx, {
+          inviteId: row.id,
+          inviterId: inviter,
+          redeemerId: redeemer,
+          creatorValue: 3,
+        });
+        // Sanity: the rows are visible inside the open tx.
+        const inside = await tx.select().from(relations).where(eq(relations.rateeId, redeemer));
+        expect(inside.length).toBeGreaterThan(0);
+        throw new Error("simulated failure after materialization");
+      }),
+    ).rejects.toThrow("simulated failure");
+
+    // After rollback, none of the materialized rows are visible.
+    const after = await db.select().from(relations).where(eq(relations.rateeId, redeemer));
+    const fromRedeemer = await db.select().from(relations).where(eq(relations.raterId, redeemer));
+    expect(after).toEqual([]);
+    expect(fromRedeemer).toEqual([]);
+  });
+
+  it("skips creator_value materialization when inviterId is null", async () => {
+    const r = await createInvite({ createdBy: inviter, note: "null inviter materialization" });
+    if ("error" in r) throw new Error("seed failed");
+    const [row] = await db.select({ id: invites.id }).from(invites).where(eq(invites.code, r.code));
+
+    await materializeInviteRelations(db, {
+      inviteId: row.id,
+      inviterId: null,
+      redeemerId: redeemer,
+      creatorValue: 3,
+    });
+
+    const rels = await db.select().from(relations).where(eq(relations.rateeId, redeemer));
+    expect(rels).toEqual([]);
+  });
+});
+
+describe("PUT /api/relations/:rateeId", () => {
+  let me: string;
+  let other: string;
+
+  beforeEach(async () => {
+    me = randomUUID();
+    other = randomUUID();
+    await insertUserAndProfile(me);
+    await insertUserAndProfile(other);
+    authAs(me);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(me);
+    await deleteUserAndProfile(other);
+  });
+
+  const put = (rateeId: string, body: unknown) =>
+    app.request(`/api/relations/${rateeId}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  it("rates a member and returns 200", async () => {
+    const res = await put(other, { value: 3 });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(relations).where(eq(relations.raterId, me));
+    expect(row.value).toBe(3);
+  });
+
+  it("rejects value outside 1..4", async () => {
+    expect((await put(other, { value: 0 })).status).toBe(400);
+    expect((await put(other, { value: 5 })).status).toBe(400);
+    expect((await put(other, { value: "3" })).status).toBe(400);
+  });
+
+  it("rejects self-rating", async () => {
+    const res = await put(me, { value: 3 });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("self_rating");
+  });
+
+  it("404s on non-existent ratee", async () => {
+    const res = await put(randomUUID(), { value: 3 });
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects malformed UUID in path", async () => {
+    const res = await put("not-a-uuid", { value: 3 });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/relations/candidates", () => {
+  let me: string;
+  let them: string;
+
+  beforeEach(async () => {
+    me = randomUUID();
+    them = randomUUID();
+    await insertUserAndProfile(me);
+    await insertUserAndProfile(them, { displayName: "Them" });
+    authAs(me);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(me);
+    await deleteUserAndProfile(them);
+  });
+
+  it("returns the soft-hidden ratedYou attribution", async () => {
+    await rateMember({ raterId: them, rateeId: me, value: 4 });
+    const res = await app.request("/api/relations/candidates");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.suggestions).toHaveLength(1);
+    expect(body.suggestions[0].reason).toEqual({ type: "ratedYou" });
+    expect(JSON.stringify(body)).not.toContain('"value"');
+  });
+});
+
+describe("GET /api/relations/subgraph", () => {
+  let me: string;
+  let other: string;
+
+  beforeEach(async () => {
+    me = randomUUID();
+    other = randomUUID();
+    await insertUserAndProfile(me);
+    await insertUserAndProfile(other, { displayName: "Other" });
+    authAs(me);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(me);
+    await deleteUserAndProfile(other);
+  });
+
+  it("default returns my outgoing first-hop subgraph", async () => {
+    await rateMember({ raterId: me, rateeId: other, value: 2 });
+    const res = await app.request("/api/relations/subgraph");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.centerId).toBe(me);
+    expect(body.edges).toHaveLength(1);
+    expect(body.edges[0]).toMatchObject({ raterId: me, rateeId: other, value: 2 });
+  });
+
+  it("query params widen the view", async () => {
+    await rateMember({ raterId: me, rateeId: other, value: 2 });
+    await rateMember({ raterId: other, rateeId: me, value: 4 });
+    const res = await app.request("/api/relations/subgraph?in=true&hops=1");
+    const body = await res.json();
+    expect(body.edges).toHaveLength(2);
+  });
+});
+
+describe("POST /api/relations/hint (admin-only)", () => {
+  let admin: string;
+  let nonAdmin: string;
+  let target: string;
+  let rater: string;
+
+  beforeEach(async () => {
+    admin = randomUUID();
+    nonAdmin = randomUUID();
+    target = randomUUID();
+    rater = randomUUID();
+    await insertUserAndProfile(admin, { isAdmin: true });
+    await insertUserAndProfile(nonAdmin);
+    await insertUserAndProfile(target);
+    await insertUserAndProfile(rater);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(admin);
+    await deleteUserAndProfile(nonAdmin);
+    await deleteUserAndProfile(target);
+    await deleteUserAndProfile(rater);
+  });
+
+  const post = (body: unknown) =>
+    app.request("/api/relations/hint", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  it("creates a hint when admin", async () => {
+    authAs(admin);
+    const res = await post({ raterId: rater, rateeId: target });
+    expect(res.status).toBe(201);
+    const [row] = await db.select().from(relations).where(eq(relations.raterId, rater));
+    expect(row.isHint).toBe(true);
+    expect(row.value).toBeNull();
+    expect(row.hintedBy).toBe(admin);
+  });
+
+  it("403s when non-admin", async () => {
+    authAs(nonAdmin);
+    const res = await post({ raterId: rater, rateeId: target });
+    expect(res.status).toBe(403);
+  });
+
+  it("400 on self-rating", async () => {
+    authAs(admin);
+    const res = await post({ raterId: rater, rateeId: rater });
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when rater or ratee profile missing", async () => {
+    authAs(admin);
+    const res = await post({ raterId: randomUUID(), rateeId: target });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /api/relations/hint/:raterId/:rateeId (admin-only)", () => {
+  let admin: string;
+  let nonAdmin: string;
+  let rater: string;
+  let target: string;
+
+  beforeEach(async () => {
+    admin = randomUUID();
+    nonAdmin = randomUUID();
+    rater = randomUUID();
+    target = randomUUID();
+    await insertUserAndProfile(admin, { isAdmin: true });
+    await insertUserAndProfile(nonAdmin);
+    await insertUserAndProfile(rater);
+    await insertUserAndProfile(target);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(admin);
+    await deleteUserAndProfile(nonAdmin);
+    await deleteUserAndProfile(rater);
+    await deleteUserAndProfile(target);
+  });
+
+  it("deletes a hint when admin", async () => {
+    await db.insert(relations).values({
+      raterId: rater,
+      rateeId: target,
+      value: null,
+      isHint: true,
+      hintedBy: admin,
+    });
+    authAs(admin);
+    const res = await app.request(`/api/relations/hint/${rater}/${target}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+    const rows = await db.select().from(relations).where(eq(relations.raterId, rater));
+    expect(rows).toEqual([]);
+  });
+
+  it("refuses to delete a confirmed rating (404)", async () => {
+    await rateMember({ raterId: rater, rateeId: target, value: 3 });
+    authAs(admin);
+    const res = await app.request(`/api/relations/hint/${rater}/${target}`, { method: "DELETE" });
+    expect(res.status).toBe(404);
+    const rows = await db.select().from(relations).where(eq(relations.raterId, rater));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("403s when non-admin", async () => {
+    await db.insert(relations).values({
+      raterId: rater,
+      rateeId: target,
+      value: null,
+      isHint: true,
+      hintedBy: admin,
+    });
+    authAs(nonAdmin);
+    const res = await app.request(`/api/relations/hint/${rater}/${target}`, { method: "DELETE" });
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary

PR 2 of the four-PR Relations ship (see `docs/design-relations.md` and `docs/plan-relations.md`).

- New `/api/relations/*` routes: candidate feed (server-side soft-hide), personal subgraph (in/out/hops toggles), member-rate (creates or re-rates; flips a pending hint to confirmed), admin-only hint create + delete.
- `POST /api/invites` extended to accept `creatorValue` (1..4) and `hints[]` (member ids). Validation rejects self/duplicate/non-member/>10 hints. Invite + hints inserted in one transaction.
- Auth callback redemption transaction now also materializes a confirmed inviter→redeemer rating from `creator_value` and pending redeemer→ratee hints from `invite_hints`. Atomic — partial failures roll the consumed invite back.

No UI yet — that's PR 3.

## Test plan

- [x] `npx vitest run tests/functional/server/relations.test.ts` — 41 cases covering candidate ordering, source dedup, soft-hide, subgraph toggles, hint→confirmed transition, re-rating, redemption atomicity (rollback test), admin gate.
- [x] `npx vitest run tests/functional/server/invites.test.ts` — 27 cases including 6 new ones for creatorValue/hints validation.
- [x] `npm run lint` — clean (warnings only, all pre-existing).
- [x] `npm run typecheck` — clean.
- [x] Full functional suite — 126 passed.
- [x] Playwright e2e — 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)