### PR TITLE
Freeze slug on first set — never update on display name change (#188)

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -16,7 +16,6 @@ import {
   listMembers,
   markWebUpdated,
   parseEditableProfile,
-  toSlug,
   upsertProfile,
 } from "./profiles";
 import { joinProgram, leaveProgram, listPrograms } from "./programs";
@@ -102,11 +101,10 @@ const api = new Hono<{ Variables: ApiVariables }>()
     }
 
     if (Object.keys(parsed).length > 0) {
-      const update = {
-        ...parsed,
-        ...(parsed.displayName !== undefined ? { slug: parsed.displayName ? toSlug(parsed.displayName) : null } : {}),
-      };
-      await db.update(profiles).set(update).where(eq(profiles.id, user.id));
+      // Slug is set once on upsertProfile and never changed — updating
+      // it here would silently break any existing links to the old slug.
+      // See #188.
+      await db.update(profiles).set(parsed).where(eq(profiles.id, user.id));
     }
 
     const profile = await getProfileForSelf(user.id);


### PR DESCRIPTION
## Summary
Removes the slug update from `PUT /me`. Slugs are set once by `upsertProfile` at signup and never changed, keeping `/members/aria-chen`-style URLs stable even if the member later edits their display name.

The slug update in `PUT /me` silently broke existing links whenever a member changed their display name — the old URL would 404 with no redirect.

## Trade-off
Slugs can now drift from display names (e.g. a member who changes from "Aria Chen" to "Aria Smith" keeps the slug `aria-chen`). This is acceptable: slugs are identifiers, not mirrors of the current name. A member wanting a new slug can contact an admin, or we can add self-service slug editing later.

## Test plan
- [ ] Edit display name in `/profile/edit` — slug does not change
- [ ] Old profile URL still resolves after display name change

Closes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)