### PR TITLE
Restore tsconfig jsx: react-jsx for Next 16

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary

- Next 16 requires the automatic JSX runtime (`"jsx": "react-jsx"`) and rewrites tsconfig.json on every dev start when it's set to anything else.
- PR #146 (`security updates` / `npm audit fix`) flipped this back to `"preserve"` as an incidental editor reformat. Since then, `next dev` has been auto-correcting tsconfig on every start, leaving a dirty working tree.
- This commits the correction once so the file stays as Next expects.

## Test plan

- [x] `npm run lint` passes (no new diagnostics)
- [x] `npm run typecheck` passes (the change is type-checker config only)
- [x] `npm run test:functional` passes (134 / 135 — 1 pre-existing skip)
- [ ] CI lint + functional
- [ ] Vercel preview deploy + e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)