### PR TITLE
Add admin role: programs and member management

### DIFF
--- a/docs/admin-implementation.md
+++ b/docs/admin-implementation.md
@@ -1,0 +1,266 @@
+# Admin Role Implementation — Brief for Claude Code
+
+## Context
+
+This document captures all design decisions, architecture, and remaining work for the admin role feature in the Intentional Society app. It is intended to give Claude Code full context to continue implementation without gaps.
+
+---
+
+## What has already been written (do not rewrite)
+
+The following files have been created or modified on the `admin-page` branch:
+
+### New files
+- `src/server/programs-admin.ts` — DB functions: `listAdminPrograms`, `createProgram`, `updateProgram`, `deleteProgram`, `listProgramMembers`, `assignMember`, `removeMember`
+- `src/server/members-admin.ts` — DB functions: `listAdminMembers`, `setAdminStatus`
+- `src/app/admin/layout.tsx` — Admin layout with `requireAdmin()` gate + top nav (Programs, Members links)
+- `src/app/admin/page.tsx` — Admin dashboard with two cards linking to /admin/programs and /admin/members
+
+### Modified files
+- `src/server/api.ts` — Added `checkAdmin` helper and all admin API routes (see full list below)
+- `src/lib/api-server.ts` — Added `requireAdmin()` page-level guard (mirrors `requireUser()`, redirects non-admins to `/`)
+- `src/lib/api-types.ts` — Added `AdminProgram`, `AdminProgramMember`, `AdminMember` type aliases inferred from API routes
+
+---
+
+## API routes added to src/server/api.ts
+
+All routes require `isAdmin = true` on the caller's profile (checked via `checkAdmin` helper). Non-admins receive 403.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | /api/admin/programs | List all programs with member counts |
+| POST | /api/admin/programs | Create a program |
+| PUT | /api/admin/programs/:id | Update name / description / slug |
+| DELETE | /api/admin/programs/:id | Delete program (guard: 409 if members exist) |
+| GET | /api/admin/programs/:id/members | List members of a program |
+| POST | /api/admin/programs/:id/members | Assign a member to a program |
+| DELETE | /api/admin/programs/:id/members/:profileId | Remove a member from a program |
+| GET | /api/admin/members | List all members with isAdmin flag |
+| PATCH | /api/admin/members/:id/admin | Grant or revoke admin status |
+
+---
+
+## What still needs to be built
+
+### 1. src/app/admin/programs/page.tsx + programs-admin-panel.tsx
+
+Server page calls `requireAdmin()` and fetches programs via `serverApiClient.api.admin.programs.$get()`, passing data to the client panel.
+
+The client panel (`programs-admin-panel.tsx`, `"use client"`) handles:
+
+**Program list:**
+- Table/list of all programs: name, slug, member count, active status, created date
+- Inactive programs should be visually dimmed (e.g. `opacity-50` or a grey "Inactive" badge)
+- "New program" button that shows an inline create form
+- Each row has Edit and Delete buttons
+
+**Create form (inline, shown on demand):**
+- Name field (required) — slug auto-populates as user types, editable
+- Description field (optional textarea)
+- Slug field — pre-filled from name, user can override; show warning text "Changing the slug will break existing links" when slug differs from the auto-generated version
+- `is_active` toggle (default on) — controls visibility on the member-facing /programs page
+- Submit → POST /api/admin/programs
+- `created_by` is set server-side from `user.id`, not shown in the form
+
+**Edit (inline, replaces row on click):**
+- Same fields as create, pre-filled with current values (including the `is_active` toggle)
+- Submit → PUT /api/admin/programs/:id
+
+**Delete:**
+- Uses `window.confirm` (same pattern as invites revoke)
+- DELETE /api/admin/programs/:id
+- If API returns 409 `has_members`, show error: "Cannot delete — this program has {memberCount} member(s). Remove them first."
+- On success, remove from list
+
+**Member management (expanded row, accordion-style below each program row):**
+- Clicking a "Members" button on a program row expands a section directly below it
+- Keeps program context visible while managing members — no navigation needed
+- List current members of that program with a Remove button per row
+- A search input below the current members filters all members not yet in the program by display name
+  - Fetch all members from GET /api/admin/members when first expanded (cached for the session)
+  - Clicking a filtered member assigns them → POST /api/admin/programs/:id/members
+  - Remove → DELETE /api/admin/programs/:id/members/:profileId
+
+### 2. src/app/admin/members/page.tsx + members-admin-panel.tsx
+
+Server page calls `requireAdmin()` and fetches members via `serverApiClient.api.admin.members.$get()`, passing data to the client panel.
+
+The server page must pass `currentUserId={me.id}` (from `requireAdmin()` return value) as a prop to the panel, so the panel can identify and disable the current user's own toggle row.
+
+The client panel (`members-admin-panel.tsx`, `"use client"`) handles:
+
+**Member list:**
+- Table/list of all members: avatar, display name, location, admin badge
+- Each row has a toggle button: "Make admin" / "Remove admin"
+
+**Admin toggle behaviour:**
+- Calls PATCH /api/admin/members/:id/admin with `{ isAdmin: true/false }`
+- If API returns 403 `self_demotion`: show error "You cannot remove your own admin status."
+- If API returns 409 `last_admin`: show error "Cannot remove the last admin."
+- The toggle button for the current user's own row should be visually disabled with title tooltip "You cannot remove your own admin access" — but the API also enforces this as a hard guard.
+- On success, update the row in local state (no full reload needed)
+
+### 3. src/components/site-header.tsx
+
+Add `isAdmin` prop (boolean) to `SiteHeader`.
+
+Add an Admin link inside the Sheet nav, visually distinct from the other links:
+- Use the `Shield` icon from `lucide-react` (already imported: `Menu` is used; add `Shield` to the import)
+- Style it differently from regular nav items to signal it is a power-user area — e.g. slightly different color or a divider above it
+- Only render if `isAdmin === true`
+- Link to `/admin`
+
+Example:
+```tsx
+{isAdmin && (
+  <>
+    <div className="my-1 border-t border-border" />
+    <SheetClose
+      nativeButton={false}
+      render={
+        <Link
+          href="/admin"
+          className="flex items-center gap-2 rounded px-2 py-2 font-medium text-primary hover:bg-muted"
+        >
+          <Shield className="h-4 w-4" />
+          Admin
+        </Link>
+      }
+    />
+  </>
+)}
+```
+
+### 4. src/app/layout.tsx
+
+Pass `isAdmin` to `SiteHeader`. The `me` object is already fetched here. Change:
+
+```tsx
+<SiteHeader displayName={me?.profile?.displayName ?? null} />
+```
+
+to:
+
+```tsx
+<SiteHeader
+  displayName={me?.profile?.displayName ?? null}
+  isAdmin={me?.profile?.isAdmin ?? false}
+/>
+```
+
+---
+
+## Design decisions (all confirmed)
+
+### Authorization
+- Single `isAdmin` boolean on `profiles` table — no roles table needed
+- `checkAdmin` helper in `api.ts` gates every `/api/admin/*` route
+- `requireAdmin()` in `api-server.ts` gates every admin page server-side (non-admins never receive the page HTML)
+
+### Admin self-demotion guard
+- API (`setAdminStatus`) rejects `self_demotion` with 403
+- UI disables the toggle on the current user's own row with a tooltip
+- API also rejects `last_admin` with 409 — the last admin cannot be removed
+
+### Program deletion guard
+- API returns 409 `has_members` (with `memberCount`) instead of cascading
+- UI shows the member count in the error message and instructs the admin to remove members first
+- Note: `profilePrograms` has `ON DELETE CASCADE` in the schema, so if you ever want to change this to cascade, just remove the guard check in `deleteProgram`
+
+### Slug policy
+- Auto-generated from program name on creation (`programSlug` helper in `programs-admin.ts`)
+- Admin can override the slug manually in the form
+- On edit: show a warning if the slug differs from the auto-generated version ("Changing the slug will break existing links")
+- If an auto-generated slug on rename conflicts with an existing program, the existing slug is preserved (handled in `updateProgram`)
+
+### Request body schemas
+
+**POST `/api/admin/programs`** (create):
+```ts
+{ name: string; slug?: string; description?: string; isActive?: boolean }
+```
+- `slug` auto-generated from name if omitted
+- `isActive` defaults to `true` server-side if omitted
+- `created_by` is set server-side from `user.id`, not in the body
+
+**PUT `/api/admin/programs/:id`** (update, all fields optional):
+```ts
+{ name?: string; slug?: string; description?: string | null; isActive?: boolean }
+```
+
+**PATCH `/api/admin/members/:id/admin`**:
+```ts
+{ isAdmin: boolean }
+```
+
+### Sort order
+
+- `listAdminPrograms`: `createdAt DESC` (newest first)
+- `listAdminMembers`: `createdAt DESC` (newest first)
+- Member-facing `listPrograms`: `name ASC` (unchanged)
+
+### Slug conflict error handling
+
+For both POST and PUT: if the submitted slug is already taken by another program, the API returns `409 slug_taken`. The UI shows an inline error directly below the slug field: **"This slug is already in use by another program."** This is distinct from the slug-change advisory warning (which is informational, shown whenever slug ≠ auto-generated form).
+
+### Schema migration required
+
+Two columns were added to the `programs` table. Run these before testing:
+
+```bash
+npx drizzle-kit generate   # generates the SQL migration file
+npx drizzle-kit migrate    # applies it to your local DB
+```
+
+The schema changes (already in `src/server/schema.ts`):
+
+- **`is_active` (boolean, default true)** — soft-hides a program from the member-facing `/programs` page without deleting it. The member-facing `listPrograms` in `programs.ts` already filters to `is_active = true` (confirmed: `programs.ts:44`). The admin view (`listAdminPrograms`) returns all programs regardless.
+- **`created_by` (UUID FK → profiles, on delete set null)** — tracks which admin created the program. Stored automatically from `user.id` when POST /api/admin/programs is called.
+
+### RLS (important non-issue)
+- All tables have RLS enabled with deny-by-default
+- Drizzle connects as the `postgres` superuser which bypasses RLS entirely
+- No RLS policy changes are needed for admin writes — this was confirmed by reading the schema comments
+
+### Nav placement
+- Admin link lives in the slide-out Sheet menu (hamburger, top-right)
+- Visually distinct from regular nav links: `Shield` icon + primary color + divider above
+- Only visible to users where `isAdmin === true`
+- One click from anywhere → `/admin`
+- `SheetClose` API confirmed: uses `nativeButton={false}` and `render={<Link …/>}` — matches existing pattern in `site-header.tsx`
+
+---
+
+## Existing patterns to follow
+
+- Client components use `useState` + `useCallback` + `useEffect` for data loading (no TanStack Query yet — see comment in invites-panel.tsx)
+- API calls use `apiClient` from `@/lib/api` on the client, `serverApiClient` from `@/lib/api-server` on the server
+- Destructive confirmations use `window.confirm` (see `confirmRevoke` in invites-panel.tsx)
+- Error states use `{ kind: "idle" | "saving" | "error"; message?: string }` pattern
+- UI components: `Button`, `Label`, `Textarea` from `@/components/ui/`
+- Tailwind CSS v4 for styling, follow existing class patterns
+
+---
+
+## Future work (not in scope for this PR)
+
+- Admin-issued invites: create invite with `creatorValue: null` from admin UI; view and revoke all invites (not just own)
+- Member profile detail view: full profile visible to admins, reserved space for account deactivation
+- Hint seeding: admin surface for seeding the relations graph (documented in `docs/design-relations.md`)
+- E2E tests: `e2e-admin@testfake.local` test user already exists; tests should cover: non-admin redirect, program CRUD, member admin toggle
+
+---
+
+## Running the app
+
+```bash
+npm run dev       # starts local Supabase + Next.js dev server
+npm run lint      # Biome linter
+npm test          # all tests
+```
+
+To promote a user to admin for local testing, run in Supabase Studio (localhost:54323):
+```sql
+UPDATE profiles SET is_admin = true WHERE id = '<user-uuid>';
+```

