### PR TITLE
Profile pictures

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -10,9 +10,10 @@
 # the same Supabase CLI version gets identical values. If the CLI ever
 # rotates them, fix this file when bumping the `supabase` devDependency.
 #
-# The secret key is used by the e2e session-minting helper to create
-# and delete test users via the Supabase Admin API; it is never shipped
-# to production.
+# The secret key is a server-side credential — used for avatar Storage
+# operations (src/lib/supabase/admin.ts) and the e2e session helper. It
+# MUST be set in the Vercel project env for production avatar uploads
+# to work; it is never exposed to the browser. See docs/doc-supabase.md.
 
 # Must use 127.0.0.1 (not localhost). The dev CSP whitelists this exact
 # origin in connect-src; CSP host matching is literal, so swapping in

--- a/docs/design-profile-pictures.md
+++ b/docs/design-profile-pictures.md
@@ -298,11 +298,11 @@ avatar a new path, so a replace shows immediately.
     ```toml
     [storage.buckets.avatars]
     public = false
-    file_size_limit = "3MiB"
+    file_size_limit = "1MB"
     allowed_mime_types = ["image/webp"]
     ```
 12. **Hosted Supabase** — create the same `avatars` bucket (private,
-    3 MB, `image/webp`) in the dashboard. Document it in
+    1 MB, `image/webp`) in the dashboard. Document it in
     `docs/doc-supabase.md`.
 13. **Env var** — add `SUPABASE_SECRET_KEY` (server-only; follows the
     existing `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` naming).

--- a/docs/design-profile-pictures.md
+++ b/docs/design-profile-pictures.md
@@ -298,11 +298,11 @@ avatar a new path, so a replace shows immediately.
     ```toml
     [storage.buckets.avatars]
     public = false
-    file_size_limit = "2MiB"
+    file_size_limit = "3MiB"
     allowed_mime_types = ["image/webp"]
     ```
 12. **Hosted Supabase** — create the same `avatars` bucket (private,
-    2 MiB, `image/webp`) in the dashboard. Document it in
+    3 MB, `image/webp`) in the dashboard. Document it in
     `docs/doc-supabase.md`.
 13. **Env var** — add `SUPABASE_SECRET_KEY` (server-only; follows the
     existing `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` naming).

--- a/docs/design-profile-pictures.md
+++ b/docs/design-profile-pictures.md
@@ -1,7 +1,10 @@
 # Design — Profile pictures
 
-Status: design captured 2026-05-16. Not yet implemented. Closes #131
-(and #136, the avatar-URL tracking-pixel issue, folded in).
+Status: implemented on branch `profile-pictures` (2026-05-16). Two
+provisioning steps remain before production works: create the hosted
+`avatars` bucket and set `SUPABASE_SECRET_KEY` in the Vercel project
+env (see `docs/doc-supabase.md`). Closes #131 (and #136, the
+avatar-URL tracking-pixel issue, folded in).
 
 ## Goal
 

--- a/docs/design-profile-pictures.md
+++ b/docs/design-profile-pictures.md
@@ -167,6 +167,13 @@ for the members grid and graph nodes. If the many-tiny-avatars `/myweb`
 graph later proves heavy, exporting a second small size at upload time
 is a minor follow-up.
 
+**Stored square, displayed round.** The crop is square (`aspect={1}`);
+`react-easy-crop`'s `cropShape: "round"` only draws a circular overlay
+so the user previews the circle while positioning. The stored 1024²
+WebP keeps its corners — circular display is CSS (`rounded-full` on the
+`Avatar` box, as today), so a square or rounded-rect rendering stays
+free from the same master.
+
 Re-encoding (either stage) **strips all EXIF metadata**, including GPS
 coordinates the camera embedded — a free privacy win.
 

--- a/docs/design-profile-pictures.md
+++ b/docs/design-profile-pictures.md
@@ -146,7 +146,7 @@ other; neither should be removed without the other.
 Two stages, each doing a distinct job:
 
 - **Browser** — after crop-confirm, draw the crop to a `<canvas>` and
-  export **WebP** (`canvas.toBlob`, quality ~0.82) at the master size.
+  export **WebP** (`canvas.toBlob`, quality ~0.88) at the master size.
   The crop step already produced this canvas, so the resize is nearly
   free. This keeps the upload to ~100–200 KB, which is what makes the
   Hono-through upload (decision 2) fit Vercel's request-body limit.

--- a/docs/design-profile-pictures.md
+++ b/docs/design-profile-pictures.md
@@ -33,7 +33,7 @@ Two problems with the free-text field, from #136:
 
 ## Functionality in scope
 
-- Upload a photo from the Edit-profile screen.
+- Upload a photo from the Edit-profile or Welcome screen.
 - Crop + zoom + reposition to a circle before saving.
 - Resize/compress to a sane fixed size before it leaves the browser.
 - Store the file on Supabase Storage; record its location on the

