### PR TITLE
Miscellaneous doc updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Requires Docker Desktop. `npm run dev` auto-starts a local Supabase stack (Postg
 ## CI/CD
 
 - **ci.yml**: lint + functional tests on every PR (required to pass)
-- **e2e.yml**: Playwright against Vercel preview URL, triggered by `deployment_status` event (not required, but check results before merging)
+- **e2e.yml**: Playwright against Vercel preview URL, triggered by `deployment_status` event. Not a required GitHub check, but team policy requires it green before merging to `main`.
 - Vercel auto-deploys `main` to production; the build command runs `drizzle-kit migrate` before `next build` on production deploys only (gated by `VERCEL_ENV`)
 
 ## Key docs

--- a/docs/doc-vercel.md
+++ b/docs/doc-vercel.md
@@ -9,6 +9,7 @@ Current configuration for the Vercel project as deployed. This documents setting
 - **Dashboard:** https://vercel.com/intentional-society-vercel/is-app-vercel
 - **Framework preset:** Next.js (must be set manually — Vercel does not auto-detect from an existing repo)
 - **Build command:** `if [ "$VERCEL_ENV" = "production" ]; then npx drizzle-kit migrate; fi && next build` (set in `vercel.json`). Runs Drizzle migrations before the Next.js build on production deploys only — preview deploys skip migrations. If the production migration fails, the build aborts before `next build` and the previous production deploy keeps serving traffic.
+- **Build machine:** `Elastic` (auto-sized 4–30 vCPUs / 8–60 GB, billed $0.0035 per CPU-minute). Vercel's current recommended default — the platform right-sizes each build automatically. Pin to a fixed tier (Standard / Enhanced / Turbo) in *Settings → Build and Deployment → Build Machine* if a project ever needs a guaranteed size.
 - **Domain:** `app.intentionalsociety.org` (DNS configured to point to Vercel)
 - **Deployment Protection:** Vercel Authentication disabled on preview deployments, so GitHub Actions can run Playwright e2e tests against preview URLs without hitting a sign-in wall
 - **Integrations:** Axiom (Log Drain — streams all serverless function output to Axiom automatically)


### PR DESCRIPTION
Two small documentation updates accumulated on this branch:

- **doc-vercel**: document the Build Machine setting.
- **CLAUDE.md**: the CI/CD section now states that green e2e is a
  team-policy gate for merging to `main`, rather than describing
  `e2e.yml` as merely something to "check before merging".

Docs-only — the Vercel deploy is skipped, so there's no preview/e2e
run; `ci.yml` is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)