### PR TITLE
Add header-gated request timing helper

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,6 +1,8 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
+import { timed } from "@/lib/timing";
+
 export const createClient = (request: NextRequest) => {
   let supabaseResponse = NextResponse.next({
     request: { headers: request.headers },
@@ -32,6 +34,6 @@ export const createClient = (request: NextRequest) => {
 
 export const updateSession = async (request: NextRequest) => {
   const { supabase, response } = createClient(request);
-  await supabase.auth.getUser();
+  await timed(request, "supabase-auth-getUser", () => supabase.auth.getUser());
   return response;
 };

--- a/src/lib/timing.ts
+++ b/src/lib/timing.ts
@@ -1,0 +1,26 @@
+// Header-gated request timing for ad-hoc SSR latency probing on
+// preview deploys (and prod in a pinch). Add `x-debug-timing: 1` to a
+// request and any `timed(request, label, fn)` block on its path logs
+// `[timing] label=Nms` to stdout, which lands in Vercel function logs.
+//
+// Default behavior is unchanged: when the header is absent, `timed`
+// returns the inner promise without measuring — one header.get + a
+// boolean check. The helper is meant to stay in the codebase so we
+// don't have to re-instrument every time something feels slow.
+
+const enabled = (request: { headers: Headers }): boolean =>
+  request.headers.get("x-debug-timing") === "1";
+
+export const timed = async <T>(
+  request: { headers: Headers },
+  label: string,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  if (!enabled(request)) return fn();
+  const start = performance.now();
+  try {
+    return await fn();
+  } finally {
+    console.log(`[timing] ${label}=${(performance.now() - start).toFixed(1)}ms`);
+  }
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,9 +1,10 @@
 import type { NextRequest } from "next/server";
 
 import { updateSession } from "@/lib/supabase/middleware";
+import { timed } from "@/lib/timing";
 
 export async function proxy(request: NextRequest) {
-  return await updateSession(request);
+  return timed(request, "proxy-total", () => updateSession(request));
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

Introduces `src/lib/timing.ts` with a `timed(request, label, fn)` wrapper that logs `[timing] label=Nms` to stdout only when the request carries `x-debug-timing: 1`. Wired into two call sites:

- `src/proxy.ts` — `proxy-total` (full proxy/middleware time per request)
- `src/lib/supabase/middleware.ts updateSession` — `supabase-auth-getUser` (the Supabase Auth round-trip we suspect dominates the redirect chain)

Designed to **stay in the codebase**:
- When the header is absent, the helper short-circuits before any measurement — one `headers.get()` lookup and a boolean check, single-digit microseconds.
- No env var management, no redeploys to toggle, no instrument-then-revert dance.

## How to use

Hit any deployment with the header:

```
curl -H "x-debug-timing: 1" https://<preview-url>/signin
```

Then read the timing lines out of Vercel function logs:

```
vercel logs <deployment-url> --no-follow --since 5m --query 'message:"[timing]"'
```

## Investigates #149

Next step after this lands: send the header from a Playwright run (or a manual sign-in flow) against a fresh preview and read the per-step timing to see where the redirect chain's 20+ seconds actually goes.

## Test plan

- [x] `npm run test:functional` — 137 / 138 pass (1 skipped is pre-existing, unrelated).
- [x] `npx tsc --noEmit` — clean.
- [ ] CI lint + functional tests.
- [ ] Vercel preview build, then a curl with the debug header to confirm the markers actually fire in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)