--- a/drizzle/0005_naive_sentinel.sql
+++ b/drizzle/0005_naive_sentinel.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "programs" ADD COLUMN "is_active" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "programs" ADD COLUMN "created_by" uuid;--> statement-breakpoint
+ALTER TABLE "programs" ADD CONSTRAINT "programs_created_by_profiles_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."profiles"("id") ON DELETE set null ON UPDATE no action;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,624 @@
+{
+  "id": "032af9c1-dfdc-444c-a759-40fb8b5ab5cf",
+  "prevId": "4427bf30-e874-44db-8d6b-4ce55a11ca45",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.invite_hints": {
+      "name": "invite_hints",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_hints_invite_id_invites_id_fk": {
+          "name": "invite_hints_invite_id_invites_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "invites",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_hints_ratee_id_profiles_id_fk": {
+          "name": "invite_hints_ratee_id_profiles_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_hints_invite_id_ratee_id_pk": {
+          "name": "invite_hints_invite_id_ratee_id_pk",
+          "columns": [
+            "invite_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by": {
+          "name": "redeemed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_value": {
+          "name": "creator_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_profiles_id_fk": {
+          "name": "invites_created_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_profiles_id_fk": {
+          "name": "invites_redeemed_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "redeemed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_redemption_pair": {
+          "name": "invites_redemption_pair",
+          "value": "(\"invites\".\"redeemed_by\" IS NULL) = (\"invites\".\"redeemed_at\" IS NULL)"
+        },
+        "invites_expires_after_created": {
+          "name": "invites_expires_after_created",
+          "value": "\"invites\".\"expires_at\" > \"invites\".\"created_at\""
+        },
+        "invites_creator_value_range": {
+          "name": "invites_creator_value_range",
+          "value": "\"invites\".\"creator_value\" IS NULL OR (\"invites\".\"creator_value\" BETWEEN 1 AND 4)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profile_programs": {
+      "name": "profile_programs",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_programs_profile_id_profiles_id_fk": {
+          "name": "profile_programs_profile_id_profiles_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_programs_program_id_programs_id_fk": {
+          "name": "profile_programs_program_id_programs_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_programs_profile_id_program_id_pk": {
+          "name": "profile_programs_profile_id_program_id_pk",
+          "columns": [
+            "profile_id",
+            "program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplementary_info": {
+          "name": "supplementary_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by": {
+          "name": "referred_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by_legacy": {
+          "name": "referred_by_legacy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_desire": {
+          "name": "live_desire",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_updated_web": {
+          "name": "last_updated_web",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profiles_referred_by_profiles_id_fk": {
+          "name": "profiles_referred_by_profiles_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "referred_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_slug_unique": {
+          "name": "profiles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "programs_created_by_profiles_id_fk": {
+          "name": "programs_created_by_profiles_id_fk",
+          "tableFrom": "programs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_slug_unique": {
+          "name": "programs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "rater_id": {
+          "name": "rater_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hint": {
+          "name": "is_hint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hinted_by": {
+          "name": "hinted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "relations_rater_id_profiles_id_fk": {
+          "name": "relations_rater_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "rater_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_ratee_id_profiles_id_fk": {
+          "name": "relations_ratee_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_hinted_by_profiles_id_fk": {
+          "name": "relations_hinted_by_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "hinted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "relations_rater_id_ratee_id_pk": {
+          "name": "relations_rater_id_ratee_id_pk",
+          "columns": [
+            "rater_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relations_no_self": {
+          "name": "relations_no_self",
+          "value": "\"relations\".\"rater_id\" != \"relations\".\"ratee_id\""
+        },
+        "relations_value_range": {
+          "name": "relations_value_range",
+          "value": "\"relations\".\"value\" IS NULL OR (\"relations\".\"value\" BETWEEN 1 AND 4)"
+        },
+        "relations_hint_state": {
+          "name": "relations_hint_state",
+          "value": "(NOT \"relations\".\"is_hint\" AND \"relations\".\"value\" IS NOT NULL)\n       OR (\"relations\".\"is_hint\" AND \"relations\".\"value\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1778171917828,
       "tag": "0004_add_profile_slug",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1778825031815,
+      "tag": "0005_naive_sentinel",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { requireAdmin } from "@/lib/api-server";
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireAdmin();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <div className="flex w-full max-w-3xl items-center justify-between">
+        <div className="flex items-center gap-4">
+          <h1 className="text-2xl font-bold">Admin</h1>
+          <nav className="flex gap-4 text-sm text-muted-foreground">
+            <Link href="/admin/programs" className="hover:text-foreground">
+              Programs
+            </Link>
+            <Link href="/admin/members" className="hover:text-foreground">
+              Members
+            </Link>
+          </nav>
+        </div>
+        <Link href="/" className="text-sm text-muted-foreground hover:text-foreground">
+          ← Back
+        </Link>
+      </div>
+      {children}
+    </main>
+  );
+}

--- a/src/app/admin/members/members-admin-panel.tsx
+++ b/src/app/admin/members/members-admin-panel.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { apiClient } from "@/lib/api";
+import type { AdminMember } from "@/lib/api-types";
+import { Button } from "@/components/ui/button";
+
+type ToggleState = { kind: "idle" } | { kind: "saving" } | { kind: "error"; message: string };
+
+export function MembersAdminPanel({
+  members: initialMembers,
+  currentUserId,
+}: {
+  members: AdminMember[];
+  currentUserId: string;
+}) {
+  const [members, setMembers] = useState<AdminMember[]>(initialMembers);
+  const [toggleState, setToggleState] = useState<Record<string, ToggleState>>({});
+
+  const toggle = useCallback(
+    async (member: AdminMember) => {
+      setToggleState((prev) => ({ ...prev, [member.id]: { kind: "saving" } }));
+      try {
+        const res = await apiClient.api.admin.members[":id"].admin.$patch(
+          { param: { id: member.id }, json: { isAdmin: !member.isAdmin } } as never,
+        );
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          const error = (body as Record<string, unknown>).error;
+          if (res.status === 403 && error === "self_demotion") {
+            setToggleState((prev) => ({
+              ...prev,
+              [member.id]: { kind: "error", message: "You cannot remove your own admin status." },
+            }));
+            return;
+          }
+          if (res.status === 409 && error === "last_admin") {
+            setToggleState((prev) => ({
+              ...prev,
+              [member.id]: { kind: "error", message: "Cannot remove the last admin." },
+            }));
+            return;
+          }
+          setToggleState((prev) => ({
+            ...prev,
+            [member.id]: { kind: "error", message: `Something went wrong (${res.status}).` },
+          }));
+          return;
+        }
+        setMembers((prev) =>
+          prev.map((m) => (m.id === member.id ? { ...m, isAdmin: !member.isAdmin } : m)),
+        );
+        setToggleState((prev) => ({ ...prev, [member.id]: { kind: "idle" } }));
+      } catch {
+        setToggleState((prev) => ({
+          ...prev,
+          [member.id]: { kind: "error", message: "Network error. Please try again." },
+        }));
+      }
+    },
+    [],
+  );
+
+  return (
+    <section className="flex w-full max-w-3xl flex-col gap-4">
+      <h2 className="text-lg font-semibold">Members</h2>
+      <ul className="flex flex-col gap-2">
+        {members.map((member) => {
+          const state = toggleState[member.id] ?? { kind: "idle" };
+          const isSelf = member.id === currentUserId;
+          const initials = member.displayName ? member.displayName[0].toUpperCase() : "?";
+
+          return (
+            <li
+              key={member.id}
+              className="flex items-center gap-3 rounded border border-border p-3"
+            >
+              {member.avatarUrl ? (
+                <img
+                  src={member.avatarUrl}
+                  alt=""
+                  className="h-8 w-8 rounded-full object-cover"
+                />
+              ) : (
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-medium text-muted-foreground">
+                  {initials}
+                </div>
+              )}
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="font-medium">
+                  {member.displayName ?? "(unnamed)"}
+                </span>
+                {member.location && (
+                  <span className="text-sm text-muted-foreground">{member.location}</span>
+                )}
+              </div>
+              {member.isAdmin && (
+                <span className="text-xs font-semibold uppercase tracking-wide text-primary">
+                  Admin
+                </span>
+              )}
+              <div className="flex flex-col items-end gap-1">
+                {isSelf ? (
+                  <Button size="sm" disabled title="You cannot remove your own admin access">
+                    Admin (you)
+                  </Button>
+                ) : member.isAdmin ? (
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    disabled={state.kind === "saving"}
+                    onClick={() => toggle(member)}
+                  >
+                    {state.kind === "saving" ? "Saving…" : "Remove admin"}
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    disabled={state.kind === "saving"}
+                    onClick={() => toggle(member)}
+                  >
+                    {state.kind === "saving" ? "Saving…" : "Make admin"}
+                  </Button>
+                )}
+                {state.kind === "error" && (
+                  <p role="alert" className="text-sm text-destructive">
+                    {state.message}
+                  </p>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/admin/members/page.tsx
+++ b/src/app/admin/members/page.tsx
@@ -1,0 +1,10 @@
+import { requireAdmin, serverApiClient } from "@/lib/api-server";
+import { MembersAdminPanel } from "./members-admin-panel";
+
+export default async function AdminMembersPage() {
+  const me = await requireAdmin();
+  const res = await serverApiClient.api.admin.members.$get();
+  if (!res.ok) throw new Error("Failed to load members");
+  const { members } = await res.json();
+  return <MembersAdminPanel members={members} currentUserId={me.id} />;
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+export default function AdminPage() {
+  return (
+    <div className="flex w-full max-w-3xl flex-col gap-4">
+      <p className="text-muted-foreground">
+        Manage programs and members for Intentional Society.
+      </p>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Link
+          href="/admin/programs"
+          className="rounded border border-border p-6 hover:bg-muted/50 transition-colors"
+        >
+          <h2 className="font-semibold">Programs</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Create, edit, and manage program membership.
+          </p>
+        </Link>
+        <Link
+          href="/admin/members"
+          className="rounded border border-border p-6 hover:bg-muted/50 transition-colors"
+        >
+          <h2 className="font-semibold">Members</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            View all members and manage admin access.
+          </p>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/programs/page.tsx
+++ b/src/app/admin/programs/page.tsx
@@ -1,0 +1,10 @@
+import { requireAdmin, serverApiClient } from "@/lib/api-server";
+import { ProgramsAdminPanel } from "./programs-admin-panel";
+
+export default async function AdminProgramsPage() {
+  await requireAdmin();
+  const res = await serverApiClient.api.admin.programs.$get();
+  if (!res.ok) throw new Error("Failed to load programs");
+  const { programs } = await res.json();
+  return <ProgramsAdminPanel programs={programs} />;
+}

--- a/src/app/admin/programs/programs-admin-panel.tsx
+++ b/src/app/admin/programs/programs-admin-panel.tsx
@@ -1,0 +1,617 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { apiClient } from "@/lib/api";
+import type { AdminMember, AdminProgram, AdminProgramMember } from "@/lib/api-types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+type SaveState = { kind: "idle" } | { kind: "saving" } | { kind: "error"; message: string };
+type Tab = "settings" | "members";
+
+const toSlug = (name: string) =>
+  name.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+function formatDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function ProgramsAdminPanel({ programs: initialPrograms }: { programs: AdminProgram[] }) {
+  const [programs, setPrograms] = useState<AdminProgram[]>(initialPrograms);
+
+  // Create form
+  const [showCreate, setShowCreate] = useState(false);
+  const [createName, setCreateName] = useState("");
+  const [createSlug, setCreateSlug] = useState("");
+  const [createSlugTouched, setCreateSlugTouched] = useState(false);
+  const [createSlugCustomizing, setCreateSlugCustomizing] = useState(false);
+  const [createDesc, setCreateDesc] = useState("");
+  const [createActive, setCreateActive] = useState(true);
+  const [createState, setCreateState] = useState<SaveState>({ kind: "idle" });
+
+  // Selected program (expanded row with tabs)
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedTab, setSelectedTab] = useState<Tab>("settings");
+
+  // Edit form (inside Settings tab)
+  const [editName, setEditName] = useState("");
+  const [editSlug, setEditSlug] = useState("");
+  const [editSlugCustomizing, setEditSlugCustomizing] = useState(false);
+  const [editDesc, setEditDesc] = useState("");
+  const [editActive, setEditActive] = useState(true);
+  const [editState, setEditState] = useState<SaveState>({ kind: "idle" });
+
+  // Member management (inside Members tab)
+  const [programMembers, setProgramMembers] = useState<Record<string, AdminProgramMember[]>>({});
+  const [allMembers, setAllMembers] = useState<AdminMember[] | null>(null);
+  const [memberSearch, setMemberSearch] = useState("");
+  const [memberOpState, setMemberOpState] = useState<SaveState>({ kind: "idle" });
+
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    const res = await apiClient.api.admin.programs.$get();
+    if (res.ok) {
+      const { programs: loaded } = await res.json();
+      setPrograms(loaded);
+    }
+  }, []);
+
+  const selectProgram = (program: AdminProgram) => {
+    if (selectedId === program.id) {
+      setSelectedId(null);
+      return;
+    }
+    setSelectedId(program.id);
+    setSelectedTab("settings");
+    setEditName(program.name);
+    setEditSlug(program.slug);
+    setEditSlugCustomizing(false);
+    setEditDesc(program.description ?? "");
+    setEditActive(program.isActive);
+    setEditState({ kind: "idle" });
+    setMemberSearch("");
+    setMemberOpState({ kind: "idle" });
+  };
+
+  const handleMembersTab = async (programId: string) => {
+    setSelectedTab("members");
+    if (!programMembers[programId]) {
+      const res = await apiClient.api.admin.programs[":id"].members.$get({ param: { id: programId } });
+      if (res.ok) {
+        const { members } = await res.json();
+        setProgramMembers((prev) => ({ ...prev, [programId]: members }));
+      }
+    }
+    if (allMembers === null) {
+      const res = await apiClient.api.admin.members.$get();
+      if (res.ok) {
+        const { members } = await res.json();
+        setAllMembers(members);
+      }
+    }
+  };
+
+  const handleCreate = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setCreateState({ kind: "saving" });
+    try {
+      const res = await apiClient.api.admin.programs.$post({
+        json: {
+          name: createName,
+          slug: createSlug || undefined,
+          description: createDesc || undefined,
+          isActive: createActive,
+        },
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        const error = (body as Record<string, unknown>).error;
+        if (res.status === 409 && error === "slug_taken") {
+          setCreateState({ kind: "error", message: "This URL slug is already in use by another program." });
+          return;
+        }
+        setCreateState({ kind: "error", message: `Failed to create program (${res.status}).` });
+        return;
+      }
+      setCreateName("");
+      setCreateSlug("");
+      setCreateSlugTouched(false);
+      setCreateSlugCustomizing(false);
+      setCreateDesc("");
+      setCreateActive(true);
+      setCreateState({ kind: "idle" });
+      setShowCreate(false);
+      await reload();
+    } catch {
+      setCreateState({ kind: "error", message: "Network error. Please try again." });
+    }
+  };
+
+  const handleEdit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!selectedId) return;
+    setEditState({ kind: "saving" });
+    try {
+      const res = await apiClient.api.admin.programs[":id"].$put(
+        {
+          param: { id: selectedId },
+          json: { name: editName, slug: editSlug || undefined, description: editDesc || null, isActive: editActive },
+        } as never,
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        const error = (body as Record<string, unknown>).error;
+        if (res.status === 409 && error === "slug_taken") {
+          setEditState({ kind: "error", message: "This URL slug is already in use by another program." });
+          return;
+        }
+        setEditState({ kind: "error", message: `Failed to update program (${res.status}).` });
+        return;
+      }
+      setEditState({ kind: "idle" });
+      await reload();
+    } catch {
+      setEditState({ kind: "error", message: "Network error. Please try again." });
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm("Delete this program? This cannot be undone.")) return;
+    setDeleteError(null);
+    try {
+      const res = await apiClient.api.admin.programs[":id"].$delete({ param: { id } });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        const b = body as Record<string, unknown>;
+        if (res.status === 409 && b.error === "has_members") {
+          const memberCount = typeof b.memberCount === "number" ? b.memberCount : "some";
+          setDeleteError(`Cannot delete — this program has ${memberCount} member(s). Remove them first.`);
+          return;
+        }
+        setDeleteError(`Failed to delete program (${res.status}).`);
+        return;
+      }
+      if (selectedId === id) setSelectedId(null);
+      setPrograms((prev) => prev.filter((p) => p.id !== id));
+    } catch {
+      setDeleteError("Network error. Please try again.");
+    }
+  };
+
+  const handleRemoveMember = async (programId: string, profileId: string) => {
+    setMemberOpState({ kind: "saving" });
+    try {
+      const res = await apiClient.api.admin.programs[":id"].members[":profileId"].$delete({
+        param: { id: programId, profileId },
+      });
+      if (!res.ok) {
+        setMemberOpState({ kind: "error", message: `Failed to remove member (${res.status}).` });
+        return;
+      }
+      setProgramMembers((prev) => ({
+        ...prev,
+        [programId]: (prev[programId] ?? []).filter((m) => m.id !== profileId),
+      }));
+      setPrograms((prev) =>
+        prev.map((p) =>
+          p.id === programId ? { ...p, memberCount: Math.max(0, p.memberCount - 1) } : p,
+        ),
+      );
+      setMemberOpState({ kind: "idle" });
+    } catch {
+      setMemberOpState({ kind: "error", message: "Network error. Please try again." });
+    }
+  };
+
+  const handleAssignMember = async (programId: string, profileId: string) => {
+    setMemberOpState({ kind: "saving" });
+    try {
+      const res = await apiClient.api.admin.programs[":id"].members.$post(
+        { param: { id: programId }, json: { profileId } } as never,
+      );
+      if (!res.ok) {
+        setMemberOpState({ kind: "error", message: `Failed to assign member (${res.status}).` });
+        return;
+      }
+      const assigned = allMembers?.find((m) => m.id === profileId);
+      if (assigned) {
+        const newMember: AdminProgramMember = {
+          id: assigned.id,
+          displayName: assigned.displayName,
+          slug: assigned.slug,
+          avatarUrl: assigned.avatarUrl,
+          assignedAt: new Date().toISOString(),
+        };
+        setProgramMembers((prev) => ({
+          ...prev,
+          [programId]: [...(prev[programId] ?? []), newMember],
+        }));
+        setPrograms((prev) =>
+          prev.map((p) =>
+            p.id === programId ? { ...p, memberCount: p.memberCount + 1 } : p,
+          ),
+        );
+      }
+      setMemberSearch("");
+      setMemberOpState({ kind: "idle" });
+    } catch {
+      setMemberOpState({ kind: "error", message: "Network error. Please try again." });
+    }
+  };
+
+  return (
+    <section className="flex w-full max-w-3xl flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Programs</h2>
+        <Button
+          size="sm"
+          onClick={() => {
+            setShowCreate((v) => !v);
+            setCreateName("");
+            setCreateSlug("");
+            setCreateSlugTouched(false);
+            setCreateSlugCustomizing(false);
+            setCreateDesc("");
+            setCreateActive(true);
+            setCreateState({ kind: "idle" });
+          }}
+        >
+          {showCreate ? "Cancel" : "New program"}
+        </Button>
+      </div>
+
+      {deleteError && (
+        <p role="alert" className="text-sm text-destructive">
+          {deleteError}
+        </p>
+      )}
+
+      {showCreate && (
+        <form
+          onSubmit={handleCreate}
+          className="flex flex-col gap-3 rounded border border-border p-4"
+        >
+          <h3 className="font-semibold">New program</h3>
+
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="create-name">Name</Label>
+            <Input
+              id="create-name"
+              required
+              value={createName}
+              onChange={(e) => {
+                setCreateName(e.target.value);
+                if (!createSlugTouched) setCreateSlug(toSlug(e.target.value));
+              }}
+              disabled={createState.kind === "saving"}
+            />
+            {createName && (
+              <p className="text-sm text-muted-foreground">
+                URL: /programs/
+                <span className="font-mono">{createSlug || "…"}</span>
+                {!createSlugCustomizing && (
+                  <button
+                    type="button"
+                    className="ml-2 text-primary underline"
+                    onClick={() => setCreateSlugCustomizing(true)}
+                  >
+                    Customize
+                  </button>
+                )}
+              </p>
+            )}
+          </div>
+
+          {createSlugCustomizing && (
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="create-slug">URL slug</Label>
+              <Input
+                id="create-slug"
+                value={createSlug}
+                onChange={(e) => {
+                  setCreateSlug(e.target.value);
+                  setCreateSlugTouched(true);
+                }}
+                disabled={createState.kind === "saving"}
+              />
+              {createSlug !== toSlug(createName) && createSlug !== "" && (
+                <p className="text-sm text-amber-600">
+                  Heads up: changing the slug will break any existing links to this program.
+                </p>
+              )}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="create-desc">Description</Label>
+            <Textarea
+              id="create-desc"
+              rows={2}
+              value={createDesc}
+              onChange={(e) => setCreateDesc(e.target.value)}
+              disabled={createState.kind === "saving"}
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="create-active"
+              checked={createActive}
+              onChange={(e) => setCreateActive(e.target.checked)}
+              className="h-4 w-4"
+            />
+            <Label htmlFor="create-active">Active (visible to members)</Label>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button type="submit" size="sm" disabled={createState.kind === "saving"}>
+              {createState.kind === "saving" ? "Creating…" : "Create program"}
+            </Button>
+          </div>
+
+          {createState.kind === "error" && (
+            <p role="alert" className="text-sm text-destructive">
+              {createState.message}
+            </p>
+          )}
+        </form>
+      )}
+
+      <ul className="flex flex-col gap-2">
+        {programs.map((program) => {
+          const isSelected = selectedId === program.id;
+          const memberCount = program.memberCount;
+
+          return (
+            <li
+              key={program.id}
+              className={`rounded border border-border${!program.isActive ? " opacity-60" : ""}`}
+            >
+              {/* Row header — click to expand/collapse */}
+              <div className="flex items-start gap-2 p-3">
+                <button
+                  type="button"
+                  className="flex flex-1 items-start gap-2 text-left"
+                  onClick={() => selectProgram(program)}
+                >
+                  <span className="mt-1 shrink-0 text-xs text-muted-foreground">
+                    {isSelected ? "▼" : "▶"}
+                  </span>
+                  <span className="flex flex-col gap-0.5">
+                    <span className="flex flex-wrap items-center gap-2">
+                      <span className="font-semibold">{program.name}</span>
+                      {!program.isActive && (
+                        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          Inactive
+                        </span>
+                      )}
+                      <span className="text-sm text-muted-foreground">
+                        {memberCount} {memberCount === 1 ? "member" : "members"}
+                      </span>
+                    </span>
+                    <span className="text-sm text-muted-foreground">
+                      Created {formatDate(program.createdAt)}
+                    </span>
+                  </span>
+                </button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => handleDelete(program.id)}
+                >
+                  Delete
+                </Button>
+              </div>
+
+              {/* Tab panel */}
+              {isSelected && (
+                <div className="border-t border-border">
+                  {/* Tab headers */}
+                  <div className="flex border-b border-border">
+                    <button
+                      type="button"
+                      className={`px-4 py-2 text-sm font-medium transition-colors ${
+                        selectedTab === "settings"
+                          ? "border-b-2 border-primary text-primary"
+                          : "text-muted-foreground hover:text-foreground"
+                      }`}
+                      onClick={() => setSelectedTab("settings")}
+                    >
+                      Settings
+                    </button>
+                    <button
+                      type="button"
+                      className={`px-4 py-2 text-sm font-medium transition-colors ${
+                        selectedTab === "members"
+                          ? "border-b-2 border-primary text-primary"
+                          : "text-muted-foreground hover:text-foreground"
+                      }`}
+                      onClick={() => handleMembersTab(program.id)}
+                    >
+                      Members ({memberCount})
+                    </button>
+                  </div>
+
+                  {/* Settings tab */}
+                  {selectedTab === "settings" && (
+                    <form onSubmit={handleEdit} className="flex flex-col gap-3 p-4">
+                      <div className="flex flex-col gap-1">
+                        <Label htmlFor={`edit-name-${program.id}`}>Name</Label>
+                        <Input
+                          id={`edit-name-${program.id}`}
+                          required
+                          value={editName}
+                          onChange={(e) => setEditName(e.target.value)}
+                          disabled={editState.kind === "saving"}
+                        />
+                        <p className="text-sm text-muted-foreground">
+                          URL: /programs/
+                          <span className="font-mono">{editSlug || "…"}</span>
+                          {!editSlugCustomizing && (
+                            <button
+                              type="button"
+                              className="ml-2 text-primary underline"
+                              onClick={() => setEditSlugCustomizing(true)}
+                            >
+                              Customize
+                            </button>
+                          )}
+                        </p>
+                      </div>
+
+                      {editSlugCustomizing && (
+                        <div className="flex flex-col gap-1">
+                          <Label htmlFor={`edit-slug-${program.id}`}>URL slug</Label>
+                          <Input
+                            id={`edit-slug-${program.id}`}
+                            value={editSlug}
+                            onChange={(e) => setEditSlug(e.target.value)}
+                            disabled={editState.kind === "saving"}
+                          />
+                          {editSlug !== toSlug(editName) && editSlug !== "" && (
+                            <p className="text-sm text-amber-600">
+                              Heads up: changing the slug will break any existing links to this program.
+                            </p>
+                          )}
+                        </div>
+                      )}
+
+                      <div className="flex flex-col gap-1">
+                        <Label htmlFor={`edit-desc-${program.id}`}>Description</Label>
+                        <Textarea
+                          id={`edit-desc-${program.id}`}
+                          rows={2}
+                          value={editDesc}
+                          onChange={(e) => setEditDesc(e.target.value)}
+                          disabled={editState.kind === "saving"}
+                        />
+                      </div>
+
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          id={`edit-active-${program.id}`}
+                          checked={editActive}
+                          onChange={(e) => setEditActive(e.target.checked)}
+                          className="h-4 w-4"
+                        />
+                        <Label htmlFor={`edit-active-${program.id}`}>Active (visible to members)</Label>
+                      </div>
+
+                      <div className="flex items-center gap-2">
+                        <Button type="submit" size="sm" disabled={editState.kind === "saving"}>
+                          {editState.kind === "saving" ? "Saving…" : "Save changes"}
+                        </Button>
+                      </div>
+
+                      {editState.kind === "error" && (
+                        <p role="alert" className="text-sm text-destructive">
+                          {editState.message}
+                        </p>
+                      )}
+                    </form>
+                  )}
+
+                  {/* Members tab */}
+                  {selectedTab === "members" && (
+                    <div className="flex flex-col gap-3 p-4">
+                      {memberOpState.kind === "error" && (
+                        <p role="alert" className="text-sm text-destructive">
+                          {memberOpState.message}
+                        </p>
+                      )}
+
+                      {programMembers[program.id] === undefined ? (
+                        <p className="text-sm text-muted-foreground">Loading…</p>
+                      ) : (programMembers[program.id] ?? []).length === 0 ? (
+                        <p className="text-sm text-muted-foreground">No members yet.</p>
+                      ) : (
+                        <ul className="flex flex-col gap-1">
+                          {(programMembers[program.id] ?? []).map((m) => (
+                            <li key={m.id} className="flex items-center gap-2">
+                              {m.avatarUrl ? (
+                                <img
+                                  src={m.avatarUrl}
+                                  alt=""
+                                  className="h-6 w-6 rounded-full object-cover"
+                                />
+                              ) : (
+                                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs text-muted-foreground">
+                                  {m.displayName ? m.displayName[0].toUpperCase() : "?"}
+                                </div>
+                              )}
+                              <span className="flex-1 text-sm">{m.displayName ?? "(unnamed)"}</span>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                disabled={memberOpState.kind === "saving"}
+                                onClick={() => handleRemoveMember(program.id, m.id)}
+                              >
+                                Remove
+                              </Button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+
+                      <div className="flex flex-col gap-1 border-t border-border pt-3">
+                        <Label htmlFor={`member-search-${program.id}`}>Add member</Label>
+                        <Input
+                          id={`member-search-${program.id}`}
+                          placeholder="Search by name…"
+                          value={memberSearch}
+                          onChange={(e) => setMemberSearch(e.target.value)}
+                        />
+                        {memberSearch && allMembers && (
+                          <ul className="mt-1 flex flex-col gap-1 rounded border border-border p-1">
+                            {allMembers
+                              .filter(
+                                (m) =>
+                                  !(programMembers[program.id] ?? []).some((pm) => pm.id === m.id) &&
+                                  (m.displayName ?? "")
+                                    .toLowerCase()
+                                    .includes(memberSearch.toLowerCase()),
+                              )
+                              .slice(0, 10)
+                              .map((m) => (
+                                <li key={m.id}>
+                                  <button
+                                    type="button"
+                                    className="w-full rounded px-2 py-1 text-left text-sm hover:bg-muted"
+                                    disabled={memberOpState.kind === "saving"}
+                                    onClick={() => handleAssignMember(program.id, m.id)}
+                                  >
+                                    {m.displayName ?? "(unnamed)"}
+                                    {m.location && (
+                                      <span className="ml-1 text-muted-foreground">— {m.location}</span>
+                                    )}
+                                  </button>
+                                </li>
+                              ))}
+                          </ul>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,7 +40,10 @@ export default async function RootLayout({
     <html lang="en" className={cn("font-sans", gudea.variable, ovo.variable)}>
       <body className="antialiased">
         <AuthProvider initialUser={user}>
-          <SiteHeader displayName={me?.profile?.displayName ?? null} />
+          <SiteHeader
+            displayName={me?.profile?.displayName ?? null}
+            isAdmin={me?.profile?.isAdmin ?? false}
+          />
           {children}
         </AuthProvider>
       </body>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Menu } from "lucide-react";
+import { Menu, Shield } from "lucide-react";
 
 import { useAuth } from "@/components/auth-provider";
 import { Button } from "@/components/ui/button";
@@ -14,7 +14,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 
-export function SiteHeader({ displayName }: { displayName: string | null }) {
+export function SiteHeader({ displayName, isAdmin }: { displayName: string | null; isAdmin: boolean }) {
   const { user } = useAuth();
 
   if (!user) return null;
@@ -72,6 +72,23 @@ export function SiteHeader({ displayName }: { displayName: string | null }) {
                 </Link>
               }
             />
+            {isAdmin && (
+              <>
+                <div className="my-1 border-t border-border" />
+                <SheetClose
+                  nativeButton={false}
+                  render={
+                    <Link
+                      href="/admin"
+                      className="flex items-center gap-2 rounded px-2 py-2 font-medium text-primary hover:bg-muted"
+                    >
+                      <Shield className="h-4 w-4" />
+                      Admin
+                    </Link>
+                  }
+                />
+              </>
+            )}
             <form action="/signout" method="post">
               <SheetClose
                 render={

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -52,3 +52,13 @@ export const requireUser = async (): Promise<Me> => {
   if (!me) redirect("/signin");
   return me;
 };
+
+// Page-level admin gate. Use at the top of any Server Component that
+// requires admin access; redirects to /signin if unauthenticated or /
+// if authenticated but not admin.
+export const requireAdmin = async (): Promise<Me> => {
+  const me = await loadMe();
+  if (!me) redirect("/signin");
+  if (!me.profile?.isAdmin) redirect("/");
+  return me;
+};

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1,6 +1,6 @@
 import type { InferResponseType } from "hono/client";
 
-import { apiClient } from "@/lib/api";
+import type { apiClient } from "@/lib/api";
 
 // Named shapes for API responses, extracted from the Hono route
 // inference. Import these instead of reaching into the RPC client at
@@ -30,3 +30,25 @@ export type ProgramsResponse = InferResponseType<
 >;
 
 export type Program = ProgramsResponse["programs"][number];
+
+export type AdminProgramsResponse = InferResponseType<
+  (typeof apiClient.api.admin.programs)["$get"],
+  200
+>;
+
+export type AdminProgram = AdminProgramsResponse["programs"][number];
+
+export type AdminProgramMembersResponse = InferResponseType<
+  (typeof apiClient.api.admin.programs)[":id"]["members"]["$get"],
+  200
+>;
+
+export type AdminProgramMember =
+  AdminProgramMembersResponse["members"][number];
+
+export type AdminMembersResponse = InferResponseType<
+  (typeof apiClient.api.admin.members)["$get"],
+  200
+>;
+
+export type AdminMember = AdminMembersResponse["members"][number];

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -20,8 +20,31 @@ import {
   upsertProfile,
 } from "./profiles";
 import { joinProgram, leaveProgram, listPrograms } from "./programs";
+import {
+  assignMember,
+  createProgram,
+  deleteProgram,
+  listAdminPrograms,
+  listProgramMembers,
+  removeMember,
+  updateProgram,
+} from "./programs-admin";
+import {
+  listAdminMembers,
+  setAdminStatus,
+} from "./members-admin";
 import { profiles } from "./schema";
 import { resetE2EUsers } from "./test-reset";
+
+// Returns true if the given user id belongs to an admin profile.
+// Used to gate every /api/admin/* route.
+const checkAdmin = async (userId: string): Promise<boolean> => {
+  const [row] = await db
+    .select({ isAdmin: profiles.isAdmin })
+    .from(profiles)
+    .where(eq(profiles.id, userId));
+  return row?.isAdmin ?? false;
+};
 
 const api = new Hono<{ Variables: ApiVariables }>()
   .basePath("/api")
@@ -189,6 +212,148 @@ const api = new Hono<{ Variables: ApiVariables }>()
     }
     return c.json({ ok: true });
   })
+  // ── Admin: programs ──────────────────────────────────────────────
+  .get("/admin/programs", async (c) => {
+    const user = c.get("user");
+    if (!(await checkAdmin(user.id))) return c.json({ error: "forbidden" }, 403);
+    const programsList = await listAdminPrograms();
+    return c.json({ programs: programsList });
+  })
+  .post("/admin/programs", async (c) => {
+    const user = c.get("user");
+    if (!(await checkAdmin(user.id))) return c.json({ error: "forbidden" }, 403);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid JSON" }, 400);
+    }
+    if (!body || typeof body !== "object" || Array.isArray(body))
+      return c.json({ error: "body must be a JSON object" }, 400);
+    const { name, description, slug, isActive } = body as Record<string, unknown>;
+    if (typeof name !== "string") return c.json({ error: "name is required" }, 400);
+    const result = await createProgram({
+      name,
+      description: typeof description === "string" ? description : null,
+      slug: typeof slug === "string" ? slug : null,
+      isActive: typeof isActive === "boolean" ? isActive : undefined,
+      createdBy: user.id,
+    });
+    if ("error" in result) {
+      if (result.error === "slug_taken") return c.json({ error: "slug_taken" }, 409);
+      return c.json({ error: result.error }, 400);
+    }
+    return c.json(result, 201);
+  })
+  .put("/admin/programs/:id", async (c) => {
+    const user = c.get("user");
+    if (!(await checkAdmin(user.id))) return c.json({ error: "forbidden" }, 403);
+    const id = c.req.param("id");
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid JSON" }, 400);
+    }
+    if (!body || typeof body !== "object" || Array.isArray(body))
+      return c.json({ error: "body must be a JSON object" }, 400);
+    const patch = body as Record<string, unknown>;
+    const result = await updateProgram(id, {
+      name: typeof patch.name === "string" ? patch.name : undefined,
+      description:
+        patch.description !== undefined
+          ? typeof patch.description === "string"
+            ? patch.description
+            : null
+          : undefined,
+      slug: typeof patch.slug === "string" ? patch.slug : undefined,
+      isActive: typeof patch.isActive === "boolean" ? patch.isActive : undefined,
+    });
+    if ("error" in result) {
+      if (result.error === "not_found") return c.json({ error: "not_found" }, 404);
+      if (result.error === "slug_taken") return c.json({ error: "slug_taken" }, 409);
+      return c.json({ error: result.error }, 400);
+    }
+    return c.json({ ok: true });
+  })
+  .delete("/admin/programs/:id", async (c) => {
+    const user = c.get("user");
+    if (!(await checkAdmin(user.id))) return c.json({ error: "forbidden" }, 403);
+    const id = c.req.param("id");
+    const result = await deleteProgram(id);
+    if ("error" in result) {
+      if (result.error === "not_found") return c.json({ error: "not_found" }, 404);
+      if (result.error === "has_members")
+        return c.json({ error: "has_members", memberCount: result.memberCount }, 409);
+    }
+    return c.json({ ok: true });
+  })
+  .get("/admin/programs/:id/members", async (c) => {
+    const user = c.get("user");
+    if (!(await checkAdmin(user.id))) return c.json({ error: "forbidden" }, 403);
+    const programId = c.req.param("id");
+    const result = await listProgramMembers(programId);
+    if ("error" in result) return c.json({ error: "not_found" }, 404);
+    return c.json({ members: result });
+  })
+  .post("/admin/programs/:id/members", async (c) => {
+    const user = c.get("user");
+    if (!(await checkAdmin(user.id))) return c.json({ error: "forbidden" }, 403);
+    const programId = c.req.param("id");
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid JSON" }, 400);
+    }
+    const { profileId } = body as Record<string, unknown>;
+    if (typeof profileId !== "string")
+      return c.json({ error: "profileId is required" }, 400);
+    const result = await assignMember(programId, profileId);
+    if ("error" in result) {
+      if (result.error === "not_found") return c.json({ error: "not_found" }, 404);
+      return c.json({ error: "already_assigned" }, 409);
+    }
+    return c.json({ ok: true }, 201);
+  })
+  .delete("/admin/programs/:id/members/:profileId", async (c) => {
+    const user = c.get("user");
+    if (!(await checkAdmin(user.id))) return c.json({ error: "forbidden" }, 403);
+    const programId = c.req.param("id");
+    const profileId = c.req.param("profileId");
+    const result = await removeMember(programId, profileId);
+    if ("error" in result) return c.json({ error: "not_found" }, 404);
+    return c.json({ ok: true });
+  })
+  // ── Admin: members ────────────────────────────────────────────────
+  .get("/admin/members", async (c) => {
+    const user = c.get("user");
+    if (!(await checkAdmin(user.id))) return c.json({ error: "forbidden" }, 403);
+    const members = await listAdminMembers();
+    return c.json({ members });
+  })
+  .patch("/admin/members/:id/admin", async (c) => {
+    const user = c.get("user");
+    if (!(await checkAdmin(user.id))) return c.json({ error: "forbidden" }, 403);
+    const targetId = c.req.param("id");
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid JSON" }, 400);
+    }
+    const { isAdmin: targetIsAdmin } = body as Record<string, unknown>;
+    if (typeof targetIsAdmin !== "boolean")
+      return c.json({ error: "isAdmin must be a boolean" }, 400);
+    const result = await setAdminStatus(targetId, targetIsAdmin, user.id);
+    if ("error" in result) {
+      if (result.error === "not_found") return c.json({ error: "not_found" }, 404);
+      if (result.error === "self_demotion") return c.json({ error: "self_demotion" }, 403);
+      if (result.error === "last_admin") return c.json({ error: "last_admin" }, 409);
+    }
+    return c.json({ ok: true });
+  })
+  // ── Health ────────────────────────────────────────────────────────
   .get("/health", async (c) => {
     const result = await db.execute(sql`SELECT now() AS server_time`);
     return c.json({

--- a/src/server/members-admin.ts
+++ b/src/server/members-admin.ts
@@ -1,0 +1,66 @@
+import { count, desc, eq } from "drizzle-orm";
+
+import { db } from "./db";
+import { profiles } from "./schema";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const isValidUuid = (s: string): boolean => UUID_RE.test(s);
+
+export type AdminMember = {
+  id: string;
+  displayName: string | null;
+  slug: string | null;
+  avatarUrl: string | null;
+  location: string | null;
+  isAdmin: boolean;
+  createdAt: string;
+};
+
+export const listAdminMembers = async (): Promise<AdminMember[]> => {
+  const rows = await db
+    .select({
+      id: profiles.id,
+      displayName: profiles.displayName,
+      slug: profiles.slug,
+      avatarUrl: profiles.avatarUrl,
+      location: profiles.location,
+      isAdmin: profiles.isAdmin,
+      createdAt: profiles.createdAt,
+    })
+    .from(profiles)
+    .orderBy(desc(profiles.createdAt));
+
+  return rows.map((r) => ({ ...r, createdAt: r.createdAt.toISOString() }));
+};
+
+export const setAdminStatus = async (
+  targetId: string,
+  isAdmin: boolean,
+  requesterId: string,
+): Promise<
+  { ok: true } | { error: "not_found" | "self_demotion" | "last_admin" }
+> => {
+  if (!isValidUuid(targetId)) return { error: "not_found" };
+
+  // Guard: cannot remove your own admin status
+  if (!isAdmin && targetId === requesterId) return { error: "self_demotion" };
+
+  const [target] = await db
+    .select({ id: profiles.id, isAdmin: profiles.isAdmin })
+    .from(profiles)
+    .where(eq(profiles.id, targetId));
+  if (!target) return { error: "not_found" };
+
+  // Guard: cannot remove the last admin
+  if (!isAdmin && target.isAdmin) {
+    const [{ adminCount }] = await db
+      .select({ adminCount: count() })
+      .from(profiles)
+      .where(eq(profiles.isAdmin, true));
+    if (adminCount <= 1) return { error: "last_admin" };
+  }
+
+  await db.update(profiles).set({ isAdmin }).where(eq(profiles.id, targetId));
+  return { ok: true };
+};

--- a/src/server/programs-admin.ts
+++ b/src/server/programs-admin.ts
@@ -1,0 +1,237 @@
+import { and, count, desc, eq } from "drizzle-orm";
+
+import { db } from "./db";
+import { profilePrograms, profiles, programs } from "./schema";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const isValidUuid = (s: string): boolean => UUID_RE.test(s);
+
+const programSlug = (name: string): string =>
+  name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+
+export type AdminProgram = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  isActive: boolean;
+  createdBy: string | null;
+  memberCount: number;
+  createdAt: string;
+};
+
+export type AdminProgramMember = {
+  id: string;
+  displayName: string | null;
+  slug: string | null;
+  avatarUrl: string | null;
+  assignedAt: string;
+};
+
+export const listAdminPrograms = async (): Promise<AdminProgram[]> => {
+  const rows = await db
+    .select({
+      id: programs.id,
+      slug: programs.slug,
+      name: programs.name,
+      description: programs.description,
+      isActive: programs.isActive,
+      createdBy: programs.createdBy,
+      createdAt: programs.createdAt,
+    })
+    .from(programs)
+    .orderBy(desc(programs.createdAt));
+
+  const counts = await db
+    .select({ programId: profilePrograms.programId, n: count() })
+    .from(profilePrograms)
+    .groupBy(profilePrograms.programId);
+
+  const countMap = new Map(counts.map((c) => [c.programId, c.n]));
+
+  return rows.map((r) => ({
+    ...r,
+    createdAt: r.createdAt.toISOString(),
+    memberCount: countMap.get(r.id) ?? 0,
+  }));
+};
+
+export const createProgram = async (data: {
+  name: string;
+  description: string | null;
+  slug?: string | null;
+  isActive?: boolean;
+  createdBy: string;
+}): Promise<
+  { id: string; slug: string } | { error: "invalid_name" | "slug_taken" }
+> => {
+  const name = data.name.trim();
+  if (!name) return { error: "invalid_name" };
+
+  const slug = data.slug?.trim() || programSlug(name);
+
+  const [existing] = await db
+    .select({ id: programs.id })
+    .from(programs)
+    .where(eq(programs.slug, slug));
+  if (existing) return { error: "slug_taken" };
+
+  const [created] = await db
+    .insert(programs)
+    .values({
+      name,
+      description: data.description,
+      slug,
+      isActive: data.isActive ?? true,
+      createdBy: data.createdBy,
+    })
+    .returning({ id: programs.id, slug: programs.slug });
+
+  return created;
+};
+
+export const updateProgram = async (
+  id: string,
+  data: { name?: string; description?: string | null; slug?: string | null; isActive?: boolean },
+): Promise<
+  { ok: true } | { error: "not_found" | "invalid_name" | "slug_taken" }
+> => {
+  if (!isValidUuid(id)) return { error: "not_found" };
+
+  const [existing] = await db
+    .select({ id: programs.id, slug: programs.slug })
+    .from(programs)
+    .where(eq(programs.id, id));
+  if (!existing) return { error: "not_found" };
+
+  if (data.name !== undefined && !data.name.trim()) return { error: "invalid_name" };
+
+  const update: { name?: string; description?: string | null; slug?: string; isActive?: boolean } = {};
+  if (data.name !== undefined) update.name = data.name.trim();
+  if (data.description !== undefined) update.description = data.description;
+  if (data.isActive !== undefined) update.isActive = data.isActive;
+
+  // Explicit slug override takes priority; else auto-generate from name change
+  const targetSlug =
+    data.slug?.trim() || (data.name ? programSlug(data.name.trim()) : null);
+  if (targetSlug && targetSlug !== existing.slug) {
+    const [conflict] = await db
+      .select({ id: programs.id })
+      .from(programs)
+      .where(eq(programs.slug, targetSlug));
+    if (conflict) return { error: "slug_taken" };
+    update.slug = targetSlug;
+  }
+
+  if (Object.keys(update).length > 0) {
+    await db.update(programs).set(update).where(eq(programs.id, id));
+  }
+
+  return { ok: true };
+};
+
+export const deleteProgram = async (
+  id: string,
+): Promise<
+  { ok: true } | { error: "not_found" | "has_members"; memberCount?: number }
+> => {
+  if (!isValidUuid(id)) return { error: "not_found" };
+
+  const [program] = await db
+    .select({ id: programs.id })
+    .from(programs)
+    .where(eq(programs.id, id));
+  if (!program) return { error: "not_found" };
+
+  const [{ memberCount }] = await db
+    .select({ memberCount: count() })
+    .from(profilePrograms)
+    .where(eq(profilePrograms.programId, id));
+
+  if (memberCount > 0) return { error: "has_members", memberCount };
+
+  await db.delete(programs).where(eq(programs.id, id));
+  return { ok: true };
+};
+
+export const listProgramMembers = async (
+  programId: string,
+): Promise<AdminProgramMember[] | { error: "not_found" }> => {
+  if (!isValidUuid(programId)) return { error: "not_found" };
+
+  const [program] = await db
+    .select({ id: programs.id })
+    .from(programs)
+    .where(eq(programs.id, programId));
+  if (!program) return { error: "not_found" };
+
+  const rows = await db
+    .select({
+      id: profiles.id,
+      displayName: profiles.displayName,
+      slug: profiles.slug,
+      avatarUrl: profiles.avatarUrl,
+      assignedAt: profilePrograms.assignedAt,
+    })
+    .from(profilePrograms)
+    .innerJoin(profiles, eq(profilePrograms.profileId, profiles.id))
+    .where(eq(profilePrograms.programId, programId))
+    .orderBy(profiles.displayName);
+
+  return rows.map((r) => ({ ...r, assignedAt: r.assignedAt.toISOString() }));
+};
+
+export const assignMember = async (
+  programId: string,
+  profileId: string,
+): Promise<{ ok: true } | { error: "not_found" | "already_assigned" }> => {
+  if (!isValidUuid(programId) || !isValidUuid(profileId))
+    return { error: "not_found" };
+
+  const [prog] = await db
+    .select({ id: programs.id })
+    .from(programs)
+    .where(eq(programs.id, programId));
+  if (!prog) return { error: "not_found" };
+
+  const [member] = await db
+    .select({ id: profiles.id })
+    .from(profiles)
+    .where(eq(profiles.id, profileId));
+  if (!member) return { error: "not_found" };
+
+  const result = await db
+    .insert(profilePrograms)
+    .values({ profileId, programId })
+    .onConflictDoNothing()
+    .returning({ profileId: profilePrograms.profileId });
+
+  if (result.length === 0) return { error: "already_assigned" };
+  return { ok: true };
+};
+
+export const removeMember = async (
+  programId: string,
+  profileId: string,
+): Promise<{ ok: true } | { error: "not_found" }> => {
+  if (!isValidUuid(programId) || !isValidUuid(profileId))
+    return { error: "not_found" };
+
+  const result = await db
+    .delete(profilePrograms)
+    .where(
+      and(
+        eq(profilePrograms.profileId, profileId),
+        eq(profilePrograms.programId, programId),
+      ),
+    )
+    .returning({ profileId: profilePrograms.profileId });
+
+  if (result.length === 0) return { error: "not_found" };
+  return { ok: true };
+};

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -23,6 +23,7 @@ export type ProgramWithMembership = {
 export const listPrograms = async (
   userId: string,
 ): Promise<ProgramWithMembership[]> => {
+  // Only show active programs to members; admin view shows all via listAdminPrograms
   const rows = await db
     .select({
       id: programs.id,
@@ -40,6 +41,7 @@ export const listPrograms = async (
       )`,
     })
     .from(programs)
+    .where(eq(programs.isActive, true))
     .orderBy(programs.name);
 
   return rows.map((r) => ({

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -62,6 +62,10 @@ export const programs = pgTable("programs", {
   slug: text("slug").notNull().unique(),
   name: text("name").notNull(),
   description: text("description"),
+  isActive: boolean("is_active").notNull().default(true),
+  createdBy: uuid("created_by").references((): AnyPgColumn => profiles.id, {
+    onDelete: "set null",
+  }),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/tests/functional/client/site-header.test.tsx
+++ b/tests/functional/client/site-header.test.tsx
@@ -22,7 +22,7 @@ describe("SiteHeader", () => {
   it("renders nothing when there is no user", () => {
     const { container } = render(
       <AuthProvider initialUser={null}>
-        <SiteHeader displayName={null} />
+        <SiteHeader displayName={null} isAdmin={false} />
       </AuthProvider>,
     );
     expect(container).toBeEmptyDOMElement();
@@ -31,7 +31,7 @@ describe("SiteHeader", () => {
   it("renders the menu trigger when a user is present", () => {
     render(
       <AuthProvider initialUser={user}>
-        <SiteHeader displayName={null} />
+        <SiteHeader displayName={null} isAdmin={false} />
       </AuthProvider>,
     );
     expect(screen.getByRole("button", { name: /open menu/i })).toBeVisible();
@@ -41,11 +41,32 @@ describe("SiteHeader", () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     render(
       <AuthProvider initialUser={user}>
-        <SiteHeader displayName={null} />
+        <SiteHeader displayName={null} isAdmin={false} />
       </AuthProvider>,
     );
     fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
     expect(await screen.findByText("Home")).toBeVisible();
     expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows Admin link when isAdmin is true", async () => {
+    render(
+      <AuthProvider initialUser={user}>
+        <SiteHeader displayName={null} isAdmin={true} />
+      </AuthProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
+    expect(await screen.findByText("Admin")).toBeVisible();
+  });
+
+  it("hides Admin link when isAdmin is false", async () => {
+    render(
+      <AuthProvider initialUser={user}>
+        <SiteHeader displayName={null} isAdmin={false} />
+      </AuthProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
+    await screen.findByText("Home");
+    expect(screen.queryByText("Admin")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Adds `/admin` dashboard gated behind `isAdmin` flag on the caller's profile — non-admins are redirected server-side before any HTML is sent
- **Programs** (`/admin/programs`): full CRUD with create/edit (auto-slug with URL preview and optional Customize toggle), delete with member-count guard, and a tab panel (Settings | Members) per program for inline member assign/remove
- **Members** (`/admin/members`): grant or revoke admin status per member, with self-demotion and last-admin guards enforced at both API and UI level
- Admin nav link (Shield icon + divider) in the site header, visible only when `isAdmin === true`
- Migration adds `is_active` and `created_by` columns to `programs`; `is_active` filters inactive programs from the member-facing `/programs` page

## Test plan

- [ ] CI lint + functional tests pass
- [ ] Vercel preview deploys and e2e tests pass
- [ ] Sign in as `e2e-admin@testfake.local` on the preview URL — confirm Admin link appears in nav
- [ ] `/admin` dashboard shows Programs and Members cards
- [ ] `/admin/programs`: create a program (check URL preview auto-fills), edit it, expand Settings and Members tabs, assign/remove a member, delete a program with members (expect error), delete an empty one
- [ ] `/admin/members`: toggle admin on a non-self account; confirm self-toggle is disabled
- [ ] Sign in as `e2e-regular@testfake.local` — confirm `/admin` redirects to `/`

## Notes

- E2E specs for the admin surface are tracked as future work (`docs/admin-implementation.md` — Future work section); `e2e-admin@testfake.local` is already seeded in production Supabase with `is_admin = true`
- The Dependabot alerts are pre-existing on `main`, not introduced by this branch

🤖 Generated with [Claude Code](https://claude.ai/claude-code)