### PR TITLE
Fix admin-hints functional test isolation

### DIFF
--- a/tests/functional/server/admin.test.ts
+++ b/tests/functional/server/admin.test.ts
@@ -127,10 +127,12 @@ describe("GET /api/admin/hints", () => {
     const res = await app.request("/api/admin/hints");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { hints: Array<{ relator: { id: string }; relatee: { id: string }; hintedBy: { id: string } | null }> };
-    expect(body.hints).toHaveLength(1);
-    expect(body.hints[0].relator.id).toBe(nonAdmin);
-    expect(body.hints[0].relatee.id).toBe(other);
-    expect(body.hints[0].hintedBy?.id).toBe(admin);
+    // The endpoint lists every pending hint in the DB, so other rows
+    // (from parallel test files or stale local-dev state) may appear.
+    // Filter to this test's seeded UUIDs before asserting.
+    const own = body.hints.filter((h) => h.relator.id === nonAdmin && h.relatee.id === other);
+    expect(own).toHaveLength(1);
+    expect(own[0].hintedBy?.id).toBe(admin);
   });
 
   it("does not return confirmed (non-hint) rows", async () => {
@@ -143,8 +145,10 @@ describe("GET /api/admin/hints", () => {
 
     authAs(admin);
     const res = await app.request("/api/admin/hints");
-    const body = (await res.json()) as { hints: unknown[] };
-    expect(body.hints).toEqual([]);
+    const body = (await res.json()) as { hints: Array<{ relator: { id: string }; relatee: { id: string } }> };
+    // Same global-scope caveat: just assert the row this test inserted
+    // is not surfaced, rather than asserting the whole list is empty.
+    expect(body.hints.find((h) => h.relator.id === nonAdmin && h.relatee.id === other)).toBeUndefined();
   });
 
   it("returns 404 for non-admins", async () => {


### PR DESCRIPTION
## Summary

The `/api/admin/hints` endpoint returns every pending hint in the DB without filtering by user. The functional tests asserted on the full response shape — `toHaveLength(1)` and `toEqual([])` — so any unrelated rows in the `relations` table from parallel test files or stale local-dev state produced false failures.

Filter assertions to the test's own seeded UUIDs instead.

Surfaced while investigating #149 — pre-existing fragility, unrelated to that issue's root cause.

## Test plan

- [x] `npm run test:functional` — 137 / 138 pass (the 1 skipped is pre-existing, unrelated).
- [ ] CI lint + functional tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)