### PR TITLE
Use KeywordChips on profile page (#187)

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { Avatar } from "@/components/avatar";
+import { KeywordChips } from "@/components/keyword-chips";
 import { Button } from "@/components/ui/button";
 import { requireUser } from "@/lib/api-server";
 import type { Me } from "@/lib/api-types";
@@ -38,7 +39,9 @@ export default async function ProfilePage() {
       <dl className="flex w-full max-w-md flex-col gap-4">
         <Field label="Display name">{profile.displayName}</Field>
         <Field label="Bio">{profile.bio}</Field>
-        <Field label="Keywords">{profile.keywords.length > 0 ? profile.keywords.join(", ") : null}</Field>
+        <Field label="Keywords">
+          <KeywordChips keywords={profile.keywords} max={20} className="flex flex-wrap gap-1" />
+        </Field>
         <Field label="Location">{profile.location}</Field>
         <Field label="Live desire">{profile.liveDesire}</Field>
         <Field label="Supplementary info">{profile.supplementaryInfo}</Field>


### PR DESCRIPTION
## Summary
One-line fix: replaces `profile.keywords.join(", ")` on `/profile` with the existing `KeywordChips` component, matching the visual style used in the member directory cards.

Closes #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)