--- a/docs/design-profile-pictures.md
+++ b/docs/design-profile-pictures.md
@@ -1,0 +1,365 @@
+# Design — Profile pictures
+
+Status: design captured 2026-05-16. Not yet implemented. Closes #131
+(and #136, the avatar-URL tracking-pixel issue, folded in).
+
+## Goal
+
+Give members real profile pictures: upload a photo from "Edit
+profile", crop/zoom it to a circle, store it on infrastructure we
+control, and render it everywhere an avatar appears. Retire the
+free-text `avatarUrl` field, which today lets any HTTPS host be
+fetched by every visitor.
+
+## Where we are today
+
+- `profiles.avatarUrl` is a `text` column holding a user-typed URL.
+- The Edit-profile form has a plain "Avatar URL" `<input type="url">`.
+- `Avatar` (`src/components/avatar.tsx`) renders `<img src={url}>`
+  for any URL, or initials when null. It carries a
+  `biome-ignore noImgElement` because the host is unknown.
+- Avatars render in: members grid, `/myweb` graph + suggestion cards,
+  member typeahead, admin hints, the profile page.
+
+Two problems with the free-text field, from #136:
+
+1. **Tracking-pixel risk** — every visitor's browser fetches whatever
+   third-party host a member typed, leaking IP + load time to it.
+2. **No optimisation** — an arbitrary host can't go through
+   `next/image`, so we serve unbounded original-size images.
+
+## Functionality in scope
+
+- Upload a photo from the Edit-profile screen.
+- Crop + zoom + reposition to a circle before saving.
+- Resize/compress to a sane fixed size before it leaves the browser.
+- Store the file on Supabase Storage; record its location on the
+  profile.
+- Render via `next/image` from a host we control, everywhere.
+- Remove a photo (fall back to initials).
+- Replace a photo (old object cleaned up, no orphan).
+
+## Off-the-shelf survey
+
+### Storage backend
+
+| Option | Verdict |
+|---|---|
+| **Supabase Storage** | **Chosen.** Already in our stack — `[storage]` is enabled in `config.toml`, runs in the local Docker stack, S3-backed with a CDN on the hosted side. No new vendor, no new bill. |
+| S3 + CloudFront | Rejected — a second vendor, IAM, and a CDN to wire up for no gain over what Supabase already gives us. |
+| Bytes in a Postgres column | Rejected — bloats the DB and its backups, no CDN, defeats `next/image`. An anti-pattern for binary blobs. |
+
+### Cropping UI library
+
+| Library | Notes |
+|---|---|
+| **`react-easy-crop`** | **Chosen.** ~1.9M weekly downloads, actively maintained. Built-in pinch-zoom and drag, supports a circular crop overlay, and hands back crop geometry we feed to a `<canvas>`. Best mobile UX of the field, small. |
+| `react-image-crop` | Lighter and dependency-free, but no zoom — a worse fit for "position your face in the circle". |
+| `react-cropper` (Cropper.js) | Heaviest; more than we need. |
+| Pintura | Commercial licence. Overkill. |
+
+`react-easy-crop` gives us a crop *rectangle*; the actual pixel
+extraction is our own ~30-line `<canvas>` helper. The library does not
+upload, resize, or encode — that is deliberate and fine.
+
+### Image resizing
+
+Supabase offers server-side **image transformations** (`?width=&height=`
+on the object URL), but only on the **Pro plan**. We will not depend on
+it. Instead we **resize in the browser before upload**: the crop step
+already produces a `<canvas>`, so we export it at a fixed size. This
+works on any plan, uploads less data, and means we store exactly one
+predictable file per member. `next/image` handles display-size
+downscaling on top.
+
+## Key decisions
+
+### 1. Private bucket, signed URLs (24h TTL)
+
+The `avatars` bucket is **private**. Objects are reachable only via a
+**signed URL** — a time-limited, HMAC-signed link minted server-side.
+Object paths stay `<userId>/<random-uuid>.webp`.
+
+Rationale — this is a deliberately private membership network, so the
+privacy bar sits above a consumer product's. A signed URL is fetchable
+without a login *while valid* (the same model Facebook, Instagram, and
+Discord settled on for image CDNs — none auth-check every image GET),
+but it **expires**: a URL that leaks via a `Referer` header, browser
+history, or a pasted link stops working. A public bucket can't offer
+that — a leaked public URL is live until the object is deleted.
+
+TTL: **24 hours**. Long enough that re-signing is rare; short enough
+that a leaked link dies within a day.
+
+Performance — the member directory renders every member's avatar at
+once, so signing must not become N round-trips:
+
+- The Storage signing call is an HTTP request to Supabase, not local
+  crypto. Use the **batch** API — `createSignedUrls(paths[], ttl)` —
+  which signs the whole directory in **one** round-trip. Never loop
+  the single-path `createSignedUrl`.
+- **Cache** the signed URLs, keyed by object path, for most of the
+  TTL (a module-level `Map` on the Fluid Compute instance, or Next's
+  `use cache`). Signing then fires roughly once per TTL per warm
+  instance — not once per page view. The directory's hot path does
+  zero Storage round-trips.
+- The long TTL also keeps `next/image`'s optimizer cache stable: that
+  cache is keyed by source URL, so an hourly-churning URL would force
+  constant re-optimization. A 24h URL does not.
+
+A per-upload random filename means a replaced avatar gets a new path,
+hence a new cache key, so a replace shows immediately rather than
+waiting out the TTL.
+
+A public bucket — simpler, no signing — was the alternative; rejected
+because it cannot revoke a leaked URL.
+
+### 2. Upload goes through Hono, not browser-direct
+
+The browser sends the processed image to a new Hono endpoint; the
+**server** writes it to Storage using a Supabase client with the
+**secret key**, then updates the profile row.
+
+Rationale — this matches the app's existing architecture:
+
+- "Hono handles all API logic" (CLAUDE.md). DB access already works
+  this way: the server connects as a privileged role and RLS is only a
+  backstop. Storage should mirror that.
+- Browser-direct upload would require our **first** Storage RLS
+  policies and the first browser→Supabase *data* path (today the
+  browser only talks to Supabase for auth). Routing through Hono keeps
+  that surface closed.
+- The server can validate type, size, and decoded dimensions before
+  anything is persisted.
+
+The processed upload is small (~100–200 KB WebP), so passing it through
+a Vercel function is cheap — and it stays under Vercel's ~4.5 MB
+request-body limit only because decision 3 shrinks it first.
+Hono-through and the client-side resize are load-bearing for each
+other; neither should be removed without the other.
+
+### 3. Resize in the browser, re-encode authoritatively on the server
+
+Two stages, each doing a distinct job:
+
+- **Browser** — after crop-confirm, draw the crop to a `<canvas>` and
+  export **WebP** (`canvas.toBlob`, quality ~0.82) at the master size.
+  The crop step already produced this canvas, so the resize is nearly
+  free. This keeps the upload to ~100–200 KB, which is what makes the
+  Hono-through upload (decision 2) fit Vercel's request-body limit.
+- **Server** — Hono re-encodes the received image with `sharp` to the
+  canonical **1024×1024** WebP, and that is the object stored. The
+  client-side resize is a bandwidth optimisation, **not** a trust
+  boundary — a crafted client can ignore it. Re-encoding
+  unconditionally (rather than detecting whether the input already
+  conforms) is simpler to reason about and cheap on a ~150 KB image;
+  the stored object is then provably a well-formed 1024² WebP whatever
+  arrived.
+
+`sharp` is already in the tree as `next/image`'s dependency, so the
+server stage adds no new package.
+
+**Master size 1024².** Display sizes now run up to ~500px CSS (the
+profile page), and 1024² leaves 2× headroom for retina at that size.
+A WebP at that size lands near 100–200 KB per avatar — small enough to
+ignore. Single master only — `next/image` derives the smaller variants
+for the members grid and graph nodes. If the many-tiny-avatars `/myweb`
+graph later proves heavy, exporting a second small size at upload time
+is a minor follow-up.
+
+Re-encoding (either stage) **strips all EXIF metadata**, including GPS
+coordinates the camera embedded — a free privacy win.
+
+### 4. Schema: rename the existing column, no new column
+
+`profiles.avatar_url` is unused — zero rows hold a value — so there is
+nothing to preserve. It is repurposed in place to hold a **Storage
+object path** (e.g. `5f3c…/9a1b…webp`), never a URL. No new column, no
+data migration, no expand-contract: the column is empty and this PR
+owns every reader and writer of it, so the meaning can simply change.
+
+- **TS side, this PR** — the Drizzle property becomes `avatarPath`,
+  still mapped to the SQL column `avatar_url` for now:
+  `avatarPath: text("avatar_url")`. Code-only; generates no migration.
+- **SQL side, batched later** — the cosmetic `RENAME COLUMN avatar_url
+  TO avatar_path` joins the pending-rename batch already waiting on
+  `creator_value`, `rater_id`, and `ratee_id` (see the comments in
+  `schema.ts`).
+
+The API contract is unchanged: `getProfileForSelf` /
+`getProfileForMember` / `listMembers` keep returning a field named
+`avatarUrl` — now a server-minted signed URL (decision 1), not user
+free-text. `avatarPath` is **never** client-settable via `PUT /me`;
+only the upload endpoint writes it, and `avatarUrl` is dropped from
+`EDITABLE_PROFILE_FIELDS` so the old free-text field is gone.
+
+Because the column starts empty, #136's tracking-pixel hole closes
+completely with this PR — no legacy third-party URLs are left to
+render.
+
+## Architecture / data flow
+
+Upload:
+
+```
+Edit profile  ──select file──▶  crop modal (react-easy-crop)
+      │                               │ crop-confirm
+      │                               ▼
+      │                       canvas 1024² → WebP blob
+      │                               │
+      └──────── POST /api/me/avatar (multipart) ───────▶ Hono
+                                                          │ validate + re-encode (sharp)
+                                                          │ upload (secret key)
+                                                          ▼
+                                                  Supabase Storage
+                                                  avatars/<uid>/<uuid>.webp
+                                                          │
+                                              UPDATE profiles.avatar_path
+                                              + remove previous object
+```
+
+Display: the API field `avatarUrl` is a **signed URL** minted
+server-side through the path-keyed cache (decision 1) — one batched
+`createSignedUrls` call covers a whole directory page — and rendered
+through `next/image`. A per-upload random filename gives a replaced
+avatar a new path, so a replace shows immediately.
+
+## Implementation steps
+
+### Server
+
+1. **Schema** — rename the Drizzle property `avatarUrl` → `avatarPath`
+   on the existing `text("avatar_url")` column in `schema.ts`, with a
+   comment that the SQL rename is batched (decision 4). Code-only — no
+   `drizzle-kit generate`.
+2. **Admin Supabase client** — `src/lib/supabase/admin.ts`, a client
+   built with the URL + secret key, server-only. Used for Storage
+   writes.
+3. **URL helper** — a single `resolveAvatarUrls(paths)` chokepoint
+   used by `getProfileForSelf` / `getProfileForMember` / `listMembers`.
+   It batches cache-miss paths into one `createSignedUrls` call and
+   caches each signed URL keyed by object path with an expiry near the
+   24h TTL; a null `avatarPath` yields `null`. Single-profile callers
+   pass a one-element array. One chokepoint keeps a future scheme
+   change to a single function.
+4. **Upload endpoint** — `POST /api/me/avatar` in `src/server/api.ts`,
+   multipart body:
+   - Authenticated (existing `requireAuth`).
+   - Reject a non-image content type; reject > ~2 MB (defence in depth
+     — the client already shrank it).
+   - Decode and re-encode with `sharp` to a 1024² WebP; a decode
+     failure or absurd source dimensions (decompression-bomb guard)
+     rejects the request. The re-encoded blob is the authoritative
+     artifact.
+   - Upload it to `avatars/<userId>/<uuid>.webp`.
+   - `UPDATE profiles SET avatar_url = <new path>` — a single statement,
+     safe on the transaction pooler (no `db.transaction`).
+   - Delete the member's previous object, if any.
+   - Return the new signed `avatarUrl`.
+   The write order matters: the object exists before the row points at
+   it, and the old object is removed last — so any mid-failure leaves a
+   harmless orphan object, never a row referencing a missing file.
+5. **Delete endpoint** — `DELETE /api/me/avatar`: null out
+   `avatar_path` (and legacy `avatar_url`), remove the object.
+6. Remove `avatarUrl` from `EDITABLE_PROFILE_FIELDS` in
+   `src/server/profiles.ts`.
+
+### Client
+
+7. **`AvatarUploader`** component (`src/app/profile/`): an avatar
+   preview with an "Upload photo" button → file picker → crop modal
+   (`react-easy-crop`, circular `cropShape`) → canvas export → POST.
+   Shows progress and errors; a "Remove photo" action when one is set.
+   It uploads **immediately** on crop-confirm — independent of the
+   profile form's Save button (standard social pattern).
+8. **`profile-form.tsx`** — drop the Avatar URL `<input>`; mount
+   `AvatarUploader` at the top of the form.
+9. **`Avatar` component** — swap the raw `<img>` for `next/image`
+   (`fill`, `sizes` per call site) and drop the `biome-ignore`. The
+   host is now ours, so optimisation and a known host both apply.
+
+### Config / ops
+
+10. **`next.config.ts`** — add `images.remotePatterns`: hosted
+    `*.supabase.co` always; local `127.0.0.1:54321` in dev only
+    (mirror the existing `isProd` CSP branching).
+11. **`supabase/config.toml`** — declare the bucket so the local stack
+    and `dev:db:reset` provision it:
+    ```toml
+    [storage.buckets.avatars]
+    public = false
+    file_size_limit = "2MiB"
+    allowed_mime_types = ["image/webp"]
+    ```
+12. **Hosted Supabase** — create the same `avatars` bucket (private,
+    2 MiB, `image/webp`) in the dashboard. Document it in
+    `docs/doc-supabase.md`.
+13. **Env var** — add `SUPABASE_SECRET_KEY` (server-only; follows the
+    existing `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` naming).
+    `scripts/setup.mjs` writes the local value into `.env.local`; the
+    hosted value goes into Vercel project env.
+14. **CSP** — `img-src` already allows `https:`, so display needs no
+    change. The browser only POSTs the upload to `/api/*` (`'self'`),
+    so `connect-src` is unaffected.
+
+## Requirements worth calling out
+
+- **EXIF / privacy** — canvas re-encode strips EXIF, including GPS.
+  Free, and a real win.
+- **Image orientation** — load the source via `createImageBitmap` so
+  the browser applies EXIF orientation before cropping; otherwise
+  phone photos crop sideways.
+- **Mobile memory** — a large phone photo (40–50 megapixels is normal)
+  decoded straight into a `<canvas>` can OOM a low-end device. Pass
+  `resizeWidth`/`resizeHeight` to `createImageBitmap` so the source is
+  bounded before it reaches the canvas.
+- **HEIC** — iPhone photos are often HEIC. Non-Safari browsers can't
+  decode HEIC in a canvas. Start with `accept="image/png,image/jpeg,image/webp"`
+  on the file input and a clear error if decode fails; add a
+  `heic2any`-style decode shim only if it actually bites members.
+- **Size guard** — client shrinks before upload; the endpoint and the
+  bucket both cap size independently, so a crafted request can't
+  bypass it.
+- **Orphan cleanup** — replace deletes the old object; delete removes
+  it. Account deletion isn't a flow that exists yet — when it lands it
+  should also clear the member's `avatars/<userId>/` prefix (note for
+  whoever builds it).
+- **Accessibility** — the crop modal must be keyboard-operable and
+  focus-trapped (Base UI `Dialog` already in the stack); the displayed
+  avatar's `alt` follows the existing `Avatar` convention (empty when a
+  visible name sits beside it).
+- **Seed data** — give the seeded e2e users an avatar so the upload
+  *and* the already-set state both have e2e coverage.
+
+## Testing
+
+- **Functional** (Vitest, server project) — the local stack already
+  runs Storage, so tests hit it for real: happy-path upload sets
+  `avatar_path` and returns a URL; non-image rejected; oversize
+  rejected; unauthenticated rejected; replace removes the prior
+  object; delete clears the column.
+- **E2E** (Playwright) — `setInputFiles` on the picker, confirm the
+  crop with the default framing, assert the avatar renders on the
+  profile and members pages. Precise crop-drag interaction isn't worth
+  automating.
+- `npm test` (full functional + e2e) before the PR.
+
+## Suggested PR shape
+
+A single PR — schema property rename, upload + delete endpoints,
+`resolveAvatarUrls`, the `AvatarUploader`, the `Avatar` / `next.config`
+changes, and the bucket + env provisioning. There is no contract PR:
+decision 4 needs no data migration, and the cosmetic SQL column rename
+rides the separate pending-rename batch. Devjournal entry records the
+#136 fix and the private-bucket / signed-URL / Hono-upload decisions.
+
+## Out of scope
+
+- Supabase Pro image transformations — deliberately not a dependency;
+  `next/image` covers display sizing.
+- A separate thumbnail size — single 1024² master for now; revisit only
+  if the `/myweb` graph proves heavy.
+- Animated avatars, GIFs — WebP still frame only.
+- Moderation / reporting of avatar content — a trust-and-safety
+  question for the group, not this PR.
+- Avatar history / revert — replace is destructive by design.

