### PR TITLE
Tighten admin bypass on main-branch ruleset to per-PR

### DIFF
--- a/docs/doc-github.md
+++ b/docs/doc-github.md
@@ -19,7 +19,7 @@ Enforced via a GitHub Ruleset, managed as code in `scripts/update-main-branch-pr
 - **Force-push blocked** and **deletion blocked**.
 - **Zero required approvals globally** — keeps solo work on app code unblocked.
 - **Code-owner review required** on paths listed in `.github/CODEOWNERS` (currently `.github/workflows/` and `.github/CODEOWNERS` itself). A CI-secret-touching workflow change can't land without a second codeowner's approval.
-- **Repository Admin can bypass** for emergencies (CI wedged, urgent revert).
+- **Repository Admin can bypass per-PR** by ticking the bypass checkbox in the merge box (`bypass_mode: "pull_request"`). Not silent — admin merges that don't tick it still enforce every rule, including codeowner review. Previously was `"always"`, which silently skipped every rule for admins and defeated the codeowner gate; tightened after PR #159 merged without triggering review.
 
 ## CI workflows
 

--- a/scripts/update-main-branch-protection.mjs
+++ b/scripts/update-main-branch-protection.mjs
@@ -21,13 +21,16 @@ const ruleset = {
   name: RULESET_NAME,
   target: "branch",
   enforcement: "active",
-  // Admins can override in emergencies (CI wedged, urgent revert, etc).
-  // Worth tightening if the team grows.
+  // Admins can bypass per-PR via the merge-box checkbox — required for
+  // emergencies (CI wedged, urgent revert) but no longer a free pass on
+  // every merge. "always" would silently skip every rule for admins,
+  // including the codeowner-review gate on workflow PRs, which defeats
+  // the point of having CODEOWNERS.
   bypass_actors: [
     {
       actor_id: 5, // built-in "Repository Admin" role
       actor_type: "RepositoryRole",
-      bypass_mode: "always",
+      bypass_mode: "pull_request",
     },
   ],
   conditions: {


### PR DESCRIPTION
## Summary

- `scripts/update-main-branch-protection.mjs`: `bypass_mode: "always"` → `"pull_request"`. Repository Admins can still bypass rules, but only by ticking the bypass checkbox in the merge box on a specific PR. No more silent skip on every merge.
- `docs/doc-github.md` updated to describe the new per-PR bypass behavior.
- Live ruleset already updated via `npm run update_main_branch_protection`.

Motivation: #159 was the first PR expected to fire the codeowner-review gate, but it merged with no review because admin-bypass-always silently skipped every rule. (Compounded by CODEOWNERS not yet being on main at the time, which is a chicken-and-egg only the first PR ever hits.) Tightening bypass_mode makes the gate enforceable on the next workflow PR.

## Test plan

- [x] `npm test` (functional + e2e) green locally
- [x] `--dry-run` reviewed, bypass_actors block shows the new mode
- [x] Live ruleset verified post-apply: `[{actor_id: 5, actor_type: "RepositoryRole", bypass_mode: "pull_request"}]`
- [ ] Validation: a subsequent throwaway PR touching `.github/workflows/` should show "Code owners review required" on the merge box, with the bypass checkbox visible as an admin-only escape hatch

🤖 Filed by Claude Code