### PR TITLE
Fix #155: drop redundant React.cache() on getProfileForSelf

### DIFF
--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -1,6 +1,5 @@
 import type { User } from "@supabase/supabase-js";
 import { asc, eq, isNotNull, or, sql } from "drizzle-orm";
-import { cache } from "react";
 
 import { isUuid } from "./auth-middleware";
 import { db } from "./db";
@@ -102,13 +101,7 @@ export type ProfileForSelf = {
   updatedAt: Date;
 };
 
-// Per-request memoization: the root layout fetches the profile to show
-// displayName in the header, and `/` fetches it again for the bio-null
-// /welcome redirect gate. Without cache(), that's two DB roundtrips on
-// every signed-in render — enough to push Vercel-preview cold-starts
-// past e2e's 10s waitForURL budget. cache() keys on the arg tuple, so
-// only co-located callers with the same userId share the result.
-export const getProfileForSelf = cache(async (userId: string): Promise<ProfileForSelf | null> => {
+export const getProfileForSelf = async (userId: string): Promise<ProfileForSelf | null> => {
   const [row] = await db
     .select({
       id: profiles.id,
@@ -131,7 +124,7 @@ export const getProfileForSelf = cache(async (userId: string): Promise<ProfileFo
     .where(eq(profiles.id, userId));
 
   return row ?? null;
-});
+};
 
 // Bumps lastUpdatedWeb to now() on the user's profile. The Done button
 // at the bottom of /myweb is the only caller — clicking it captures

--- a/tests/functional/server/profiles.test.ts
+++ b/tests/functional/server/profiles.test.ts
@@ -81,19 +81,6 @@ describe("getProfileForSelf", () => {
     expect(await getProfileForSelf(randomUUID())).toBeNull();
   });
 
-  // Skipped: getProfileForSelf is wrapped in React.cache() so the root
-  // layout (header displayName) and `/` (bio-null /welcome redirect)
-  // share one DB roundtrip per request. cache()'s dedup only activates
-  // inside an active RSC render or Next.js server-request scope —
-  // vitest doesn't set that up, so the wrapper is a no-op here and
-  // both awaits hit the DB independently. Verified instead by the
-  // Playwright e2e suite running against a real Vercel preview.
-  it.skip("memoizes per request — same userId returns the same reference", async () => {
-    const a = await getProfileForSelf(testUserId);
-    const b = await getProfileForSelf(testUserId);
-    expect(b).toBe(a);
-  });
-
   it("returns the full self shape, including emergencyContact and isAdmin", async () => {
     const profile = await getProfileForSelf(testUserId);
 


### PR DESCRIPTION
## Summary
- Drops `React.cache()` from `getProfileForSelf`. The self-heal path in `/api/me` read, upserted, then re-read — and the cached `null` from the first read masked the just-inserted row (closes #155).
- The inner cache was also vestigial: `loadMe` (`src/lib/api-server.ts`) is the only entry point from a render and is itself `cache()`-wrapped, so layout + page dedup is unaffected.
- Drops the skipped vitest memoization test (its rationale no longer applies).

## Test plan
- [x] `npm test` — functional 137/137, e2e 17/17
- [x] Existing self-heal test in `tests/functional/server/api-me.test.ts:61` now exercises real production behavior (previously cache() was a vitest no-op).

Closes #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)