### PR TITLE
Diagnostic: log home-page profile state for #149

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
@@ -60,6 +61,15 @@ export default async function Home() {
   const me = await loadMe();
   if (!me) {
     return <LoggedOutHome />;
+  }
+
+  // Diagnostic for #149: log whether the redirect-to-/welcome gate
+  // sees a profile and what bio is. Gated on x-debug-timing to keep
+  // production logs uncluttered. Remove once #149 is resolved.
+  if ((await headers()).get("x-debug-timing") === "1") {
+    console.log(
+      `[debug-149] home me.profile=${me.profile ? "present" : "null"} bio=${JSON.stringify(me.profile?.bio)}`,
+    );
   }
 
   // Incomplete-profile heuristic: bio null means the member has not


### PR DESCRIPTION
## Summary

Adds a one-off \`console.log\` in \`app/page.tsx\` that prints \`me.profile\` presence and the \`bio\` value when the home page renders. Gated on \`x-debug-timing: 1\` (same header as the existing timing helper), so it only fires on Playwright requests and ad-hoc debugging curls.

## Why

The Playwright trace dissection for #149 showed that the failing test's browser navigates to \`/\` after sign-in and never gets redirected to \`/welcome\` — meaning the gate \`me.profile && me.profile.bio === null\` is somehow false at render time. Two distinct failure modes match that symptom:

1. \`me.profile\` is null — likely the \`React.cache()\` self-heal bug filed as #155.
2. \`bio\` is actually set — \`resetSeededUsers\` didn't clear it, or something restored it.

One CI run with this log enabled tells us which.

## Reading the log

\`\`\`
vercel logs <preview-url> --no-follow --since 30m --query "debug-149" --expand
\`\`\`

## Test plan

- [x] \`npm run test:functional\` — 137 / 138 pass.
- [ ] CI lint + functional + e2e.
- [ ] After merge, pull \`vercel logs ... --query "debug-149"\` from the next failing Playwright preview and read what the home page actually saw.

## Cleanup

Once we have the answer and the root cause is fixed, the log + \`headers\` import come back out. Tracking via the inline comment + the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)