### PR TITLE
Tighten supply-chain quarantine to 3 days; add Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # Mirror the `.npmrc` min-release-age quarantine: Dependabot has no
+    # visibility into npm client config, so without this it would propose
+    # versions younger than the quarantine window.
+    cooldown:
+      default-days: 3
     groups:
       # Batch patch/minor bumps together so Dependabot doesn't open one
       # PR per transitively-related package. Majors still land as their

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-# Quarantine fresh npm releases for 5 days — compromised packages are usually
+# Quarantine fresh npm releases for 3 days — compromised packages are usually
 # yanked within hours/days of publication (Shai-Hulud, debug/chalk, etc.).
 # Override per-command with `--min-release-age=0` if a genuine urgent install is needed.
-min-release-age=5
+min-release-age=3

--- a/docs/strategy-security.md
+++ b/docs/strategy-security.md
@@ -141,9 +141,11 @@ Three rules:
 
 # Supply-chain quarantine
 
-`.npmrc` sets `min-release-age=5`, so `npm install` ignores any package version published in the last five days. The window is long enough to catch the usual post-publish takedown cycle (Shai-Hulud, debug/chalk, etc.) and short enough to not block routine upgrades. Override with `--min-release-age=0` on the command line for a genuine emergency install.
+`.npmrc` sets `min-release-age=3`, so `npm install` ignores any package version published in the last three days. The window is long enough to catch the usual post-publish takedown cycle (Shai-Hulud, debug/chalk, etc.) and short enough to not block routine upgrades. Override with `--min-release-age=0` on the command line for a genuine emergency install.
 
 Requires npm ≥11 — older npm warns and ignores the setting, so this is silent if the Vercel build image ever rolls back. The gate engages on dependency resolution (adding or bumping a dep); `npm ci` against a frozen lockfile installs whatever's pinned regardless.
+
+Dependabot has no visibility into `.npmrc`, so `.github/dependabot.yml` carries a matching `cooldown.default-days: 3` for the npm ecosystem. Keep the two values in sync — otherwise Dependabot opens PRs bumping to versions the `.npmrc` quarantine would still reject.
 
 # Secret rotation
 


### PR DESCRIPTION
Moves the npm release-age quarantine window from 5 to 3 days, and closes the gap where Dependabot bypassed the quarantine entirely.

## Changes

- **`.npmrc`** — `min-release-age` 5 → 3 days
- **`.github/dependabot.yml`** — new `cooldown.default-days: 3` on the npm ecosystem. Dependabot has no visibility into npm client config, so previously it opened PRs (e.g. #163, #164) bumping to versions the `.npmrc` quarantine would reject. The `npm ci` path in CI/Vercel doesn't re-resolve, so nothing downstream caught it either.
- **`docs/strategy-security.md`** — quarantine section updated to 3 days; documents that the `.npmrc` and `dependabot.yml` values must stay in sync.

Config + docs only — no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)