--- a/docs/design-profile-pictures.md
+++ b/docs/design-profile-pictures.md
@@ -1,10 +1,7 @@
 # Design — Profile pictures
 
-Status: implemented on branch `profile-pictures` (2026-05-16). Two
-provisioning steps remain before production works: create the hosted
-`avatars` bucket and set `SUPABASE_SECRET_KEY` in the Vercel project
-env (see `docs/doc-supabase.md`). Closes #131 (and #136, the
-avatar-URL tracking-pixel issue, folded in).
+Status: implemented 2026-05-16. Closes #131 (and #136, the avatar-URL
+tracking-pixel issue, folded in).
 
 ## Goal
 

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-16 | James | Profile pictures (#131)
+
+Members upload a photo on the edit-profile screen and crop it in a circular modal (react-easy-crop); the server re-encodes it with `sharp` to a 1024² WebP and stores it in a private Supabase Storage `avatars` bucket. Avatars are served as 24h signed URLs — batched and cached in `src/server/avatars.ts` — and rendered through `next/image`. The `avatar_url` column (TS property `avatarPath`) now holds a Storage object path, not free-text, which also closes #136's tracking-pixel hole. Full design and decision rationale: `docs/design-profile-pictures.md`.
+
 ## 2026-05-15 | James | Node 24 LTS upgrade
 
 `.nvmrc`, the three CI workflows, and `@types/node` move to Node 24 — catching CI and local dev up to production, which Vercel already runs on 24. `engines.node` now pins the version in source so the two can't drift again.

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,9 +4,9 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
-## 2026-05-16 | James | Profile pictures (#131)
+## 2026-05-16 | James | Profile pictures
 
-Members upload a photo on the edit-profile screen and crop it in a circular modal (react-easy-crop); the server re-encodes it with `sharp` to a 1024² WebP and stores it in a private Supabase Storage `avatars` bucket. Avatars are served as 24h signed URLs — batched and cached in `src/server/avatars.ts` — and rendered through `next/image`. The `avatar_url` column (TS property `avatarPath`) now holds a Storage object path, not free-text, which also closes #136's tracking-pixel hole. Full design and decision rationale: `docs/design-profile-pictures.md`.
+Members upload a photo on the welcome/edit-profile screen and crop it in a circular modal (react-easy-crop); the server re-encodes it with `sharp` to a 1024² WebP and stores it in a private Supabase Storage `avatars` bucket. Avatars are served as 24h signed URLs — batched and cached in `src/server/avatars.ts` — and rendered through `next/image`. The `avatar_url` column (TS property `avatarPath`) now holds a Storage object path. Full design: `docs/design-profile-pictures.md`.
 
 ## 2026-05-15 | James | Node 24 LTS upgrade
 

--- a/docs/doc-supabase.md
+++ b/docs/doc-supabase.md
@@ -96,7 +96,7 @@ Profile pictures (issue #131) live in a Storage bucket named **`avatars`**. Crea
 
 - **Name:** `avatars`
 - **Public:** off — objects are served via short-lived signed URLs
-- **File size limit:** 3 MB (the dashboard field takes decimal B/KB/MB, not MiB) — a loose backstop; the upload endpoint enforces the real ~2 MiB cap
+- **File size limit:** 1 MB (the field takes decimal MB/KB/B units, not MiB)
 - **Allowed MIME types:** `image/webp`
 
 The server reaches Storage with the **secret key** (`src/lib/supabase/admin.ts`), which bypasses Storage RLS — so no bucket policies are needed, the same posture as the `postgres` superuser for the database.

--- a/docs/doc-supabase.md
+++ b/docs/doc-supabase.md
@@ -78,7 +78,7 @@ The trailing `*` matters: the invite-signup flow from `/signup` passes `emailRed
 ### API keys
 
 - **Publishable default key:** exposed to the browser as `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`
-- **Service role key:** not currently used by the app; keep secret if ever needed
+- **Secret key:** used server-side by `src/lib/supabase/admin.ts` for avatar Storage operations (upload, signing, delete) and by the e2e session helper; exposed as `SUPABASE_SECRET_KEY`. Never sent to the browser.
 
 Both are set as Vercel environment variables (see `docs/doc-vercel.md`), not committed to the repo.
 
@@ -89,6 +89,17 @@ The hosted project's auto-generated **Data API** is disabled at the dashboard to
 **Why it stays off.** Authorization logic lives in the Hono middleware (`src/server/auth-middleware.ts`), so PostgREST and pg_graphql add attack surface without adding capability. RLS denies `anon` and `authenticated` on every table as a backstop (see `docs/architecture-appstack.md`), so flipping the toggle on would not directly expose data — but it would put every table one RLS-policy bug away from a leak, and create a parallel access path that bypasses the request logging, validation, and shape-checking in the Hono layer.
 
 Keeping the Data API off leaves a single door to the database: the Hono API at `src/server/api.ts`, which connects via the `postgres` superuser in `DATABASE_URL` (a server-only env var).
+
+### Storage — `avatars` bucket
+
+Profile pictures (issue #131) live in a Storage bucket named **`avatars`**. Create it once in the dashboard (Storage → New bucket) to match the local declaration in `supabase/config.toml`:
+
+- **Name:** `avatars`
+- **Public:** off — objects are served via short-lived signed URLs
+- **File size limit:** 2 MiB
+- **Allowed MIME types:** `image/webp`
+
+The server reaches Storage with the **secret key** (`src/lib/supabase/admin.ts`), which bypasses Storage RLS — so no bucket policies are needed, the same posture as the `postgres` superuser for the database.
 
 ---
 

--- a/docs/doc-supabase.md
+++ b/docs/doc-supabase.md
@@ -96,7 +96,7 @@ Profile pictures (issue #131) live in a Storage bucket named **`avatars`**. Crea
 
 - **Name:** `avatars`
 - **Public:** off — objects are served via short-lived signed URLs
-- **File size limit:** 2 MiB
+- **File size limit:** 3 MB (the dashboard field takes decimal B/KB/MB, not MiB) — a loose backstop; the upload endpoint enforces the real ~2 MiB cap
 - **Allowed MIME types:** `image/webp`
 
 The server reaches Storage with the **secret key** (`src/lib/supabase/admin.ts`), which bypasses Storage RLS — so no bucket policies are needed, the same posture as the `postgres` superuser for the database.

--- a/next.config.ts
+++ b/next.config.ts
@@ -66,7 +66,13 @@ if (!isProd) {
 
 const nextConfig: NextConfig = {
   typedRoutes: true,
-  images: { remotePatterns },
+  images: {
+    remotePatterns,
+    // The local Supabase Storage container lives on 127.0.0.1, which
+    // Next 16's optimizer blocks as an SSRF guard. Allow it in dev
+    // only — production avatars come from the public *.supabase.co host.
+    dangerouslyAllowLocalIP: !isProd,
+  },
   async headers() {
     return [{ source: "/(.*)", headers: securityHeaders }];
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -48,8 +48,25 @@ const securityHeaders = [
   },
 ];
 
+// Avatar objects are served from Supabase Storage (signed URLs) and
+// rendered through next/image, so the optimizer must be allowed to
+// fetch from the Supabase host. Local dev points at the Supabase
+// container on 127.0.0.1:54321 — mirror the isProd CSP branching.
+const remotePatterns: NonNullable<NextConfig["images"]>["remotePatterns"] = [
+  { protocol: "https", hostname: "*.supabase.co", pathname: "/storage/v1/object/**" },
+];
+if (!isProd) {
+  remotePatterns.push({
+    protocol: "http",
+    hostname: "127.0.0.1",
+    port: "54321",
+    pathname: "/storage/v1/object/**",
+  });
+}
+
 const nextConfig: NextConfig = {
   typedRoutes: true,
+  images: { remotePatterns },
   async headers() {
     return [{ source: "/(.*)", headers: securityHeaders }];
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "^19.2.6",
         "react-joyride": "^3.1.0",
         "shadcn": "^4.7.0",
+        "sharp": "^0.34.5",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -1758,7 +1759,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -7063,7 +7063,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -11331,7 +11330,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -11375,7 +11373,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "postgres": "^3.4.8",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "react-easy-crop": "^5.5.7",
         "react-joyride": "^3.1.0",
         "shadcn": "^4.7.0",
         "sharp": "^0.34.5",
@@ -9933,6 +9934,12 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "license": "MIT"
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/npm-normalize-package-bin": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
@@ -10672,6 +10679,20 @@
       },
       "peerDependencies": {
         "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.7.tgz",
+      "integrity": "sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-innertext": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-dom": "^19.2.6",
     "react-joyride": "^3.1.0",
     "shadcn": "^4.7.0",
+    "sharp": "^0.34.5",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "postgres": "^3.4.8",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "react-easy-crop": "^5.5.7",
     "react-joyride": "^3.1.0",
     "shadcn": "^4.7.0",
     "sharp": "^0.34.5",

--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { Avatar } from "@/components/avatar";
 import { serverApiClient } from "@/lib/api-server";
 import type { MemberProfile } from "@/lib/api-types";
 
@@ -47,6 +48,14 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
           ← Directory
         </Link>
       </div>
+
+      <Avatar
+        name={profile.displayName}
+        url={profile.avatarUrl}
+        sizes="128px"
+        priority
+        className="flex h-32 w-32 items-center justify-center overflow-hidden rounded-full bg-muted text-3xl font-semibold text-muted-foreground"
+      />
 
       <dl className="flex w-full max-w-md flex-col gap-4">
         <Field label="Bio">{profile.bio}</Field>

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -16,6 +16,7 @@ function MemberCard({ member }: { member: MemberSummary }) {
       <Avatar
         name={member.displayName}
         url={member.avatarUrl}
+        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 256px"
         className="flex aspect-square w-full items-center justify-center overflow-hidden rounded-t-sm bg-muted text-2xl font-semibold text-muted-foreground"
       />
       <div className="flex flex-col gap-1 p-4">

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -11,13 +11,13 @@ function MemberCard({ member }: { member: MemberSummary }) {
   return (
     <Link
       href={href}
-      className="flex h-full flex-col rounded border border-border hover:bg-muted/50 transition-colors overflow-hidden"
+      className="flex h-full flex-col rounded-sm border border-border hover:bg-muted/50 transition-colors overflow-hidden"
     >
       <Avatar
         name={member.displayName}
         url={member.avatarUrl}
         sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 256px"
-        className="flex aspect-square w-full items-center justify-center overflow-hidden rounded-t-sm bg-muted text-2xl font-semibold text-muted-foreground"
+        className="flex aspect-square w-full items-center justify-center overflow-hidden bg-muted text-2xl font-semibold text-muted-foreground"
       />
       <div className="flex flex-col gap-1 p-4">
         <span className="font-semibold">{member.displayName}</span>

--- a/src/app/profile/avatar-uploader.tsx
+++ b/src/app/profile/avatar-uploader.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useRef, useState } from "react";
+import Cropper, { type Area } from "react-easy-crop";
+import "react-easy-crop/react-easy-crop.css";
+
+import { Avatar } from "@/components/avatar";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+const AVATAR_CLASS =
+  "flex h-32 w-32 items-center justify-center overflow-hidden rounded-full bg-muted text-3xl font-semibold text-muted-foreground";
+
+// Largest dimension we keep a picked source at. Bounding the source
+// once, here, means the crop UI and the extraction canvas never hold
+// the full-resolution image — the mobile-OOM guard from
+// docs/design-profile-pictures.md.
+const MAX_SOURCE_DIMENSION = 1600;
+// Master size stored; the server re-encodes to the same dimension.
+const OUTPUT_DIMENSION = 1024;
+
+const getContext = (canvas: HTMLCanvasElement): CanvasRenderingContext2D => {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("canvas 2d context unavailable");
+  return ctx;
+};
+
+// Decodes a picked file, applying EXIF orientation, and re-draws it
+// down to MAX_SOURCE_DIMENSION. Returns an object URL for the bounded
+// image — the caller owns revoking it.
+const boundSource = async (file: File): Promise<string> => {
+  const bitmap = await createImageBitmap(file, { imageOrientation: "from-image" });
+  const scale = Math.min(1, MAX_SOURCE_DIMENSION / Math.max(bitmap.width, bitmap.height));
+  const width = Math.round(bitmap.width * scale);
+  const height = Math.round(bitmap.height * scale);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  getContext(canvas).drawImage(bitmap, 0, 0, width, height);
+  bitmap.close();
+
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/webp", 0.9));
+  if (!blob) throw new Error("could not process image");
+  return URL.createObjectURL(blob);
+};
+
+const loadImage = (src: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("image load failed"));
+    img.src = src;
+  });
+
+// Draws the chosen crop rectangle into a square OUTPUT_DIMENSION canvas
+// and exports it as a WebP blob. `area` is in the bounded source's
+// pixel space, so it lines up with the image loaded here.
+const cropToWebp = async (src: string, area: Area): Promise<Blob> => {
+  const img = await loadImage(src);
+  const canvas = document.createElement("canvas");
+  canvas.width = OUTPUT_DIMENSION;
+  canvas.height = OUTPUT_DIMENSION;
+  getContext(canvas).drawImage(
+    img,
+    area.x,
+    area.y,
+    area.width,
+    area.height,
+    0,
+    0,
+    OUTPUT_DIMENSION,
+    OUTPUT_DIMENSION,
+  );
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/webp", 0.82));
+  if (!blob) throw new Error("could not encode image");
+  return blob;
+};
+
+type Status = { kind: "idle" } | { kind: "busy" } | { kind: "error"; message: string };
+
+// Profile-picture upload. Lives above the profile form and acts on its
+// own — picking and confirming a crop uploads immediately, independent
+// of the form's Save button.
+export function AvatarUploader({ name, initialUrl }: { name: string | null; initialUrl: string | null }) {
+  const [url, setUrl] = useState(initialUrl);
+  const [cropSrc, setCropSrc] = useState<string | null>(null);
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [area, setArea] = useState<Area | null>(null);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const busy = status.kind === "busy";
+
+  const closeCropper = () => {
+    setCropSrc((src) => {
+      if (src) URL.revokeObjectURL(src);
+      return null;
+    });
+  };
+
+  const handleFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    // Reset so picking the same file again still fires onChange.
+    event.target.value = "";
+    if (!file) return;
+
+    setStatus({ kind: "idle" });
+    try {
+      const bounded = await boundSource(file);
+      setCrop({ x: 0, y: 0 });
+      setZoom(1);
+      setArea(null);
+      setCropSrc(bounded);
+    } catch {
+      setStatus({ kind: "error", message: "Couldn't read that image. Try a PNG or JPEG." });
+    }
+  };
+
+  const handleSave = async () => {
+    if (!cropSrc || !area) return;
+    setStatus({ kind: "busy" });
+    try {
+      const blob = await cropToWebp(cropSrc, area);
+      const form = new FormData();
+      form.append("file", blob, "avatar.webp");
+
+      const res = await fetch("/api/me/avatar", { method: "POST", body: form, credentials: "include" });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? "Upload failed.");
+      }
+      const { avatarUrl } = (await res.json()) as { avatarUrl: string };
+
+      setUrl(avatarUrl);
+      setStatus({ kind: "idle" });
+      closeCropper();
+    } catch (err) {
+      setStatus({ kind: "error", message: err instanceof Error ? err.message : "Upload failed." });
+    }
+  };
+
+  const handleRemove = async () => {
+    setStatus({ kind: "busy" });
+    try {
+      const res = await fetch("/api/me/avatar", { method: "DELETE", credentials: "include" });
+      if (!res.ok) throw new Error("Couldn't remove the photo.");
+      setUrl(null);
+      setStatus({ kind: "idle" });
+    } catch (err) {
+      setStatus({ kind: "error", message: err instanceof Error ? err.message : "Couldn't remove the photo." });
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <Avatar name={name} url={url} sizes="128px" className={AVATAR_CLASS} />
+
+      <div className="flex gap-2">
+        <Button type="button" onClick={() => fileInputRef.current?.click()} disabled={busy}>
+          {url ? "Change photo" : "Upload photo"}
+        </Button>
+        {url && (
+          <Button type="button" variant="ghost" onClick={handleRemove} disabled={busy}>
+            Remove
+          </Button>
+        )}
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/webp"
+        className="hidden"
+        onChange={handleFile}
+      />
+
+      {status.kind === "error" && !cropSrc && (
+        <p role="alert" className="text-sm text-destructive">
+          {status.message}
+        </p>
+      )}
+
+      <Dialog
+        open={cropSrc !== null}
+        onOpenChange={(open) => {
+          if (!open) closeCropper();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Position your photo</DialogTitle>
+          </DialogHeader>
+
+          {cropSrc && (
+            <>
+              <div className="relative h-72 w-full overflow-hidden rounded bg-muted">
+                <Cropper
+                  image={cropSrc}
+                  crop={crop}
+                  zoom={zoom}
+                  aspect={1}
+                  cropShape="round"
+                  showGrid={false}
+                  onCropChange={setCrop}
+                  onZoomChange={setZoom}
+                  onCropComplete={(_area, areaPixels) => setArea(areaPixels)}
+                />
+              </div>
+              <label className="flex items-center gap-3 text-sm">
+                Zoom
+                <input
+                  type="range"
+                  min={1}
+                  max={3}
+                  step={0.01}
+                  value={zoom}
+                  onChange={(e) => setZoom(Number(e.target.value))}
+                  className="flex-1"
+                  aria-label="Zoom"
+                />
+              </label>
+              {status.kind === "error" && (
+                <p role="alert" className="text-sm text-destructive">
+                  {status.message}
+                </p>
+              )}
+            </>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={closeCropper} disabled={busy}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleSave} disabled={busy || !area}>
+              {busy ? "Saving…" : "Save photo"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/profile/avatar-uploader.tsx
+++ b/src/app/profile/avatar-uploader.tsx
@@ -160,7 +160,7 @@ export function AvatarUploader({ name, initialUrl }: { name: string | null; init
 
   return (
     <div className="flex flex-col items-center gap-3">
-      <Avatar name={name} url={url} sizes="128px" className={AVATAR_CLASS} />
+      <Avatar name={name} url={url} sizes="128px" priority className={AVATAR_CLASS} />
 
       <div className="flex gap-2">
         <Button type="button" onClick={() => fileInputRef.current?.click()} disabled={busy}>

--- a/src/app/profile/avatar-uploader.tsx
+++ b/src/app/profile/avatar-uploader.tsx
@@ -40,7 +40,12 @@ const boundSource = async (file: File): Promise<string> => {
   getContext(canvas).drawImage(bitmap, 0, 0, width, height);
   bitmap.close();
 
-  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/webp", 0.9));
+  // The bounded image is both what the cropper displays and what
+  // cropToWebp extracts the final crop from, so its quality is a real
+  // link in the chain — but it only needs to sit above the final
+  // encode (0.88) to not be the limiting generation; higher just grows
+  // the blob. The object URL is revoked when the modal closes.
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/webp", 0.92));
   if (!blob) throw new Error("could not process image");
   return URL.createObjectURL(blob);
 };
@@ -72,7 +77,7 @@ const cropToWebp = async (src: string, area: Area): Promise<Blob> => {
     OUTPUT_DIMENSION,
     OUTPUT_DIMENSION,
   );
-  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/webp", 0.82));
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/webp", 0.88));
   if (!blob) throw new Error("could not encode image");
   return blob;
 };

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -25,7 +25,6 @@ export default async function EditProfilePage() {
           keywords: profile.keywords ?? [],
           location: profile.location ?? "",
           supplementaryInfo: profile.supplementaryInfo ?? "",
-          avatarUrl: profile.avatarUrl ?? "",
           emergencyContact: profile.emergencyContact ?? "",
           liveDesire: profile.liveDesire ?? "",
         }}

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { requireUser } from "@/lib/api-server";
 import type { Me } from "@/lib/api-types";
 
+import { AvatarUploader } from "../avatar-uploader";
 import { ProfileForm } from "../profile-form";
 
 export default async function EditProfilePage() {
@@ -17,6 +18,8 @@ export default async function EditProfilePage() {
           ← Back to profile
         </Link>
       </div>
+
+      <AvatarUploader name={profile.displayName} initialUrl={profile.avatarUrl} />
 
       <ProfileForm
         initial={{

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { Avatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
 import { requireUser } from "@/lib/api-server";
 import type { Me } from "@/lib/api-types";
@@ -26,6 +27,12 @@ export default async function ProfilePage() {
         </Link>
       </div>
 
+      <Avatar
+        name={profile.displayName}
+        url={profile.avatarUrl}
+        className="flex h-32 w-32 items-center justify-center overflow-hidden rounded-full bg-muted text-3xl font-semibold text-muted-foreground"
+      />
+
       <dl className="flex w-full max-w-md flex-col gap-4">
         <Field label="Display name">{profile.displayName}</Field>
         <Field label="Bio">{profile.bio}</Field>
@@ -33,7 +40,6 @@ export default async function ProfilePage() {
         <Field label="Location">{profile.location}</Field>
         <Field label="Live desire">{profile.liveDesire}</Field>
         <Field label="Supplementary info">{profile.supplementaryInfo}</Field>
-        <Field label="Avatar URL">{profile.avatarUrl}</Field>
         <Field label="Emergency contact">{profile.emergencyContact}</Field>
       </dl>
 

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -30,6 +30,7 @@ export default async function ProfilePage() {
       <Avatar
         name={profile.displayName}
         url={profile.avatarUrl}
+        sizes="128px"
         className="flex h-32 w-32 items-center justify-center overflow-hidden rounded-full bg-muted text-3xl font-semibold text-muted-foreground"
       />
 

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -31,6 +31,7 @@ export default async function ProfilePage() {
         name={profile.displayName}
         url={profile.avatarUrl}
         sizes="128px"
+        priority
         className="flex h-32 w-32 items-center justify-center overflow-hidden rounded-full bg-muted text-3xl font-semibold text-muted-foreground"
       />
 

--- a/src/app/profile/profile-form.tsx
+++ b/src/app/profile/profile-form.tsx
@@ -16,7 +16,6 @@ type ProfileFormProps = {
     keywords: string[];
     location: string;
     supplementaryInfo: string;
-    avatarUrl: string;
     emergencyContact: string;
     liveDesire: string;
   };
@@ -31,7 +30,6 @@ export function ProfileForm({ initial }: ProfileFormProps) {
   const [keywordsText, setKeywordsText] = useState(initial.keywords.join(", "));
   const [location, setLocation] = useState(initial.location);
   const [supplementaryInfo, setSupplementaryInfo] = useState(initial.supplementaryInfo);
-  const [avatarUrl, setAvatarUrl] = useState(initial.avatarUrl);
   const [emergencyContact, setEmergencyContact] = useState(initial.emergencyContact);
   const [liveDesire, setLiveDesire] = useState(initial.liveDesire);
   const [status, setStatus] = useState<Status>({ kind: "idle" });
@@ -53,7 +51,6 @@ export function ProfileForm({ initial }: ProfileFormProps) {
           keywords,
           location: location.trim() || null,
           supplementaryInfo: supplementaryInfo.trim() || null,
-          avatarUrl: avatarUrl.trim() || null,
           emergencyContact: emergencyContact.trim() || null,
           liveDesire: liveDesire.trim() || null,
         },
@@ -129,15 +126,6 @@ export function ProfileForm({ initial }: ProfileFormProps) {
         onChange={(e) => setSupplementaryInfo(e.target.value)}
         disabled={disabled}
         rows={3}
-      />
-
-      <Label htmlFor="avatarUrl">Avatar URL</Label>
-      <Input
-        id="avatarUrl"
-        type="url"
-        value={avatarUrl}
-        onChange={(e) => setAvatarUrl(e.target.value)}
-        disabled={disabled}
       />
 
       <Label htmlFor="emergencyContact">Emergency contact</Label>

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,6 +1,7 @@
 import { requireUser } from "@/lib/api-server";
 import type { Me } from "@/lib/api-types";
 
+import { AvatarUploader } from "../profile/avatar-uploader";
 import { WelcomeForm } from "./welcome-form";
 
 export default async function WelcomePage() {
@@ -13,6 +14,7 @@ export default async function WelcomePage() {
       <p className="max-w-md text-center text-base text-muted-foreground">
         Tell us a little about yourself. You can edit this later.
       </p>
+      <AvatarUploader name={profile?.displayName ?? null} initialUrl={profile?.avatarUrl ?? null} />
       <WelcomeForm
         initial={{
           displayName: profile?.displayName ?? "",

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -20,7 +20,6 @@ export default async function WelcomePage() {
           keywords: profile?.keywords ?? [],
           location: profile?.location ?? "",
           supplementaryInfo: profile?.supplementaryInfo ?? "",
-          avatarUrl: profile?.avatarUrl ?? "",
           emergencyContact: profile?.emergencyContact ?? "",
           liveDesire: profile?.liveDesire ?? "",
         }}

--- a/src/app/welcome/welcome-form.tsx
+++ b/src/app/welcome/welcome-form.tsx
@@ -16,7 +16,6 @@ type Initial = {
   keywords: string[];
   location: string;
   supplementaryInfo: string;
-  avatarUrl: string;
   emergencyContact: string;
   liveDesire: string;
 };
@@ -30,7 +29,6 @@ export function WelcomeForm({ initial }: { initial: Initial }) {
   const [keywordsText, setKeywordsText] = useState(initial.keywords.join(", "));
   const [location, setLocation] = useState(initial.location);
   const [supplementaryInfo, setSupplementaryInfo] = useState(initial.supplementaryInfo);
-  const [avatarUrl, setAvatarUrl] = useState(initial.avatarUrl);
   const [emergencyContact, setEmergencyContact] = useState(initial.emergencyContact);
   const [liveDesire, setLiveDesire] = useState(initial.liveDesire);
   const [password, setPassword] = useState("");
@@ -53,7 +51,6 @@ export function WelcomeForm({ initial }: { initial: Initial }) {
           keywords,
           location: location.trim() || null,
           supplementaryInfo: supplementaryInfo.trim() || null,
-          avatarUrl: avatarUrl.trim() || null,
           emergencyContact: emergencyContact.trim() || null,
           liveDesire: liveDesire.trim() || null,
         },
@@ -144,15 +141,6 @@ export function WelcomeForm({ initial }: { initial: Initial }) {
         onChange={(e) => setSupplementaryInfo(e.target.value)}
         disabled={disabled}
         rows={3}
-      />
-
-      <Label htmlFor="avatarUrl">Avatar URL</Label>
-      <Input
-        id="avatarUrl"
-        type="url"
-        value={avatarUrl}
-        onChange={(e) => setAvatarUrl(e.target.value)}
-        disabled={disabled}
       />
 
       <Label htmlFor="emergencyContact">Emergency contact</Label>

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -20,26 +20,30 @@ export const initials = (name: string | null): string =>
 // our own Supabase Storage host, so next/image optimisation applies.
 // `sizes` lets a caller hint the rendered size; the 96px default suits
 // the small avatars (graph nodes, typeahead) — the members grid and
-// profile page pass larger values. Default `alt=""` because every call
-// site renders the displayName as visible sibling text, so the avatar
-// is decorative for screen readers.
+// profile page pass larger values. `priority` opts an above-the-fold
+// single avatar (profile page, uploader preview) out of next/image's
+// default lazy-loading. Default `alt=""` because every call site
+// renders the displayName as visible sibling text, so the avatar is
+// decorative for screen readers.
 export function Avatar({
   name,
   url,
   alt = "",
   sizes = "96px",
+  priority = false,
   className,
 }: {
   name: string | null;
   url: string | null | undefined;
   alt?: string;
   sizes?: string;
+  priority?: boolean;
   className?: string;
 }) {
   return (
     <div className={`relative ${className ?? ""}`}>
       {url ? (
-        <Image src={url} alt={alt} fill sizes={sizes} className="object-cover" />
+        <Image src={url} alt={alt} fill sizes={sizes} priority={priority} className="object-cover" />
       ) : (
         <span>{initials(name)}</span>
       )}

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 // 1–2 letter initials from the first letters of up to two whitespace-
 // separated tokens. `filter(Boolean)` guards against double-spaces;
 // the trailing `|| "?"` keeps an empty/whitespace name from rendering
@@ -11,29 +13,33 @@ export const initials = (name: string | null): string =>
     .join("")
     .toUpperCase() || "?";
 
-// One className styles both states — when `url` is present the image
-// fills the container and the background/font classes hide behind it;
-// when absent, the initials sit centered using those same classes. This
-// keeps the call site to a single style declaration regardless of which
-// branch renders. Default `alt=""` because every call site so far
-// renders the displayName as visible sibling text (so the avatar is
-// decorative for screen readers).
+// One `className` styles both states — when `url` is present the image
+// fills the container (the wrapper is `relative` so next/image `fill`
+// has a positioned ancestor); when absent, the initials sit centered
+// using the caller's background/font classes. Avatar objects come from
+// our own Supabase Storage host, so next/image optimisation applies.
+// `sizes` lets a caller hint the rendered size; the 96px default suits
+// the small avatars (graph nodes, typeahead) — the members grid and
+// profile page pass larger values. Default `alt=""` because every call
+// site renders the displayName as visible sibling text, so the avatar
+// is decorative for screen readers.
 export function Avatar({
   name,
   url,
   alt = "",
+  sizes = "96px",
   className,
 }: {
   name: string | null;
   url: string | null | undefined;
   alt?: string;
+  sizes?: string;
   className?: string;
 }) {
   return (
-    <div className={className}>
+    <div className={`relative ${className ?? ""}`}>
       {url ? (
-        // biome-ignore lint/performance/noImgElement: avatarUrl is user-supplied and can come from any host
-        <img src={url} alt={alt} className="h-full w-full object-cover" />
+        <Image src={url} alt={alt} fill sizes={sizes} className="object-cover" />
       ) : (
         <span>{initials(name)}</span>
       )}

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,13 @@
+import "server-only";
+
+import { createClient } from "@supabase/supabase-js";
+
+// Privileged Supabase client for server-side Storage operations
+// (signing, upload, delete). It authenticates with the secret key, so
+// it bypasses Storage RLS — consistent with how `db` connects as a
+// privileged Postgres role and treats RLS as a backstop. Never import
+// this into client code; the `server-only` guard fails the build if
+// something tries.
+export const supabaseAdmin = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SECRET_KEY!, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,13 +1,12 @@
-import "server-only";
-
 import { createClient } from "@supabase/supabase-js";
 
 // Privileged Supabase client for server-side Storage operations
 // (signing, upload, delete). It authenticates with the secret key, so
 // it bypasses Storage RLS — consistent with how `db` connects as a
-// privileged Postgres role and treats RLS as a backstop. Never import
-// this into client code; the `server-only` guard fails the build if
-// something tries.
+// privileged Postgres role and treats RLS as a backstop. Server-only
+// by placement and convention (like `src/server/db.ts`):
+// SUPABASE_SECRET_KEY is not a NEXT_PUBLIC var, so it never reaches the
+// client bundle. Do not import this into client code.
 export const supabaseAdmin = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SECRET_KEY!, {
   auth: { persistSession: false, autoRefreshToken: false },
 });

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -7,6 +7,7 @@ import { isRelationValue } from "@/lib/relation-value";
 
 import { getAppSettings } from "./app-settings";
 import { type ApiVariables, isAdmin, isUuid, requireAdmin, requireAuth } from "./auth-middleware";
+import { clearAvatar, encodeAvatar, MAX_AVATAR_UPLOAD_BYTES, replaceAvatar } from "./avatars";
 import { db } from "./db";
 import { checkInvite, createInvite, getInvitesForCreator, revokeInvite, validateNote } from "./invites";
 import {
@@ -114,6 +115,43 @@ const api = new Hono<{ Variables: ApiVariables }>()
   .put("/me/last-updated-web", async (c) => {
     const user = c.get("user");
     await markWebUpdated(user.id);
+    return c.json({ ok: true });
+  })
+  .post("/me/avatar", async (c) => {
+    const user = c.get("user");
+
+    const form = await c.req.parseBody().catch(() => null);
+    if (!form) {
+      return c.json({ error: "invalid form body" }, 400);
+    }
+    const file = form.file;
+    if (!(file instanceof File)) {
+      return c.json({ error: "missing file field" }, 400);
+    }
+    if (file.size > MAX_AVATAR_UPLOAD_BYTES) {
+      return c.json({ error: "file too large" }, 400);
+    }
+    if (!file.type.startsWith("image/")) {
+      return c.json({ error: "file must be an image" }, 400);
+    }
+
+    let webp: Buffer;
+    try {
+      webp = await encodeAvatar(Buffer.from(await file.arrayBuffer()));
+    } catch {
+      // sharp throws on bytes that do not decode as an image.
+      return c.json({ error: "could not decode image" }, 400);
+    }
+
+    // Ensure a profile row exists before pointing it at the object —
+    // the same self-heal guarantee GET/PUT /me carry.
+    await upsertProfile(user);
+    const avatarUrl = await replaceAvatar(user.id, webp);
+    return c.json({ avatarUrl });
+  })
+  .delete("/me/avatar", async (c) => {
+    const user = c.get("user");
+    await clearAvatar(user.id);
     return c.json({ ok: true });
   })
   .post("/invites", async (c) => {

--- a/src/server/avatars.ts
+++ b/src/server/avatars.ts
@@ -1,5 +1,3 @@
-import "server-only";
-
 import { randomUUID } from "node:crypto";
 
 import { eq } from "drizzle-orm";

--- a/src/server/avatars.ts
+++ b/src/server/avatars.ts
@@ -1,0 +1,72 @@
+import "server-only";
+
+import { supabaseAdmin } from "@/lib/supabase/admin";
+
+// Supabase Storage bucket holding avatar objects. Private — objects
+// are reachable only via a signed URL (see
+// docs/design-profile-pictures.md decision 1).
+export const AVATAR_BUCKET = "avatars";
+
+// TTL handed to Supabase when signing, and how long a signed URL is
+// trusted from our cache. The cache window is deliberately shorter
+// than the TTL so a URL is re-signed before it can expire mid-use.
+const SIGN_TTL_SECONDS = 24 * 60 * 60;
+const CACHE_TTL_MS = 23 * 60 * 60 * 1000;
+
+type CacheEntry = { url: string; expiresAt: number };
+
+// Module-level cache keyed by object path. On Fluid Compute the
+// instance is reused across requests, so signing fires roughly once
+// per path per TTL rather than once per page view — the directory's
+// hot path then does zero Storage round-trips.
+const signedUrlCache = new Map<string, CacheEntry>();
+
+// Signs a batch of avatar object paths, returning a path → signed-URL
+// map. Cache hits skip the network; misses are signed in a single
+// `createSignedUrls` round-trip however many there are. Null/undefined
+// inputs and objects that fail to sign (e.g. already deleted) are
+// simply absent from the result.
+export const resolveAvatarUrls = async (
+  paths: readonly (string | null | undefined)[],
+): Promise<Map<string, string>> => {
+  const result = new Map<string, string>();
+  const now = Date.now();
+  const misses: string[] = [];
+
+  for (const path of paths) {
+    if (!path || result.has(path)) continue;
+    const cached = signedUrlCache.get(path);
+    if (cached && cached.expiresAt > now) {
+      result.set(path, cached.url);
+    } else if (!misses.includes(path)) {
+      misses.push(path);
+    }
+  }
+
+  if (misses.length > 0) {
+    const { data, error } = await supabaseAdmin.storage.from(AVATAR_BUCKET).createSignedUrls(misses, SIGN_TTL_SECONDS);
+    if (error) throw error;
+    for (const row of data ?? []) {
+      if (row.error || !row.path || !row.signedUrl) continue;
+      signedUrlCache.set(row.path, { url: row.signedUrl, expiresAt: now + CACHE_TTL_MS });
+      result.set(row.path, row.signedUrl);
+    }
+  }
+
+  return result;
+};
+
+// Replaces the stored `avatarPath` on each row with a freshly signed
+// `avatarUrl`. This is the single chokepoint where a stored path
+// becomes a URL, so a future change of serving scheme stays a
+// one-function edit — and it guarantees the raw path never reaches a
+// client. Single-row callers pass a one-element array.
+export const attachAvatarUrls = async <T extends { avatarPath: string | null }>(
+  rows: readonly T[],
+): Promise<(Omit<T, "avatarPath"> & { avatarUrl: string | null })[]> => {
+  const signed = await resolveAvatarUrls(rows.map((r) => r.avatarPath));
+  return rows.map(({ avatarPath, ...rest }) => ({
+    ...rest,
+    avatarUrl: avatarPath ? (signed.get(avatarPath) ?? null) : null,
+  }));
+};

--- a/src/server/avatars.ts
+++ b/src/server/avatars.ts
@@ -93,7 +93,7 @@ export const encodeAvatar = (input: Buffer): Promise<Buffer> =>
   sharp(input, { limitInputPixels: 100_000_000 })
     .rotate()
     .resize(AVATAR_DIMENSION, AVATAR_DIMENSION, { fit: "cover" })
-    .webp({ quality: 82 })
+    .webp({ quality: 88 })
     .toBuffer();
 
 // Stores an encoded avatar for a user: uploads the object, points the

--- a/src/server/avatars.ts
+++ b/src/server/avatars.ts
@@ -80,7 +80,7 @@ export const attachAvatarUrls = async <T extends { avatarPath: string | null }>(
 // Maximum accepted upload size. The browser shrinks the image well
 // below this; the cap is defence-in-depth against a client that does
 // not (see docs/design-profile-pictures.md decision 3).
-export const MAX_AVATAR_UPLOAD_BYTES = 2 * 1024 * 1024;
+export const MAX_AVATAR_UPLOAD_BYTES = 1_000_000;
 
 const AVATAR_DIMENSION = 1024;
 

--- a/src/server/avatars.ts
+++ b/src/server/avatars.ts
@@ -1,6 +1,14 @@
 import "server-only";
 
+import { randomUUID } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+import sharp from "sharp";
+
 import { supabaseAdmin } from "@/lib/supabase/admin";
+
+import { db } from "./db";
+import { profiles } from "./schema";
 
 // Supabase Storage bucket holding avatar objects. Private — objects
 // are reachable only via a signed URL (see
@@ -69,4 +77,63 @@ export const attachAvatarUrls = async <T extends { avatarPath: string | null }>(
     ...rest,
     avatarUrl: avatarPath ? (signed.get(avatarPath) ?? null) : null,
   }));
+};
+
+// Maximum accepted upload size. The browser shrinks the image well
+// below this; the cap is defence-in-depth against a client that does
+// not (see docs/design-profile-pictures.md decision 3).
+export const MAX_AVATAR_UPLOAD_BYTES = 2 * 1024 * 1024;
+
+const AVATAR_DIMENSION = 1024;
+
+// Re-encodes arbitrary uploaded image bytes into the canonical avatar
+// artifact: a 1024² WebP, cover-cropped square, EXIF orientation
+// applied, all metadata stripped. Rejects (throws) bytes that do not
+// decode as an image — the caller maps that to a 400. limitInputPixels
+// caps the decoded surface as a decompression-bomb guard.
+export const encodeAvatar = (input: Buffer): Promise<Buffer> =>
+  sharp(input, { limitInputPixels: 100_000_000 })
+    .rotate()
+    .resize(AVATAR_DIMENSION, AVATAR_DIMENSION, { fit: "cover" })
+    .webp({ quality: 82 })
+    .toBuffer();
+
+// Stores an encoded avatar for a user: uploads the object, points the
+// profile row at it, then removes the previous object. The ordering is
+// deliberate — the object exists before the row references it, and the
+// old object is dropped last — so a mid-failure only ever orphans a
+// file, never leaves a row pointing at a missing object. Returns the
+// new signed URL. Assumes the profile row already exists.
+export const replaceAvatar = async (userId: string, webp: Buffer): Promise<string> => {
+  const path = `${userId}/${randomUUID()}.webp`;
+
+  const { error: uploadError } = await supabaseAdmin.storage
+    .from(AVATAR_BUCKET)
+    .upload(path, webp, { contentType: "image/webp", upsert: false });
+  if (uploadError) throw uploadError;
+
+  const [existing] = await db
+    .select({ avatarPath: profiles.avatarPath })
+    .from(profiles)
+    .where(eq(profiles.id, userId));
+  // Single autocommit statement — safe on the transaction pooler.
+  await db.update(profiles).set({ avatarPath: path }).where(eq(profiles.id, userId));
+
+  if (existing?.avatarPath && existing.avatarPath !== path) {
+    await supabaseAdmin.storage.from(AVATAR_BUCKET).remove([existing.avatarPath]);
+  }
+
+  return (await resolveAvatarUrls([path])).get(path) ?? "";
+};
+
+// Clears a user's avatar: nulls the column, then removes the object.
+export const clearAvatar = async (userId: string): Promise<void> => {
+  const [existing] = await db
+    .select({ avatarPath: profiles.avatarPath })
+    .from(profiles)
+    .where(eq(profiles.id, userId));
+  if (!existing?.avatarPath) return;
+
+  await db.update(profiles).set({ avatarPath: null }).where(eq(profiles.id, userId));
+  await supabaseAdmin.storage.from(AVATAR_BUCKET).remove([existing.avatarPath]);
 };

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -2,16 +2,19 @@ import type { User } from "@supabase/supabase-js";
 import { asc, eq, isNotNull, or, sql } from "drizzle-orm";
 
 import { isUuid } from "./auth-middleware";
+import { attachAvatarUrls } from "./avatars";
 import { db } from "./db";
 import { profiles } from "./schema";
 
+// avatarUrl is intentionally absent: the avatar is set through the
+// dedicated upload endpoint (POST /api/me/avatar), not as free-text
+// here. The column it maps to is `avatarPath`, a Storage object path.
 export const EDITABLE_PROFILE_FIELDS = [
   "displayName",
   "bio",
   "keywords",
   "location",
   "supplementaryInfo",
-  "avatarUrl",
   "emergencyContact",
   "liveDesire",
 ] as const;
@@ -24,7 +27,6 @@ export type EditableProfileInput = Partial<{
   keywords: string[];
   location: string | null;
   supplementaryInfo: string | null;
-  avatarUrl: string | null;
   emergencyContact: string | null;
   liveDesire: string | null;
 }>;
@@ -112,7 +114,7 @@ export const getProfileForSelf = async (userId: string): Promise<ProfileForSelf 
       supplementaryInfo: profiles.supplementaryInfo,
       referredBy: profiles.referredBy,
       referredByLegacy: profiles.referredByLegacy,
-      avatarUrl: profiles.avatarUrl,
+      avatarPath: profiles.avatarPath,
       emergencyContact: profiles.emergencyContact,
       liveDesire: profiles.liveDesire,
       isAdmin: profiles.isAdmin,
@@ -123,7 +125,9 @@ export const getProfileForSelf = async (userId: string): Promise<ProfileForSelf 
     .from(profiles)
     .where(eq(profiles.id, userId));
 
-  return row ?? null;
+  if (!row) return null;
+  const [profile] = await attachAvatarUrls([row]);
+  return profile;
 };
 
 // Bumps lastUpdatedWeb to now() on the user's profile. The Done button
@@ -164,14 +168,16 @@ export const getProfileForMember = async (idOrSlug: string): Promise<ProfileForM
       keywords: profiles.keywords,
       location: profiles.location,
       supplementaryInfo: profiles.supplementaryInfo,
-      avatarUrl: profiles.avatarUrl,
+      avatarPath: profiles.avatarPath,
       liveDesire: profiles.liveDesire,
       createdAt: profiles.createdAt,
     })
     .from(profiles)
     .where(where);
 
-  return row ?? null;
+  if (!row) return null;
+  const [profile] = await attachAvatarUrls([row]);
+  return profile;
 };
 
 export type MemberSummary = {
@@ -184,18 +190,19 @@ export type MemberSummary = {
 };
 
 export const listMembers = async (): Promise<MemberSummary[]> => {
-  return db
+  const rows = await db
     .select({
       id: profiles.id,
       slug: profiles.slug,
       displayName: profiles.displayName,
       location: profiles.location,
       keywords: profiles.keywords,
-      avatarUrl: profiles.avatarUrl,
+      avatarPath: profiles.avatarPath,
     })
     .from(profiles)
     .where(isNotNull(profiles.displayName))
-    .orderBy(asc(profiles.displayName)) as Promise<MemberSummary[]>;
+    .orderBy(asc(profiles.displayName));
+  return (await attachAvatarUrls(rows)) as MemberSummary[];
 };
 
 // Placeholder. Same rationale as getProfileForMember — admin tooling

--- a/src/server/relations.ts
+++ b/src/server/relations.ts
@@ -16,6 +16,7 @@ import type { PgTransaction } from "drizzle-orm/pg-core";
 import { isRelationValue, type RelationValue } from "@/lib/relation-value";
 
 import { isUuid } from "./auth-middleware";
+import { attachAvatarUrls } from "./avatars";
 import { db } from "./db";
 import { inviteHints, invites, profiles, relations } from "./schema";
 
@@ -41,7 +42,7 @@ export type RelationSuggestionReason =
 
 // Card payload for the rating-decision UI. Fields are chosen so a
 // member can decide without navigating away from the suggestion feed.
-export type RelationSuggestion = SuggestionCardColumns & { reason: RelationSuggestionReason };
+export type RelationSuggestion = Omit<SuggestionCardRow, "avatarPath"> & { avatarUrl: string | null };
 
 export type RelationSuggestionFeed = {
   suggestions: RelationSuggestion[];
@@ -56,7 +57,7 @@ const cardColumns = {
   id: profiles.id,
   slug: profiles.slug,
   displayName: profiles.displayName,
-  avatarUrl: profiles.avatarUrl,
+  avatarPath: profiles.avatarPath,
   bio: profiles.bio,
   keywords: profiles.keywords,
   location: profiles.location,
@@ -64,10 +65,15 @@ const cardColumns = {
 
 type SuggestionCardColumns = Pick<
   InferSelectModel<typeof profiles>,
-  "id" | "slug" | "displayName" | "avatarUrl" | "bio" | "keywords" | "location"
+  "id" | "slug" | "displayName" | "avatarPath" | "bio" | "keywords" | "location"
 >;
 
-const toCard = (row: SuggestionCardColumns, reason: RelationSuggestionReason): RelationSuggestion => ({
+// A card as assembled internally — still carrying the stored
+// avatarPath. getRelationSuggestions resolves these to signed
+// avatarUrls (yielding RelationSuggestion) just before returning.
+type SuggestionCardRow = SuggestionCardColumns & { reason: RelationSuggestionReason };
+
+const toCard = (row: SuggestionCardColumns, reason: RelationSuggestionReason): SuggestionCardRow => ({
   ...row,
   reason,
 });
@@ -79,10 +85,10 @@ const noRelationFromUserTo = (userId: string, relateeRef: SQLWrapper) =>
   sql`NOT EXISTS (SELECT 1 FROM relations rev WHERE rev.rater_id = ${userId} AND rev.ratee_id = ${relateeRef})`;
 
 const collectInto = <T extends { id: string }>(
-  target: RelationSuggestion[],
+  target: SuggestionCardRow[],
   seen: Set<string>,
   rows: T[],
-  build: (row: T) => RelationSuggestion,
+  build: (row: T) => SuggestionCardRow,
 ): void => {
   for (const row of rows) {
     if (seen.has(row.id)) continue;
@@ -99,8 +105,8 @@ const collectInto = <T extends { id: string }>(
 // directory) so the feed never goes empty while a member remains.
 export const getRelationSuggestions = async (userId: string): Promise<RelationSuggestionFeed> => {
   const seen = new Set<string>([userId]);
-  const suggestions: RelationSuggestion[] = [];
-  const otherMembers: RelationSuggestion[] = [];
+  const suggestions: SuggestionCardRow[] = [];
+  const otherMembers: SuggestionCardRow[] = [];
 
   // First wave: every query that doesn't depend on another fires in
   // parallel. Source 1 (addedMe), Source 2 hint rows, the `me` lookup
@@ -218,7 +224,12 @@ export const getRelationSuggestions = async (userId: string): Promise<RelationSu
   collectInto(suggestions, seen, recentlyActive, (row) => toCard(row, { type: "recentlyActive" }));
   collectInto(otherMembers, seen, everyoneElse, (row) => toCard(row, { type: "member" }));
 
-  return { suggestions, otherMembers };
+  // Resolve stored avatar paths to signed URLs in one batch per array
+  // — the chokepoint that keeps raw paths off the wire.
+  return {
+    suggestions: await attachAvatarUrls(suggestions),
+    otherMembers: await attachAvatarUrls(otherMembers),
+  };
 };
 
 export type SubgraphNode = {
@@ -244,7 +255,7 @@ const nodeColumns = {
   id: profiles.id,
   slug: profiles.slug,
   displayName: profiles.displayName,
-  avatarUrl: profiles.avatarUrl,
+  avatarPath: profiles.avatarPath,
 };
 
 const edgeKey = (e: { relatorId: string; relateeId: string }): string => `${e.relatorId}:${e.relateeId}`;
@@ -329,7 +340,7 @@ export const getPersonalWeb = async (params: {
           .orderBy(asc(profiles.displayName))
       : [];
 
-  return { centerId, nodes: nodeRows, edges };
+  return { centerId, nodes: await attachAvatarUrls(nodeRows), edges };
 };
 
 // Postgres error code 23503 = foreign_key_violation. In
@@ -459,11 +470,11 @@ export const listPendingHints = async (): Promise<PendingHint[]> => {
       id: profiles.id,
       displayName: profiles.displayName,
       slug: profiles.slug,
-      avatarUrl: profiles.avatarUrl,
+      avatarPath: profiles.avatarPath,
     })
     .from(profiles)
     .where(inArray(profiles.id, [...ids]));
-  const byId = new Map<string, HintProfile>(profileRows.map((p) => [p.id, p]));
+  const byId = new Map<string, HintProfile>((await attachAvatarUrls(profileRows)).map((p) => [p.id, p]));
 
   // Skip rows whose relator or relatee profile vanished mid-query;
   // hintedBy stays optional since the FK is set null on delete.

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -40,7 +40,10 @@ export const profiles = pgTable("profiles", {
     onDelete: "set null",
   }),
   referredByLegacy: text("referred_by_legacy"),
-  avatarUrl: text("avatar_url"),
+  // SQL column stays "avatar_url" until a rename migration lands; the
+  // TS name follows the post-#131 meaning — a Supabase Storage object
+  // path, not a URL. See docs/design-profile-pictures.md.
+  avatarPath: text("avatar_url"),
   emergencyContact: text("emergency_contact"),
   liveDesire: text("live_desire"),
   isAdmin: boolean("is_admin").notNull().default(false),

--- a/src/server/test-reset.ts
+++ b/src/server/test-reset.ts
@@ -76,7 +76,7 @@ export const resetE2EUsers = async (): Promise<{
       supplementaryInfo: null,
       referredBy: null,
       referredByLegacy: null,
-      avatarUrl: null,
+      avatarPath: null,
       emergencyContact: null,
       liveDesire: null,
       lastUpdatedWeb: null,

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -123,7 +123,7 @@ file_size_limit = "50MiB"
 # fresh stack; an already-running stack needs a restart to pick it up.
 [storage.buckets.avatars]
 public = false
-file_size_limit = "3MiB"
+file_size_limit = "1MB"
 allowed_mime_types = ["image/webp"]
 
 # Allow connections via S3 compatible clients

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -118,6 +118,14 @@ file_size_limit = "50MiB"
 # allowed_mime_types = ["image/png", "image/jpeg"]
 # objects_path = "./images"
 
+# Profile-picture avatars (issue #131). Private — objects are served
+# via signed URLs. `supabase start` / `db reset` provisions this on a
+# fresh stack; an already-running stack needs a restart to pick it up.
+[storage.buckets.avatars]
+public = false
+file_size_limit = "2MiB"
+allowed_mime_types = ["image/webp"]
+
 # Allow connections via S3 compatible clients
 [storage.s3_protocol]
 enabled = true

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -123,7 +123,7 @@ file_size_limit = "50MiB"
 # fresh stack; an already-running stack needs a restart to pick it up.
 [storage.buckets.avatars]
 public = false
-file_size_limit = "2MiB"
+file_size_limit = "3MiB"
 allowed_mime_types = ["image/webp"]
 
 # Allow connections via S3 compatible clients

--- a/tests/e2e/avatar.spec.ts
+++ b/tests/e2e/avatar.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+import sharp from "sharp";
+
+import { completeWelcome, resetSeededUsers, signInAs } from "./helpers/session";
+
+// Profile-picture upload (#131): a member picks a photo, confirms the
+// circular crop, and it is stored and rendered. Depends on the regular
+// seeded user starting clean, so reset per-test.
+
+test.describe.configure({ mode: "serial" });
+
+test.beforeEach(async ({ baseURL }) => {
+  if (!baseURL) throw new Error("avatar.spec.ts: baseURL is not configured");
+  await resetSeededUsers(baseURL);
+});
+
+// A genuine PNG so the browser's createImageBitmap and the server's
+// sharp decode both succeed.
+const samplePng = (): Promise<Buffer> =>
+  sharp({ create: { width: 240, height: 240, channels: 3, background: { r: 210, g: 120, b: 70 } } })
+    .png()
+    .toBuffer();
+
+test("a member can upload, crop, and see their profile picture", async ({ page }) => {
+  await signInAs(page, "regular");
+  await completeWelcome(page, { displayName: "Avatar Tester" });
+
+  await page.goto("/profile/edit");
+  await expect(page.getByRole("button", { name: "Upload photo" })).toBeVisible();
+
+  // The file input is hidden and click-triggered; setInputFiles drives
+  // it directly.
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "avatar.png",
+    mimeType: "image/png",
+    buffer: await samplePng(),
+  });
+
+  // The crop modal opens; confirm with the default framing.
+  await expect(page.getByText("Position your photo")).toBeVisible();
+  const save = page.getByRole("button", { name: "Save photo" });
+  await expect(save).toBeEnabled();
+  await save.click();
+
+  // On success the modal closes and the action flips to "Change photo".
+  await expect(page.getByRole("button", { name: "Change photo" })).toBeVisible();
+
+  // The picture renders on the profile page too — and actually loads
+  // (naturalWidth > 0), which would catch the optimizer rejecting the
+  // upstream image.
+  await page.goto("/profile");
+  const avatarImg = page.locator("main img").first();
+  await expect(avatarImg).toBeVisible();
+  await expect
+    .poll(() => avatarImg.evaluate((el) => (el as HTMLImageElement).naturalWidth))
+    .toBeGreaterThan(0);
+});

--- a/tests/functional/server/avatar.test.ts
+++ b/tests/functional/server/avatar.test.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from "node:crypto";
+import type { User } from "@supabase/supabase-js";
+import { eq, sql } from "drizzle-orm";
+import sharp from "sharp";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+import { createServerClient } from "@supabase/ssr";
+
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import app from "@/server/api";
+import { AVATAR_BUCKET } from "@/server/avatars";
+import { db } from "@/server/db";
+import { profiles } from "@/server/schema";
+
+const mockCreateServerClient = vi.mocked(createServerClient);
+
+const makeUser = (id: string): User =>
+  ({
+    id,
+    email: "avatar-test@testfake.local",
+    user_metadata: { displayName: "Avatar Tester" },
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+  }) as User;
+
+const mockAuth = (user: User | null) => {
+  mockCreateServerClient.mockReturnValue({
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user }, error: null }) },
+    // biome-ignore lint/suspicious/noExplicitAny: test mock shape
+  } as any);
+};
+
+// A genuinely-decodable image, built by sharp so the endpoint's own
+// sharp decode succeeds.
+const makeImage = (): Promise<Buffer> =>
+  sharp({ create: { width: 64, height: 64, channels: 3, background: { r: 120, g: 80, b: 200 } } })
+    .png()
+    .toBuffer();
+
+const postAvatar = (bytes: Uint8Array, type: string) => {
+  const form = new FormData();
+  // Re-wrap so the Blob part is plain-ArrayBuffer-backed (satisfies BlobPart).
+  form.append("file", new Blob([new Uint8Array(bytes)], { type }), "upload");
+  return app.request("/api/me/avatar", { method: "POST", body: form });
+};
+
+const objectsFor = async (userId: string): Promise<string[]> => {
+  const { data } = await supabaseAdmin.storage.from(AVATAR_BUCKET).list(userId);
+  return (data ?? []).map((o) => o.name);
+};
+
+describe("POST/DELETE /api/me/avatar", () => {
+  let userId: string;
+
+  beforeAll(async () => {
+    // Idempotent — the bucket is normally provisioned from config.toml,
+    // but creating it here keeps the suite robust on an already-running
+    // local stack. The "already exists" error is expected and ignored.
+    // The Storage REST API wants MB/KB/GB units (config.toml's MiB is a
+    // CLI-side format). The endpoint's MAX_AVATAR_UPLOAD_BYTES is the
+    // real gate; this bucket limit is just a backstop, so a round 3MB
+    // comfortably above it is fine.
+    await supabaseAdmin.storage.createBucket(AVATAR_BUCKET, {
+      public: false,
+      fileSizeLimit: "3MB",
+      allowedMimeTypes: ["image/webp"],
+    });
+  });
+
+  beforeEach(async () => {
+    userId = randomUUID();
+    await db.execute(
+      sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${userId}::uuid, 'avatar-test@testfake.local', false, false)`,
+    );
+    await db.insert(profiles).values({ id: userId, displayName: "Avatar Tester" });
+    mockAuth(makeUser(userId));
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    const names = await objectsFor(userId);
+    if (names.length > 0) {
+      await supabaseAdmin.storage.from(AVATAR_BUCKET).remove(names.map((n) => `${userId}/${n}`));
+    }
+    await db.delete(profiles).where(eq(profiles.id, userId));
+    await db.execute(sql`DELETE FROM auth.users WHERE id = ${userId}::uuid`);
+  });
+
+  it("stores an uploaded image and points the profile row at it", async () => {
+    const res = await postAvatar(await makeImage(), "image/png");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { avatarUrl: string };
+    expect(body.avatarUrl).toMatch(/^https?:\/\//);
+
+    const [row] = await db.select({ avatarPath: profiles.avatarPath }).from(profiles).where(eq(profiles.id, userId));
+    expect(row.avatarPath).toMatch(new RegExp(`^${userId}/[0-9a-f-]+\\.webp$`));
+    expect(await objectsFor(userId)).toHaveLength(1);
+  });
+
+  it("rejects a non-image content type", async () => {
+    const res = await postAvatar(new TextEncoder().encode("not an image"), "text/plain");
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects bytes that do not decode as an image", async () => {
+    // Passes the content-type check, but sharp can't decode it.
+    const res = await postAvatar(new TextEncoder().encode("still not an image"), "image/png");
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an oversize upload", async () => {
+    const tooBig = new Uint8Array(2 * 1024 * 1024 + 1);
+    const res = await postAvatar(tooBig, "image/webp");
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an unauthenticated request", async () => {
+    mockAuth(null);
+    const res = await postAvatar(await makeImage(), "image/png");
+    expect(res.status).toBe(401);
+  });
+
+  it("replacing an avatar removes the previous object", async () => {
+    await postAvatar(await makeImage(), "image/png");
+    const [first] = await db.select({ avatarPath: profiles.avatarPath }).from(profiles).where(eq(profiles.id, userId));
+
+    await postAvatar(await makeImage(), "image/png");
+    const [second] = await db.select({ avatarPath: profiles.avatarPath }).from(profiles).where(eq(profiles.id, userId));
+
+    expect(second.avatarPath).not.toBe(first.avatarPath);
+    // Exactly one object remains — the previous one was cleaned up.
+    expect(await objectsFor(userId)).toHaveLength(1);
+  });
+
+  it("DELETE clears the column and removes the object", async () => {
+    await postAvatar(await makeImage(), "image/png");
+
+    const res = await app.request("/api/me/avatar", { method: "DELETE" });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select({ avatarPath: profiles.avatarPath }).from(profiles).where(eq(profiles.id, userId));
+    expect(row.avatarPath).toBeNull();
+    expect(await objectsFor(userId)).toHaveLength(0);
+  });
+});

