### PR TITLE
Admin page scaffold + /api/admin/* sub-router

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-10 | James | Admin page scaffold + `/api/admin/*` sub-router
+
+`/admin` is a hub for admin-only stuff; non-admins get `notFound()`. Admin endpoints live behind a `requireAdmin` middleware in a `/api/admin/*` sub-router that 404s for non-admins. Future real settings will likely come from an `app_settings` table read by `getAppSettings()`.
+
 ## 2026-05-09 | James | Relations PRs 2 & 3 of the Relations ship
 
 `/myweb` is live: WebGraph (`@xyflow/react` + `d3-force`) over a Hono RPC backend, with a WebBuilder list of people (with four types of suggestions sorted to the front) and a dialog to set relationship strength.

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { requireUser, serverApiClient } from "@/lib/api-server";
+
+export default async function AdminPage() {
+  const me = await requireUser();
+  // Generic 404 for non-admins so the page doesn't advertise itself.
+  if (!me.profile?.isAdmin) notFound();
+
+  const res = await serverApiClient.api.admin.appsettings.$get();
+  if (!res.ok) throw new Error(`Failed to load app settings: ${res.status}`);
+  const { appSettings } = await res.json();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <div className="flex w-full max-w-xl items-center justify-between">
+        <h1 className="text-2xl font-bold">Admin</h1>
+        <Link href="/" className="text-base text-muted-foreground hover:text-foreground">
+          ← Back
+        </Link>
+      </div>
+
+      <section className="flex w-full max-w-xl flex-col gap-2">
+        <h2 className="text-lg font-semibold">App settings</h2>
+        {Object.keys(appSettings).length === 0 ? (
+          <p className="text-sm text-muted-foreground">No settings yet.</p>
+        ) : (
+          <pre className="rounded border border-border bg-muted/50 p-3 text-xs">
+            {JSON.stringify(appSettings, null, 2)}
+          </pre>
+        )}
+      </section>
+
+      <section className="flex w-full max-w-xl flex-col gap-2">
+        <h2 className="text-lg font-semibold">Programs</h2>
+        <p className="text-sm text-muted-foreground">Coming soon.</p>
+      </section>
+
+      <section className="flex w-full max-w-xl flex-col gap-2">
+        <h2 className="text-lg font-semibold">Web</h2>
+        <p className="text-sm text-muted-foreground">Coming soon.</p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,7 +44,7 @@ export default async function RootLayout({
       <body className="antialiased">
         <AuthProvider initialUser={user}>
           <QueryProvider>
-            <SiteHeader displayName={me?.profile?.displayName ?? null} />
+            <SiteHeader displayName={me?.profile?.displayName ?? null} isAdmin={me?.profile?.isAdmin ?? false} />
             {children}
           </QueryProvider>
         </AuthProvider>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "@/components/auth-provider";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 
-export function SiteHeader({ displayName }: { displayName: string | null }) {
+export function SiteHeader({ displayName, isAdmin }: { displayName: string | null; isAdmin: boolean }) {
   const { user } = useAuth();
 
   if (!user) return null;
@@ -56,6 +56,16 @@ export function SiteHeader({ displayName }: { displayName: string | null }) {
                 </Link>
               }
             />
+            {isAdmin ? (
+              <SheetClose
+                nativeButton={false}
+                render={
+                  <Link href="/admin" className="rounded px-2 py-2 hover:bg-muted">
+                    Admin
+                  </Link>
+                }
+              />
+            ) : null}
             <form action="/signout" method="post">
               <SheetClose
                 render={

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -5,7 +5,8 @@ import { log } from "next-axiom";
 
 import { isRelationValue } from "@/lib/relation-value";
 
-import { type ApiVariables, isAdmin, isUuid, requireAuth } from "./auth-middleware";
+import { getAppSettings } from "./app-settings";
+import { type ApiVariables, isAdmin, isUuid, requireAdmin, requireAuth } from "./auth-middleware";
 import { db } from "./db";
 import { checkInvite, createInvite, getInvitesForCreator, revokeInvite, validateNote } from "./invites";
 import {
@@ -28,6 +29,18 @@ import {
 } from "./relations";
 import { profiles } from "./schema";
 import { resetE2EUsers } from "./test-reset";
+
+// Admin-only sub-router. requireAdmin runs after the main api's
+// requireAuth (mounted via .route() below), so handlers here can
+// assume both an authenticated user and isAdmin === true. New admin
+// endpoints (e.g. api/admin/programs, api/admin/web) live here.
+// "appsettings" leaves room for "usersettings" elsewhere later.
+const adminRoutes = new Hono<{ Variables: ApiVariables }>()
+  .use("*", requireAdmin)
+  .get("/appsettings", async (c) => {
+    const appSettings = await getAppSettings();
+    return c.json({ appSettings });
+  });
 
 const api = new Hono<{ Variables: ApiVariables }>()
   .basePath("/api")
@@ -265,8 +278,10 @@ const api = new Hono<{ Variables: ApiVariables }>()
   )
   .post("/relations/hint", async (c) => {
     const user = c.get("user");
+    // Generic 404 — same rationale as /api/admin/*: don't advertise
+    // the admin surface to non-admins.
     if (!(await isAdmin(user.id))) {
-      return c.json({ error: "forbidden" }, 403);
+      return c.json({ error: "not_found" }, 404);
     }
 
     let body: unknown;
@@ -293,7 +308,7 @@ const api = new Hono<{ Variables: ApiVariables }>()
   .delete("/relations/hint/:relatorId/:relateeId", async (c) => {
     const user = c.get("user");
     if (!(await isAdmin(user.id))) {
-      return c.json({ error: "forbidden" }, 403);
+      return c.json({ error: "not_found" }, 404);
     }
 
     const relatorId = c.req.param("relatorId");
@@ -317,7 +332,8 @@ const api = new Hono<{ Variables: ApiVariables }>()
         serverTime: result[0].server_time,
       },
     });
-  });
+  })
+  .route("/admin", adminRoutes);
 
 // CI-only reset for the two seeded e2e users. Token header is the only
 // gate — preview and prod share the same Supabase, so a VERCEL_ENV gate

--- a/src/server/app-settings.ts
+++ b/src/server/app-settings.ts
@@ -1,0 +1,13 @@
+// App-wide settings, admin-managed. Mocked for now — when the first
+// real setting lands it'll come from an `app_settings` table (single
+// row, or keyed by name) and this function will read from it. The
+// shape stays `Record<string, unknown>` until the schema is concrete,
+// so callers (the /admin page, future setters) don't grow a brittle
+// interface against a placeholder. User-scoped settings will live
+// alongside in their own module.
+
+export type AppSettings = Record<string, unknown>;
+
+export const getAppSettings = async (): Promise<AppSettings> => {
+  return {};
+};

--- a/src/server/auth-middleware.ts
+++ b/src/server/auth-middleware.ts
@@ -25,6 +25,18 @@ export const isAdmin = async (userId: string): Promise<boolean> => {
   return row?.isAdmin ?? false;
 };
 
+// Admin-only gate for the /api/admin/* sub-router. Runs after
+// requireAuth, so c.get("user") is always populated. Returns 404
+// rather than 403 so the surface isn't advertised to non-admins —
+// matches the /admin page's notFound() behavior.
+export const requireAdmin: MiddlewareHandler<{ Variables: ApiVariables }> = async (c, next) => {
+  const user = c.get("user");
+  if (!(await isAdmin(user.id))) {
+    return c.json({ error: "not_found" }, 404);
+  }
+  return next();
+};
+
 // Routes that bypass auth. Keep this tight — the regression guard in
 // auth-middleware.test.ts asserts nothing else is public.
 // Strings are matched exactly; RegExps are tested against c.req.path.

--- a/tests/functional/client/site-header.test.tsx
+++ b/tests/functional/client/site-header.test.tsx
@@ -22,7 +22,7 @@ describe("SiteHeader", () => {
   it("renders nothing when there is no user", () => {
     const { container } = render(
       <AuthProvider initialUser={null}>
-        <SiteHeader displayName={null} />
+        <SiteHeader displayName={null} isAdmin={false} />
       </AuthProvider>,
     );
     expect(container).toBeEmptyDOMElement();
@@ -31,7 +31,7 @@ describe("SiteHeader", () => {
   it("renders the menu trigger when a user is present", () => {
     render(
       <AuthProvider initialUser={user}>
-        <SiteHeader displayName={null} />
+        <SiteHeader displayName={null} isAdmin={false} />
       </AuthProvider>,
     );
     expect(screen.getByRole("button", { name: /open menu/i })).toBeVisible();
@@ -41,11 +41,32 @@ describe("SiteHeader", () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     render(
       <AuthProvider initialUser={user}>
-        <SiteHeader displayName={null} />
+        <SiteHeader displayName={null} isAdmin={false} />
       </AuthProvider>,
     );
     fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
     expect(await screen.findByText("Home")).toBeVisible();
     expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it("hides the Admin link when isAdmin is false", async () => {
+    render(
+      <AuthProvider initialUser={user}>
+        <SiteHeader displayName={null} isAdmin={false} />
+      </AuthProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
+    await screen.findByText("Home");
+    expect(screen.queryByText("Admin")).toBeNull();
+  });
+
+  it("shows the Admin link when isAdmin is true", async () => {
+    render(
+      <AuthProvider initialUser={user}>
+        <SiteHeader displayName={null} isAdmin={true} />
+      </AuthProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
+    expect(await screen.findByText("Admin")).toBeVisible();
   });
 });

--- a/tests/functional/server/admin.test.ts
+++ b/tests/functional/server/admin.test.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from "node:crypto";
+import type { User } from "@supabase/supabase-js";
+import { eq, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+import { createServerClient } from "@supabase/ssr";
+
+import app from "@/server/api";
+import { db } from "@/server/db";
+import { profiles } from "@/server/schema";
+
+const mockCreateServerClient = vi.mocked(createServerClient);
+
+const fakeUser = (id: string): User =>
+  ({
+    id,
+    email: `${id}@testfake.local`,
+    user_metadata: {},
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+  }) as User;
+
+const authAs = (userId: string | null) => {
+  mockCreateServerClient.mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? fakeUser(userId) : null },
+        error: null,
+      }),
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test mock shape
+  } as any);
+};
+
+const insertUserAndProfile = async (id: string, opts: { isAdmin?: boolean } = {}) => {
+  await db.execute(
+    sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${id}::uuid, ${`${id}@testfake.local`}, false, false)`,
+  );
+  await db.insert(profiles).values({ id, isAdmin: opts.isAdmin ?? false });
+};
+
+const deleteUserAndProfile = async (id: string) => {
+  await db.delete(profiles).where(eq(profiles.id, id));
+  await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+};
+
+describe("GET /api/admin/appsettings", () => {
+  let admin: string;
+  let nonAdmin: string;
+
+  beforeEach(async () => {
+    admin = randomUUID();
+    nonAdmin = randomUUID();
+    await insertUserAndProfile(admin, { isAdmin: true });
+    await insertUserAndProfile(nonAdmin);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(admin);
+    await deleteUserAndProfile(nonAdmin);
+  });
+
+  it("returns settings for an admin", async () => {
+    authAs(admin);
+    const res = await app.request("/api/admin/appsettings");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ appSettings: {} });
+  });
+
+  it("returns 404 for an authenticated non-admin", async () => {
+    authAs(nonAdmin);
+    const res = await app.request("/api/admin/appsettings");
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not_found" });
+  });
+
+  it("returns 401 when no session is present", async () => {
+    authAs(null);
+    const res = await app.request("/api/admin/appsettings");
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/functional/server/relations.test.ts
+++ b/tests/functional/server/relations.test.ts
@@ -718,10 +718,10 @@ describe("POST /api/relations/hint (admin-only)", () => {
     expect(row.hintedBy).toBe(admin);
   });
 
-  it("403s when non-admin", async () => {
+  it("404s when non-admin", async () => {
     authAs(nonAdmin);
     const res = await post({ relatorId: relator, relateeId: target });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
   });
 
   it("400 on self-rating", async () => {
@@ -786,7 +786,7 @@ describe("DELETE /api/relations/hint/:relatorId/:relateeId (admin-only)", () => 
     expect(rows).toHaveLength(1);
   });
 
-  it("403s when non-admin", async () => {
+  it("404s when non-admin", async () => {
     await db.insert(relations).values({
       relatorId: relator,
       relateeId: target,
@@ -796,6 +796,6 @@ describe("DELETE /api/relations/hint/:relatorId/:relateeId (admin-only)", () => 
     });
     authAs(nonAdmin);
     const res = await app.request(`/api/relations/hint/${relator}/${target}`, { method: "DELETE" });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
Closes #143.

## Summary
- `/admin` page (hub: App settings / Programs / Web sections; Programs and Web are stubs). `notFound()` for non-admins.
- New `/api/admin/*` sub-router behind a `requireAdmin` middleware that returns 404 (not 403) so the surface isn't advertised. First endpoint: `GET /api/admin/appsettings` — `appsettings` (not `settings`) leaves room for a future `usersettings` namespace.
- `getAppSettings()` is mocked; first real setting will read from an `app_settings` table.
- `/api/relations/hint` POST/DELETE migrated 403 → 404 for consistency with the new admin pattern.
- Nav shows an "Admin" link only when `me.profile.isAdmin` (already in `/api/me`'s self shape).

## Test plan
- [x] `npm run test:functional` — 132 pass (new `tests/functional/server/admin.test.ts` covers admin/non-admin/unauthed; relations.test.ts updated).
- [x] `npm run test:e2e` — 16 pass.
- [x] Sanity-check on preview: signed-in admin sees "Admin" in the menu and loads `/admin`; non-admin gets a 404 visiting the URL directly and doesn't see the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)