### PR TITLE
Drop Sentry `includeLocalVariables` to cut server cold-start

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,6 +5,11 @@ import { scrubServerEvent } from "@/lib/sentry-scrub";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
-  includeLocalVariables: true,
+  // includeLocalVariables is intentionally omitted: it attaches the V8
+  // inspector at module load and intercepts every function call to keep
+  // frame info available, which materially slows cold-start and adds
+  // steady-state runtime overhead. The trade-off is less context in
+  // captured error reports — re-enable per environment if we ever need
+  // it for a specific debugging session.
   beforeSend: scrubServerEvent,
 });


### PR DESCRIPTION
## Summary

Drops the `includeLocalVariables: true` option from `sentry.server.config.ts`. Sentry implements the "local variables in stack frames" feature via the V8 inspector — it attaches at module load and stays attached, intercepting every function call to keep frame info available for error capture. That's a real cold-start cost and a steady-state runtime tax on every server request.

Trade-off: less context in captured server-side error reports. Re-enable per environment if a specific debugging session needs it.

This is option (A) from #149's investigation plan — the cheapest lever first, before considering the bigger structural question of how often we hit `supabase.auth.getUser()` on every request.

Investigates #149 (not closing — landing this lets us observe whether the e2e cold-start flakes change before deciding on next steps).

## Test plan

- [x] `npm run test:functional` — 137 / 138 pass (the 1 skipped is pre-existing).
- [ ] CI lint + functional tests.
- [ ] Vercel preview build + Playwright e2e — primary signal we're watching, since it's the cold-start path that triggered #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)