--- a/tests/functional/server/avatar.test.ts
+++ b/tests/functional/server/avatar.test.ts
@@ -12,7 +12,7 @@ import { createServerClient } from "@supabase/ssr";
 
 import { supabaseAdmin } from "@/lib/supabase/admin";
 import app from "@/server/api";
-import { AVATAR_BUCKET } from "@/server/avatars";
+import { AVATAR_BUCKET, MAX_AVATAR_UPLOAD_BYTES } from "@/server/avatars";
 import { db } from "@/server/db";
 import { profiles } from "@/server/schema";
 
@@ -61,13 +61,9 @@ describe("POST/DELETE /api/me/avatar", () => {
     // Idempotent — the bucket is normally provisioned from config.toml,
     // but creating it here keeps the suite robust on an already-running
     // local stack. The "already exists" error is expected and ignored.
-    // The Storage REST API wants MB/KB/GB units (config.toml's MiB is a
-    // CLI-side format). The endpoint's MAX_AVATAR_UPLOAD_BYTES is the
-    // real gate; this bucket limit is just a backstop, so a round 3MB
-    // comfortably above it is fine.
     await supabaseAdmin.storage.createBucket(AVATAR_BUCKET, {
       public: false,
-      fileSizeLimit: "3MB",
+      fileSizeLimit: "1MB",
       allowedMimeTypes: ["image/webp"],
     });
   });
