### PR TITLE
Redesign logged-in homepage with card grid

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-13 | Benji | Homepage card redesign
+
+Replaced the stacked button list on the logged-in home page with a responsive 2-column card grid. Each card has a title and short description, uses the existing `card`/`border`/`accent` design tokens, and shows a teal border + accent background on hover. Added a personalized greeting ("Welcome, [name]") and a serif italic subheading for warmth. Logged-out page unchanged.
+
 ## 2026-05-11 | James | Transactional email: Resend wired into Supabase Auth SMTP
 
 Supabase Auth sends through Resend SMTP from `devteam@mail.intentionalsociety.org`, which can also receive email via existing Zoho mailbox. Rate limits: 50/hour at Supabase Auth (we set it), 100/day at Resend (free tier cap).

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,7 +42,7 @@ function LoggedOutHome() {
 }
 
 type NavCardProps = {
-  href: string;
+  href: React.ComponentProps<typeof Link>["href"];
   title: string;
   description: string;
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,18 +41,65 @@ function LoggedOutHome() {
   );
 }
 
-function LoggedInHome() {
+type NavCardProps = {
+  href: string;
+  title: string;
+  description: string;
+};
+
+function NavCard({ href, title, description }: NavCardProps) {
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex flex-col items-center gap-1">
-        <h1 className="text-4xl font-bold">Intentional Society</h1>
-        <p className="font-serif italic text-2xl text-muted-foreground">The IS Web App</p>
+    <Link
+      href={href}
+      className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-5 transition-all hover:border-primary/40 hover:bg-accent hover:shadow-sm"
+    >
+      <h2 className="text-lg font-semibold text-card-foreground group-hover:text-accent-foreground">
+        {title}
+      </h2>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </Link>
+  );
+}
+
+function LoggedInHome({ displayName }: { displayName: string | null }) {
+  const greeting = displayName ? `Welcome, ${displayName}` : "Welcome back";
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-8 p-8 pt-12">
+      <div className="flex flex-col items-center gap-2">
+        <h1 className="text-3xl font-bold">{greeting}</h1>
+        <p className="font-serif italic text-muted-foreground">
+          What would you like to do?
+        </p>
       </div>
-      <Button render={<Link href="/myweb" />}>My web</Button>
-      <Button render={<Link href="/profile" />}>My profile</Button>
-      <Button render={<Link href="/members" />}>Member directory</Button>
-      <Button render={<Link href="/invites" />}>Manage invites</Button>
-      <Button render={<Link href="/programs" />}>Programs</Button>
+
+      <div className="grid w-full max-w-lg gap-4 sm:grid-cols-2">
+        <NavCard
+          href="/myweb"
+          title="My web"
+          description="See your connections and relational map."
+        />
+        <NavCard
+          href="/profile"
+          title="My profile"
+          description="View and edit your community profile."
+        />
+        <NavCard
+          href="/members"
+          title="Member directory"
+          description="Browse and connect with other members."
+        />
+        <NavCard
+          href="/programs"
+          title="Programs"
+          description="Explore and join community programs."
+        />
+        <NavCard
+          href="/invites"
+          title="Invite a friend"
+          description="Generate invite codes for new members."
+        />
+      </div>
     </main>
   );
 }
@@ -79,5 +126,5 @@ export default async function Home() {
     redirect("/welcome");
   }
 
-  return <LoggedInHome />;
+  return <LoggedInHome displayName={me.profile?.displayName ?? null} />;
 }

--- a/tests/e2e/invites.spec.ts
+++ b/tests/e2e/invites.spec.ts
@@ -24,7 +24,7 @@ test.describe("invites — authed member flow", () => {
   });
 
   test("create an invite, see it listed, revoke it", async ({ page }) => {
-    await page.getByRole("button", { name: "Manage invites" }).click();
+    await page.getByRole("link", { name: "Invite a friend" }).click();
     await page.waitForURL((u) => u.pathname === "/invites", { timeout: TIMEOUT_MS });
     await expect(page.getByRole("heading", { name: "Invite a member" })).toBeVisible();
 
@@ -43,7 +43,7 @@ test.describe("invites — authed member flow", () => {
   });
 
   test("429 from the API surfaces a friendly cap message", async ({ page }) => {
-    await page.getByRole("button", { name: "Manage invites" }).click();
+    await page.getByRole("link", { name: "Invite a friend" }).click();
     await page.waitForURL((u) => u.pathname === "/invites", { timeout: TIMEOUT_MS });
     // Stub POST /api/invites to return 429 — we don't want to seed
     // ten real invites per test run, and we only need to verify the
@@ -89,7 +89,7 @@ test.describe("/signup — unauthed invite flow", () => {
     try {
       await signInAs(memberPage, "regular");
       await completeWelcome(memberPage, { displayName: "Inviter" });
-      await memberPage.getByRole("button", { name: "Manage invites" }).click();
+      await memberPage.getByRole("link", { name: "Invite a friend" }).click();
       await memberPage.waitForURL((u) => u.pathname === "/invites", { timeout: TIMEOUT_MS });
       await memberPage.getByLabel(/Note \(for your records/).fill("e2e signup-flow invite — come on in");
       await memberPage.getByRole("button", { name: "Create invite" }).click();

--- a/tests/e2e/myweb.spec.ts
+++ b/tests/e2e/myweb.spec.ts
@@ -26,7 +26,7 @@ test.describe("/myweb — tour pre-dismissed", () => {
     await signInAs(page, "regular");
     await completeWelcome(page);
 
-    await page.getByRole("button", { name: "My web" }).click();
+    await page.getByRole("link", { name: "My web" }).click();
     await page.waitForURL((u) => u.pathname === "/myweb", { timeout: TIMEOUT_MS });
     await expect(page.getByRole("heading", { name: "My web" })).toBeVisible();
 
@@ -54,7 +54,7 @@ test.describe("/myweb — first-time welcome tour", () => {
   test("tour appears for a first-time visitor and can be skipped", async ({ page }) => {
     await signInAs(page, "regular");
     await completeWelcome(page);
-    await page.getByRole("button", { name: "My web" }).click();
+    await page.getByRole("link", { name: "My web" }).click();
     await page.waitForURL((u) => u.pathname === "/myweb", { timeout: TIMEOUT_MS });
 
     await expect(page.getByText("Welcome to your relational web")).toBeVisible({ timeout: 5_000 });

--- a/tests/e2e/welcome.spec.ts
+++ b/tests/e2e/welcome.spec.ts
@@ -55,5 +55,5 @@ test("fresh user lands on /welcome and can complete their profile", async ({ pag
   await page.getByRole("button", { name: "Save" }).click();
 
   await page.waitForURL((u) => u.pathname === "/", { timeout: TIMEOUT_MS });
-  await expect(page.getByRole("button", { name: "Manage invites" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Invite a friend" })).toBeVisible();
 });


### PR DESCRIPTION
Replace stacked button list with a responsive 2-column card grid. Each card has a title and description, uses card/border/accent tokens, and shows teal border + accent bg on hover. Personalized greeting uses the member's display name.