### PR TITLE
Drop the e2e reset's db.transaction (suspected #149 fix); add read-back probe

### DIFF
--- a/src/server/test-reset.ts
+++ b/src/server/test-reset.ts
@@ -42,17 +42,22 @@ export const resetE2EUsers = async (): Promise<{
   // ids the UPDATE's RETURNING reported — one entry per row touched, so
   // a duplicated id surfaces here as a repeat.
   updatedIds: string[];
-  // Post-commit read-back per seeded id. `rows` holds every physical
-  // profile row for that id; length > 1 means duplicate tuples.
-  profiles: { id: string; rows: ResetProbeRow[] }[];
+  // Post-commit read-back per seeded user. `rows` holds every physical
+  // profile row for that id: length 0 means no profile row at all (fine
+  // — e.g. e2e-admin, which no test signs in as), length > 1 means
+  // duplicate tuples.
+  profiles: { id: string; email: string; rows: ResetProbeRow[] }[];
 }> => {
   const emailList = sql.join(
     E2E_EMAILS.map((e) => sql`${e}`),
     sql`, `,
   );
-  const rows = await db.execute(sql`SELECT id FROM auth.users WHERE email IN (${emailList})`);
-  const ids = (rows as unknown as { id: string }[]).map((r) => r.id);
-  if (ids.length === 0) return { reset: 0, updatedIds: [], profiles: [] };
+  const users = (await db.execute(sql`SELECT id, email FROM auth.users WHERE email IN (${emailList})`)) as unknown as {
+    id: string;
+    email: string;
+  }[];
+  if (users.length === 0) return { reset: 0, updatedIds: [], profiles: [] };
+  const ids = users.map((u) => u.id);
 
   let updatedIds: string[] = [];
   await db.transaction(async (tx) => {
@@ -84,7 +89,7 @@ export const resetE2EUsers = async (): Promise<{
   // current_setting('search_path') / inet_server_addr characterise the
   // connection this read happened to land on.
   const profilesAfter = await Promise.all(
-    ids.map(async (id) => {
+    users.map(async ({ id, email }) => {
       const probe = (await db.execute(sql`
         SELECT
           ctid::text AS ctid,
@@ -98,9 +103,9 @@ export const resetE2EUsers = async (): Promise<{
         FROM profiles
         WHERE id = ${id}::uuid
       `)) as unknown as ResetProbeRow[];
-      return { id, rows: [...probe] };
+      return { id, email, rows: [...probe] };
     }),
   );
 
-  return { reset: ids.length, updatedIds, profiles: profilesAfter };
+  return { reset: users.length, updatedIds, profiles: profilesAfter };
 };

--- a/src/server/test-reset.ts
+++ b/src/server/test-reset.ts
@@ -1,6 +1,7 @@
 import { inArray, sql } from "drizzle-orm";
 
 import { db } from "./db";
+import { getProfileForSelf } from "./profiles";
 import { invites, profiles } from "./schema";
 
 // Two long-lived accounts seeded manually in prod Supabase (see
@@ -13,14 +14,23 @@ export const E2E_EMAILS = ["e2e-regular@testfake.local", "e2e-admin@testfake.loc
 // the seeded users. isAdmin is preserved so the admin account keeps
 // its flag across runs. auth.users is not touched — the password and
 // row stay put so the next run can sign in again.
-export const resetE2EUsers = async (): Promise<{ reset: number }> => {
+export const resetE2EUsers = async (): Promise<{
+  reset: number;
+  // Post-transaction read-back of each reset user, via the same query
+  // the redirect gate uses (getProfileForSelf). Probe for #149: callers
+  // assert bio === null here before signing in. If bio is already
+  // non-null on this fresh read, the reset transaction didn't take; if
+  // it reads null here but `/` still renders LoggedInHome, the gap is
+  // read-after-write visibility on the next request, not the reset.
+  profiles: { id: string; bio: string | null }[];
+}> => {
   const emailList = sql.join(
     E2E_EMAILS.map((e) => sql`${e}`),
     sql`, `,
   );
   const rows = await db.execute(sql`SELECT id FROM auth.users WHERE email IN (${emailList})`);
   const ids = (rows as unknown as { id: string }[]).map((r) => r.id);
-  if (ids.length === 0) return { reset: 0 };
+  if (ids.length === 0) return { reset: 0, profiles: [] };
 
   await db.transaction(async (tx) => {
     await tx.delete(invites).where(inArray(invites.createdBy, ids));
@@ -43,5 +53,9 @@ export const resetE2EUsers = async (): Promise<{ reset: number }> => {
       .where(inArray(profiles.id, ids));
   });
 
-  return { reset: ids.length };
+  const profilesAfter = await Promise.all(
+    ids.map(async (id) => ({ id, bio: (await getProfileForSelf(id))?.bio ?? null })),
+  );
+
+  return { reset: ids.length, profiles: profilesAfter };
 };

--- a/src/server/test-reset.ts
+++ b/src/server/test-reset.ts
@@ -10,7 +10,7 @@ import { invites, profiles } from "./schema";
 export const E2E_EMAILS = ["e2e-regular@testfake.local", "e2e-admin@testfake.local"] as const;
 
 // One physical `profiles` row as it stands immediately after the reset
-// transaction commits. ctid/xmin pin the exact tuple and the txid that
+// writes. ctid/xmin pin the exact tuple and the txid that
 // last wrote it; inRecovery/serverAddr/searchPath/backendPid describe
 // the connection the read-back ran on. All of this exists to diagnose
 // #149 — a read seeing a stale bio just after the reset commits — by
@@ -32,7 +32,7 @@ export type ResetProbeRow = {
 // its flag across runs. auth.users is not touched — the password and
 // row stay put so the next run can sign in again.
 //
-// After committing, it reads every seeded profile back (see #149): the
+// After the writes, it reads every seeded profile back (see #149): the
 // UPDATE's RETURNING reports which rows were touched, and a per-id
 // SELECT of the physical tuple plus connection state lets the caller
 // tell a genuine stale read apart from a duplicate tuple, a replica,
@@ -59,29 +59,31 @@ export const resetE2EUsers = async (): Promise<{
   if (users.length === 0) return { reset: 0, updatedIds: [], profiles: [] };
   const ids = users.map((u) => u.id);
 
-  let updatedIds: string[] = [];
-  await db.transaction(async (tx) => {
-    await tx.delete(invites).where(inArray(invites.createdBy, ids));
-    const updated = await tx
-      .update(profiles)
-      .set({
-        displayName: null,
-        slug: null,
-        bio: null,
-        keywords: sql`'{}'::text[]`,
-        location: null,
-        supplementaryInfo: null,
-        referredBy: null,
-        referredByLegacy: null,
-        avatarUrl: null,
-        emergencyContact: null,
-        liveDesire: null,
-        lastUpdatedWeb: null,
-      })
-      .where(inArray(profiles.id, ids))
-      .returning({ id: profiles.id });
-    updatedIds = updated.map((r) => r.id);
-  });
+  // Two separate autocommit statements rather than db.transaction:
+  // delete-then-wipe needn't be atomic for a test reset, and a
+  // multi-statement BEGIN/COMMIT over the Supabase transaction pooler
+  // can have its writes silently dropped while still reporting success
+  // (cf. supabase/supabase#43753) — the leading suspect for #149.
+  await db.delete(invites).where(inArray(invites.createdBy, ids));
+  const updated = await db
+    .update(profiles)
+    .set({
+      displayName: null,
+      slug: null,
+      bio: null,
+      keywords: sql`'{}'::text[]`,
+      location: null,
+      supplementaryInfo: null,
+      referredBy: null,
+      referredByLegacy: null,
+      avatarUrl: null,
+      emergencyContact: null,
+      liveDesire: null,
+      lastUpdatedWeb: null,
+    })
+    .where(inArray(profiles.id, ids))
+    .returning({ id: profiles.id });
+  const updatedIds = updated.map((r) => r.id);
 
   // Read each id back on a fresh pooled connection, post-commit. No
   // LIMIT, so a duplicate-tuple bug surfaces as rows.length > 1; ctid

--- a/src/server/test-reset.ts
+++ b/src/server/test-reset.ts
@@ -1,7 +1,6 @@
 import { inArray, sql } from "drizzle-orm";
 
 import { db } from "./db";
-import { getProfileForSelf } from "./profiles";
 import { invites, profiles } from "./schema";
 
 // Two long-lived accounts seeded manually in prod Supabase (see
@@ -10,19 +9,42 @@ import { invites, profiles } from "./schema";
 // service-role key.
 export const E2E_EMAILS = ["e2e-regular@testfake.local", "e2e-admin@testfake.local"] as const;
 
+// One physical `profiles` row as it stands immediately after the reset
+// transaction commits. ctid/xmin pin the exact tuple and the txid that
+// last wrote it; inRecovery/serverAddr/searchPath/backendPid describe
+// the connection the read-back ran on. All of this exists to diagnose
+// #149 — a read seeing a stale bio just after the reset commits — by
+// separating a genuine stale read from a duplicate tuple, a replica,
+// or a schema-resolution mismatch.
+export type ResetProbeRow = {
+  ctid: string;
+  xmin: string;
+  bio: string | null;
+  updatedAt: string | null;
+  inRecovery: boolean;
+  searchPath: string;
+  serverAddr: string | null;
+  backendPid: number;
+};
+
 // Clears out everything a welcome/invites test might leave behind on
 // the seeded users. isAdmin is preserved so the admin account keeps
 // its flag across runs. auth.users is not touched — the password and
 // row stay put so the next run can sign in again.
+//
+// After committing, it reads every seeded profile back (see #149): the
+// UPDATE's RETURNING reports which rows were touched, and a per-id
+// SELECT of the physical tuple plus connection state lets the caller
+// tell a genuine stale read apart from a duplicate tuple, a replica,
+// or a schema-resolution mismatch.
 export const resetE2EUsers = async (): Promise<{
   reset: number;
-  // Post-transaction read-back of each reset user, via the same query
-  // the redirect gate uses (getProfileForSelf). Probe for #149: callers
-  // assert bio === null here before signing in. If bio is already
-  // non-null on this fresh read, the reset transaction didn't take; if
-  // it reads null here but `/` still renders LoggedInHome, the gap is
-  // read-after-write visibility on the next request, not the reset.
-  profiles: { id: string; bio: string | null }[];
+  // ids the UPDATE's RETURNING reported — one entry per row touched, so
+  // a duplicated id surfaces here as a repeat.
+  updatedIds: string[];
+  // Post-commit read-back per seeded id. `rows` holds every physical
+  // profile row for that id; length > 1 means duplicate tuples.
+  profiles: { id: string; rows: ResetProbeRow[] }[];
 }> => {
   const emailList = sql.join(
     E2E_EMAILS.map((e) => sql`${e}`),
@@ -30,11 +52,12 @@ export const resetE2EUsers = async (): Promise<{
   );
   const rows = await db.execute(sql`SELECT id FROM auth.users WHERE email IN (${emailList})`);
   const ids = (rows as unknown as { id: string }[]).map((r) => r.id);
-  if (ids.length === 0) return { reset: 0, profiles: [] };
+  if (ids.length === 0) return { reset: 0, updatedIds: [], profiles: [] };
 
+  let updatedIds: string[] = [];
   await db.transaction(async (tx) => {
     await tx.delete(invites).where(inArray(invites.createdBy, ids));
-    await tx
+    const updated = await tx
       .update(profiles)
       .set({
         displayName: null,
@@ -50,12 +73,34 @@ export const resetE2EUsers = async (): Promise<{
         liveDesire: null,
         lastUpdatedWeb: null,
       })
-      .where(inArray(profiles.id, ids));
+      .where(inArray(profiles.id, ids))
+      .returning({ id: profiles.id });
+    updatedIds = updated.map((r) => r.id);
   });
 
+  // Read each id back on a fresh pooled connection, post-commit. No
+  // LIMIT, so a duplicate-tuple bug surfaces as rows.length > 1; ctid
+  // and xmin pin the tuple and its writing txid; pg_is_in_recovery /
+  // current_setting('search_path') / inet_server_addr characterise the
+  // connection this read happened to land on.
   const profilesAfter = await Promise.all(
-    ids.map(async (id) => ({ id, bio: (await getProfileForSelf(id))?.bio ?? null })),
+    ids.map(async (id) => {
+      const probe = (await db.execute(sql`
+        SELECT
+          ctid::text AS ctid,
+          xmin::text AS xmin,
+          bio,
+          updated_at::text AS "updatedAt",
+          pg_is_in_recovery() AS "inRecovery",
+          current_setting('search_path') AS "searchPath",
+          inet_server_addr()::text AS "serverAddr",
+          pg_backend_pid() AS "backendPid"
+        FROM profiles
+        WHERE id = ${id}::uuid
+      `)) as unknown as ResetProbeRow[];
+      return { id, rows: [...probe] };
+    }),
   );
 
-  return { reset: ids.length, profiles: profilesAfter };
+  return { reset: ids.length, updatedIds, profiles: profilesAfter };
 };

--- a/tests/e2e/helpers/session.ts
+++ b/tests/e2e/helpers/session.ts
@@ -86,13 +86,15 @@ export const resetSeededUsers = async (baseURL: string): Promise<void> => {
 
   // #149 probe: the endpoint reads every seeded profile back after its
   // reset transaction commits, with physical-tuple (ctid/xmin) and
-  // connection (replica/search_path) diagnostics. A clean reset is
-  // exactly one row per id with bio null. Anything else throws here —
-  // failing loud in beforeEach instead of 20s later at a /welcome
-  // timeout — and dumps the full diagnostic so CI shows the surviving
-  // bio string (its value names the test that wrote it, since each
-  // completeWelcome caller passes a distinct bio), the tuple identity,
-  // and whether the read ran on a replica.
+  // connection (replica/search_path) diagnostics. A reset is clean when
+  // every existing profile row has bio null. Two things fail loud here
+  // — in beforeEach, instead of 20s later at a /welcome timeout: a row
+  // whose bio survived the reset (the #149 symptom), or duplicate
+  // tuples for one id. A seeded user with no profile row at all (0 rows
+  // — e.g. e2e-admin, which no test signs in as) is fine, not flagged.
+  // The dump shows the surviving bio string (its value names the test
+  // that wrote it, since each completeWelcome caller passes a distinct
+  // bio), the tuple identity, and whether the read ran on a replica.
   type ResetProbeRow = {
     ctid: string;
     xmin: string;
@@ -106,11 +108,13 @@ export const resetSeededUsers = async (baseURL: string): Promise<void> => {
   const body = (await res.json()) as {
     reset: number;
     updatedIds: string[];
-    profiles: { id: string; rows: ResetProbeRow[] }[];
+    profiles: { id: string; email: string; rows: ResetProbeRow[] }[];
   };
-  const anomalies = body.profiles.filter((p) => p.rows.length !== 1 || p.rows[0]?.bio !== null);
+  const anomalies = body.profiles.filter((p) => p.rows.length > 1 || p.rows.some((r) => r.bio !== null));
   if (anomalies.length > 0) {
-    const detail = anomalies.map((p) => `  ${p.id}: ${p.rows.length} row(s) → ${JSON.stringify(p.rows)}`).join("\n");
+    const detail = anomalies
+      .map((p) => `  ${p.email} (${p.id}): ${p.rows.length} row(s) → ${JSON.stringify(p.rows)}`)
+      .join("\n");
     throw new Error(
       `reset endpoint: seeded profile not clean after reset — see #149\n` +
         `updatedIds=${JSON.stringify(body.updatedIds)}\n${detail}`,

--- a/tests/e2e/helpers/session.ts
+++ b/tests/e2e/helpers/session.ts
@@ -84,16 +84,36 @@ export const resetSeededUsers = async (baseURL: string): Promise<void> => {
     throw new Error(`reset endpoint returned ${res.status}: ${await res.text().catch(() => "")}`);
   }
 
-  // #149 probe: the endpoint reads each profile back via getProfileForSelf
-  // after its reset transaction commits. If bio is already non-null on
-  // that read, the reset didn't take and a `/`→`/welcome` test would
-  // flake on a stale gate — fail loud here instead of 20s later.
-  const body = (await res.json()) as { reset: number; profiles: { id: string; bio: string | null }[] };
-  const stale = body.profiles.filter((p) => p.bio !== null);
-  if (stale.length > 0) {
+  // #149 probe: the endpoint reads every seeded profile back after its
+  // reset transaction commits, with physical-tuple (ctid/xmin) and
+  // connection (replica/search_path) diagnostics. A clean reset is
+  // exactly one row per id with bio null. Anything else throws here —
+  // failing loud in beforeEach instead of 20s later at a /welcome
+  // timeout — and dumps the full diagnostic so CI shows the surviving
+  // bio string (its value names the test that wrote it, since each
+  // completeWelcome caller passes a distinct bio), the tuple identity,
+  // and whether the read ran on a replica.
+  type ResetProbeRow = {
+    ctid: string;
+    xmin: string;
+    bio: string | null;
+    updatedAt: string | null;
+    inRecovery: boolean;
+    searchPath: string;
+    serverAddr: string | null;
+    backendPid: number;
+  };
+  const body = (await res.json()) as {
+    reset: number;
+    updatedIds: string[];
+    profiles: { id: string; rows: ResetProbeRow[] }[];
+  };
+  const anomalies = body.profiles.filter((p) => p.rows.length !== 1 || p.rows[0]?.bio !== null);
+  if (anomalies.length > 0) {
+    const detail = anomalies.map((p) => `  ${p.id}: ${p.rows.length} row(s) → ${JSON.stringify(p.rows)}`).join("\n");
     throw new Error(
-      `reset endpoint reports bio still set after reset for ${stale.length} user(s): ` +
-        `${stale.map((p) => p.id).join(", ")} — see #149`,
+      `reset endpoint: seeded profile not clean after reset — see #149\n` +
+        `updatedIds=${JSON.stringify(body.updatedIds)}\n${detail}`,
     );
   }
 };

--- a/tests/e2e/helpers/session.ts
+++ b/tests/e2e/helpers/session.ts
@@ -83,4 +83,17 @@ export const resetSeededUsers = async (baseURL: string): Promise<void> => {
   if (!res.ok) {
     throw new Error(`reset endpoint returned ${res.status}: ${await res.text().catch(() => "")}`);
   }
+
+  // #149 probe: the endpoint reads each profile back via getProfileForSelf
+  // after its reset transaction commits. If bio is already non-null on
+  // that read, the reset didn't take and a `/`→`/welcome` test would
+  // flake on a stale gate — fail loud here instead of 20s later.
+  const body = (await res.json()) as { reset: number; profiles: { id: string; bio: string | null }[] };
+  const stale = body.profiles.filter((p) => p.bio !== null);
+  if (stale.length > 0) {
+    throw new Error(
+      `reset endpoint reports bio still set after reset for ${stale.length} user(s): ` +
+        `${stale.map((p) => p.id).join(", ")} — see #149`,
+    );
+  }
 };

--- a/tests/e2e/invites.spec.ts
+++ b/tests/e2e/invites.spec.ts
@@ -20,7 +20,12 @@ test.describe("invites — authed member flow", () => {
     if (!baseURL) throw new Error("invites.spec.ts: baseURL is not configured");
     await resetSeededUsers(baseURL);
     await signInAs(page, "regular");
-    await completeWelcome(page, { displayName: "Member Under Test" });
+    // Distinct bio per completeWelcome caller: if a reset leaves this
+    // value behind, the #149 probe names this exact call site.
+    await completeWelcome(page, {
+      displayName: "Member Under Test",
+      bio: "e2e bio · invites.spec · authed-flow beforeEach",
+    });
   });
 
   test("create an invite, see it listed, revoke it", async ({ page }) => {
@@ -88,7 +93,10 @@ test.describe("/signup — unauthed invite flow", () => {
     let code: string;
     try {
       await signInAs(memberPage, "regular");
-      await completeWelcome(memberPage, { displayName: "Inviter" });
+      await completeWelcome(memberPage, {
+        displayName: "Inviter",
+        bio: "e2e bio · invites.spec · signup-flow inviter",
+      });
       await memberPage.getByRole("link", { name: "Invite a friend" }).click();
       await memberPage.waitForURL((u) => u.pathname === "/invites", { timeout: TIMEOUT_MS });
       await memberPage.getByLabel(/Note \(for your records/).fill("e2e signup-flow invite — come on in");

--- a/tests/e2e/myweb.spec.ts
+++ b/tests/e2e/myweb.spec.ts
@@ -24,7 +24,8 @@ test.describe("/myweb — tour pre-dismissed", () => {
 
   test("/myweb loads, Done flips into View, Edit flips back", async ({ page }) => {
     await signInAs(page, "regular");
-    await completeWelcome(page);
+    // Distinct bio per completeWelcome caller — see the #149 probe.
+    await completeWelcome(page, { bio: "e2e bio · myweb.spec · tour-pre-dismissed" });
 
     await page.getByRole("link", { name: "My web" }).click();
     await page.waitForURL((u) => u.pathname === "/myweb", { timeout: TIMEOUT_MS });
@@ -53,7 +54,8 @@ test.describe("/myweb — first-time welcome tour", () => {
 
   test("tour appears for a first-time visitor and can be skipped", async ({ page }) => {
     await signInAs(page, "regular");
-    await completeWelcome(page);
+    // Distinct bio per completeWelcome caller — see the #149 probe.
+    await completeWelcome(page, { bio: "e2e bio · myweb.spec · first-time-tour" });
     await page.getByRole("link", { name: "My web" }).click();
     await page.waitForURL((u) => u.pathname === "/myweb", { timeout: TIMEOUT_MS });
 


### PR DESCRIPTION
## What

Two things, both targeting supabase/supabase#149 — the intermittent `waitForURL('/welcome')` 20s e2e timeouts:

1. **The change** — `resetE2EUsers` no longer wraps `DELETE invites` + `UPDATE profiles` in a `db.transaction`; it runs them as two separate autocommit statements.
2. **A diagnostic probe** (kept, deliberately) — `/api/_test/reset` reads every seeded profile back after the reset, and `resetSeededUsers` fails loud in `beforeEach` if a profile isn't clean, dumping physical-tuple (`ctid`/`xmin`), connection (`inRecovery`/`searchPath`/`serverAddr`), and the surviving `bio`. Each `completeWelcome` caller passes a distinct bio so a survivor names its author.

## Why — and how settled this is

The probe caught a clean supabase/supabase#149 failure and ruled out replica, schema mismatch, duplicate tuples, caching, and a write-write race. The **leading hypothesis** for what remains: a multi-statement `BEGIN…COMMIT` over the Supabase transaction pooler can report success — `RETURNING` returns rows — while silently dropping its writes (cf. [supabase/supavisor#1051](https://github.com/supabase/supavisor/issues/1051)). On that theory the reset's `UPDATE bio=null` never persisted, so the redirect gate kept seeing a stale `bio`. A test reset doesn't need delete+wipe atomic, so dropping the transaction removes the *suspected* exposure.

**This is not proven.** supabase/supabase#149 is intermittent. The evidence so far is one green CI E2E run after the change against two failed runs immediately before it — consistent with the hypothesis, not confirmation of it. A few more green runs are needed before calling it fixed, so **#149 is intentionally left open.**

The probe is kept precisely for that reason: if supabase/supabase#149 recurs it now fails loud in `beforeEach` with full diagnostics instead of a silent 20s timeout.

## Testing

Full suite green locally (142 functional + 17 e2e). First CI E2E run after the change: green. The two runs immediately before: failed on the probe.

Addresses supabase/supabase#149 — full investigation trail: https://github.com/Intentional-Society/is-app/issues/149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