@@ -115,7 +111,7 @@ describe("POST/DELETE /api/me/avatar", () => {
   });
 
   it("rejects an oversize upload", async () => {
-    const tooBig = new Uint8Array(2 * 1024 * 1024 + 1);
+    const tooBig = new Uint8Array(MAX_AVATAR_UPLOAD_BYTES + 1);
     const res = await postAvatar(tooBig, "image/webp");
     expect(res.status).toBe(400);
   });


### PR DESCRIPTION
Implements profile pictures (#131). Members upload a photo from the
Welcome and Edit-profile screens, position it in a circular crop/zoom
modal, and it's stored and rendered everywhere avatars appear.

## What's here
- `POST`/`DELETE /api/me/avatar` — the server re-encodes any uploaded
  image with `sharp` to a canonical 1024² WebP and stores it in a
  private Supabase Storage `avatars` bucket.
- `AvatarUploader` — a `react-easy-crop` modal that uploads immediately
  on crop-confirm.
- Avatars serve as 24h signed URLs, batched and cached
  (`src/server/avatars.ts`), rendered through `next/image`.
- `profiles.avatar_url` (TS property `avatarPath`) now holds a Storage
  object path, not free-text — which also closes #136 (the avatar-URL
  tracking-pixel issue).

## Schema
No migration here — the empty `avatar_url` column is repurposed in
place; the cosmetic SQL `RENAME COLUMN avatar_url → avatar_path` rides
the existing pending-rename batch.

## Provisioning (done)
Hosted `avatars` bucket created (private, 1 MB, image/webp);
`SUPABASE_SECRET_KEY` set in the Vercel project env.

## Tests
7 functional tests for the avatar endpoints + a full upload/render
e2e. `npm test` green (149 functional, 18 e2e).

Design and decision rationale: `docs/design-profile-pictures.md`.

Closes #131. Folds in #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)