### PR TITLE
Add CODEOWNERS + ruleset enforcement; close out security-hardening punch list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Workflow changes touch CI secrets (E2E_ADMIN_PASSWORD, CI_RESET_TOKEN);
+# the gate exists so a tampered workflow can't land without an explicit
+# review from someone authorized to handle those secrets. See item 6 in
+# docs/plan-security-hardening.md.
+.github/workflows/  @james-baker @benjifriedman
+.github/CODEOWNERS  @james-baker @benjifriedman

--- a/docs/doc-github.md
+++ b/docs/doc-github.md
@@ -17,7 +17,8 @@ Enforced via a GitHub Ruleset, managed as code in `scripts/update-main-branch-pr
 - **PR required** for every change — even solo pushes, so the `pull_request` workflow trigger gates every merge into main.
 - **Required status check:** "Lint & Functional Tests" (E2E is not required — it runs post-deploy against the Vercel preview and can flake on cold start; check manually before merging).
 - **Force-push blocked** and **deletion blocked**.
-- **Zero required approvals** (solo dev).
+- **Zero required approvals globally** — keeps solo work on app code unblocked.
+- **Code-owner review required** on paths listed in `.github/CODEOWNERS` (currently `.github/workflows/` and `.github/CODEOWNERS` itself). A CI-secret-touching workflow change can't land without a second codeowner's approval.
 - **Repository Admin can bypass** for emergencies (CI wedged, urgent revert).
 
 ## CI workflows

--- a/docs/plan-security-hardening.md
+++ b/docs/plan-security-hardening.md
@@ -22,46 +22,19 @@ A review of the repo, code, CI, and deployment. What we already have that's good
 - **`/api/_test/reset` is token-gated** — `CI_RESET_TOKEN` shared-secret header is the sole gate; the destructive scope is fixed to the two seeded e2e users (`src/server/test-reset.ts`). Previously also gated on `VERCEL_ENV !== "production"`, but preview and prod share the same Supabase, so the environment gate was theatre against a token that already mutates prod data on preview runs.
 - **`hono` bumped past GHSA-458j-xx4x-4375** — `npm audit` is clean.
 - **Dependabot + CodeQL + secret-scanning push protection** are all configured (`.github/dependabot.yml`, `.github/workflows/codeql.yml`).
-
----
-
-## Worth doing soon
-
-### 5. `SECURITY.md` + private vulnerability reporting
-
-In flight as PR #85 (sent back for changes — the disclosure-policy parts are right; secret-rotation runbook and admin-account threat notes need to move out of the public file into `docs/`). Once the disclosure-policy file lands, enable Settings → Code security → "Private vulnerability reporting" so the `security/advisories/new` link the file points at actually works.
-
-### 6. `E2E_ADMIN_PASSWORD` controls a real `is_admin=true` prod account
-
-Lives in a GH Actions secret. An attacker can study every workflow we ever write looking for an `echo`/`printenv` mistake or a malicious dep that exfils env. Two mitigations, pick one:
-
-- Drop `e2e-admin` until we actually have admin tests; flip the flag in the seed step instead of keeping a long-lived admin account, **or**
-- Restrict the e2e workflow with `permissions: read-all` and require a CODEOWNERS-gated approval on workflow file changes.
-
-### 9. Length-limit profile fields
-
-`parseEditableProfile` accepts arbitrary-length strings. Vercel caps body at ~4.5MB so total payload is bounded, but a member can spam ~4MB strings. Add `MAX_BIO=10000`, `MAX_DISPLAY_NAME=100`, etc.
-
-### 11. Document the `sb_secret_…` in git history
-
-Any `sb_secret_…` token in this repo is the deterministic local Supabase CLI default — not a real secret. Add a README note and a `# pragma: allowlist secret`-style annotation where it appears, so GitGuardian / TruffleHog don't open issues against the public repo.
+- **`SECURITY.md` + private vulnerability reporting** landed in PR #85.
+- **CODEOWNERS gate on `.github/workflows/`** (`.github/CODEOWNERS`, enforced by the main-branch ruleset's `require_code_owner_review: true`) — workflow changes need an approving review from one of the listed codeowners before they can merge. Narrows the "land a tampered workflow that echoes `E2E_ADMIN_PASSWORD` / `CI_RESET_TOKEN`" path.
 
 ---
 
 ## Worth knowing, not blocking
 
+- **`E2E_ADMIN_PASSWORD` controls a real `is_admin=true` prod account.** Blast radius from a leak is bounded — admin can revoke any invite and create/delete relation hints (`src/server/api.ts`), nothing more. Can't elevate other accounts (`parseEditableProfile` allowlist), can't read PII beyond `/members`, can't drop tables. External fork PRs can't pull the secret. Realistic vectors are: malicious npm dep exfilling env from any CI step (applies to every CI secret, not just admin), or a maintainer-account compromise. CODEOWNERS on `.github/workflows/` handles the "tampered workflow" path; the rest is accepted risk for an invite-only audience.
+- **Main is protected by ruleset `15374115` ("main branch protection"), not classic protection** — `gh api .../branches/main/protection` returns 404; rulesets live at `/repos/.../rulesets`. Managed in code at `scripts/update-main-branch-protection.mjs`, applied via `npm run update_main_branch_protection`.
+- **`/api/_test/reset` is registered in prod.** Intentional. Token-gated, destructive scope hard-coded to the two seeded test users (`E2E_EMAILS` in `src/server/test-reset.ts`). Preview and prod share the same Supabase, so an env-gate here would be theatre against a token that already mutates prod data on preview runs.
+- **`parseEditableProfile` accepts arbitrary-length strings.** Vercel caps body at ~4.5MB so total payload is bounded; a member can still spam ~4MB strings. Quality-of-service, not security. Add `MAX_BIO=10000`, `MAX_DISPLAY_NAME=100`, etc. when convenient.
+- **`sb_secret_…` in git history.** Deterministic local Supabase CLI default — not a real secret. README note + `# pragma: allowlist secret`-style annotation will keep GitGuardian / TruffleHog from filing false positives if/when the repo goes public.
 - **`/api/invites/:code/check` is unauthenticated and unrate-limited.** 32¹⁰ keyspace makes brute-forcing infeasible, but high-QPS hammering can drive DB CPU. Vercel WAF / Cloudflare in front handles this cheaply if it ever shows up.
 - **`displayName` flows through user-controlled `user_metadata`.** React escapes by default; just be careful that future emails or admin tooling escape it too.
 - **Supabase project ref is in docs.** Already shipped to the browser via `NEXT_PUBLIC_SUPABASE_URL`, so no new exposure — just know the dashboard URL pattern is public.
 - **OTP enumeration oracle** at the GoTrue layer is acknowledged in code; acceptable for an invite-only app, revisit if abuse shows up.
-
----
-
-## Suggested landing order
-
-1. **Item 5** (`SECURITY.md` revisions + enable PVR) — needed before first outside contact; the advisory link is currently dead.
-2. **Item 6** (`E2E_ADMIN_PASSWORD`) — pick a mitigation; an attacker reading workflows is a realistic threat now that the repo is public.
-3. **Item 11** (document `sb_secret_…`) — cheap, prevents false-positive scanner noise.
-4. **Item 9** (length limits) — quality-of-service, lower urgency than the others.
-
-Items from "worth knowing, not blocking" can ship whenever the underlying surface changes.

--- a/scripts/update-main-branch-protection.mjs
+++ b/scripts/update-main-branch-protection.mjs
@@ -42,15 +42,19 @@ const ruleset = {
     // Block branch deletion and force-pushes on main.
     { type: "deletion" },
     { type: "non_fast_forward" },
-    // Require a PR for every change. Zero approvals (solo dev) — the
-    // point is to force CI to gate every merge into main, since direct
-    // pushes bypass the pull_request workflow trigger entirely.
+    // Require a PR for every change. Zero approvals globally — the
+    // baseline point is to force CI to gate every merge into main,
+    // since direct pushes bypass the pull_request workflow trigger
+    // entirely. require_code_owner_review adds a targeted gate on
+    // CODEOWNERS-claimed paths only (currently .github/workflows/ and
+    // .github/CODEOWNERS), so workflow changes need a codeowner's
+    // approval but everything else stays count=0.
     {
       type: "pull_request",
       parameters: {
         required_approving_review_count: 0,
         dismiss_stale_reviews_on_push: false,
-        require_code_owner_review: false,
+        require_code_owner_review: true,
         require_last_push_approval: false,
         required_review_thread_resolution: false,
       },


### PR DESCRIPTION
## Summary

- `.github/CODEOWNERS` claims `.github/workflows/` and `.github/CODEOWNERS` itself for @james-baker and @benjifriedman.
- `scripts/update-main-branch-protection.mjs` flips `require_code_owner_review: true` (with `required_approving_review_count: 0` unchanged), so workflow PRs now require a codeowner approval but non-workflow PRs stay unchanged. **Live ruleset is already updated** via `npm run update_main_branch_protection`.
- `docs/plan-security-hardening.md` folds completed items into "what's in place" and reclassifies the remaining four items from #58 (admin-password risk, length limits, `sb_secret_` docs, the now-obsolete env-gate on `/api/_test/reset`) as known-and-accepted. Also corrects an earlier inaccuracy: main is protected via ruleset `15374115`, not classic branch protection.
- `docs/doc-github.md` updated to describe the new code-owner-review behavior.

Closes #58.

## Test plan

- [x] `npm test` (functional + e2e) green locally
- [x] `npm run update_main_branch_protection --dry-run` reviewed against current live config
- [x] Live ruleset verified post-apply: `require_code_owner_review: true`, `required_approving_review_count: 0`
- [ ] Confirm this PR itself triggers the codeowner gate (workflow/CODEOWNERS files touched) — should request review from the other codeowner and block self-merge

🤖 Filed by Claude Code