### PR TITLE
Default x-debug-timing header in Playwright e2e

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,6 +30,12 @@ export default defineConfig({
   use: {
     baseURL,
     trace: "on-first-retry",
+    // Per-request timing for the redirect chain — see src/lib/timing.ts.
+    // The middleware short-circuits unless this header is present, so the
+    // cost on test traffic is a single header.get + boolean check; the
+    // upside is continuous per-step timing data in Vercel function logs
+    // for every CI run, queryable via `vercel logs ... --query "timing"`.
+    extraHTTPHeaders: { "x-debug-timing": "1" },
   },
   // The setup project calls POST /api/_test/reset once at the top of the
   // run. Specs that need guaranteed-clean state (welcome, invites) also


### PR DESCRIPTION
## Summary

With `src/lib/timing.ts` in place (#153), requests carrying `x-debug-timing: 1` emit per-step timing to Vercel function logs. This PR sets that header as a default on every Playwright request via `use.extraHTTPHeaders`.

Every CI e2e run from here on emits timing data for the post-signin redirect chain — direct signal for #149 and a continuous perf-regression alarm.

## Reading the data

```
vercel logs <preview-url> --no-follow --since 1h --query "timing" --expand
```

Lines like `[timing] supabase-auth-getUser=Xms` and `[timing] proxy-total=Yms` will appear interleaved with the access lines.

## Known gap

Tests that create their own browser context via `browser.newContext()` (e.g. the multi-context `/signup` unauthed test in `invites.spec.ts`) don't inherit `use.extraHTTPHeaders`. The fix is to pass `extraHTTPHeaders` to those `newContext()` calls explicitly — worth a follow-up if we want fuller coverage. Default-page tests, which cover the bulk of the failing-test surface, are fine.

## Test plan

- [x] `npm run test:functional` — 137 / 138 pass.
- [ ] CI lint + functional + e2e.
- [ ] After merge, run `vercel logs <preview-url> --query "timing"` against the e2e job's preview and confirm timing lines for the authed-redirect flow are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)