### PR TITLE
Add npm min-release-age=5 to quarantine fresh package versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Quarantine fresh npm releases for 5 days — compromised packages are usually
+# yanked within hours/days of publication (Shai-Hulud, debug/chalk, etc.).
+# Override per-command with `--min-release-age=0` if a genuine urgent install is needed.
+min-release-age=5

--- a/docs/strategy-security.md
+++ b/docs/strategy-security.md
@@ -139,6 +139,12 @@ Three rules:
 2. **Verify in the browser, not just in tests.** CSP violations appear in the DevTools console; functional and e2e tests almost never catch them because Playwright runs against a permissive headless Chromium. Open the deployed site, look for `Refused to ...` errors, fix them.
 3. **Loosening is a one-way ratchet.** Anything added here is harder to remove than to add — every addition needs a one-line justification in the comment next to it, like the existing `connect-src` comment.
 
+# Supply-chain quarantine
+
+`.npmrc` sets `min-release-age=5`, so `npm install` ignores any package version published in the last five days. The window is long enough to catch the usual post-publish takedown cycle (Shai-Hulud, debug/chalk, etc.) and short enough to not block routine upgrades. Override with `--min-release-age=0` on the command line for a genuine emergency install.
+
+Requires npm ≥11 — older npm warns and ignores the setting, so this is silent if the Vercel build image ever rolls back. The gate engages on dependency resolution (adding or bumping a dep); `npm ci` against a frozen lockfile installs whatever's pinned regardless.
+
 # Secret rotation
 
 If a secret is suspected compromised, rotate it immediately using the steps below.


### PR DESCRIPTION
## Summary
- `.npmrc` sets `min-release-age=5` so `npm install` refuses any version published in the last five days — catches the usual post-publish takedown cycle (Shai-Hulud, debug/chalk, etc.) without blocking routine upgrades.
- Per-command escape hatch: `--min-release-age=0` for genuine emergency installs.
- `docs/strategy-security.md` gains a short `# Supply-chain quarantine` section between HTTP Headers and Secret rotation, noting the npm ≥11 requirement and that the gate engages on dep resolution (not on `npm ci` against a frozen lockfile).

## Test plan
- [x] Confirmed unit is days via npm's own config definition (`86400000 * obj['min-release-age']`).
- [x] Confirmed the setting key is `min-release-age` (not `minimum-release-age`) by `npm config ls -l`.
- [ ] CI green (lint + functional).
- [ ] Vercel preview build picks up `.npmrc` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)