### PR TITLE
Add account deletion with confirmation UI (#185)

### DIFF
--- a/src/app/profile/delete-account-button.tsx
+++ b/src/app/profile/delete-account-button.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { apiClient } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+
+export function DeleteAccountButton() {
+  const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await apiClient.api.me.$delete();
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        if (body.error === "admins_cannot_self_delete") {
+          setError("Admin accounts cannot be self-deleted. Ask another admin to remove your admin flag first.");
+        } else {
+          setError("Something went wrong. Please try again.");
+        }
+        setDeleting(false);
+        return;
+      }
+      router.push("/");
+      router.refresh();
+    } catch {
+      setError("Something went wrong. Please try again.");
+      setDeleting(false);
+    }
+  };
+
+  if (!confirming) {
+    return (
+      <button
+        type="button"
+        onClick={() => setConfirming(true)}
+        className="text-sm text-destructive underline hover:no-underline"
+      >
+        Delete my account
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded border border-destructive/40 bg-destructive/10 p-4">
+      <p className="text-sm text-destructive font-medium">
+        This will permanently delete your account, profile, relations, and avatar. This cannot be undone.
+      </p>
+      <div className="flex gap-3">
+        <Button
+          type="button"
+          onClick={handleDelete}
+          disabled={deleting}
+          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+        >
+          {deleting ? "Deleting…" : "Yes, delete my account"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => setConfirming(false)}
+          disabled={deleting}
+        >
+          Cancel
+        </Button>
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/profile/delete-account-button.tsx
+++ b/src/app/profile/delete-account-button.tsx
@@ -63,7 +63,7 @@ export function DeleteAccountButton() {
         </Button>
         <Button
           type="button"
-          variant="outline"
+          variant="primary"
           onClick={() => setConfirming(false)}
           disabled={deleting}
         >

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,9 +1,12 @@
 import Link from "next/link";
 
 import { Avatar } from "@/components/avatar";
+import { KeywordChips } from "@/components/keyword-chips";
 import { Button } from "@/components/ui/button";
 import { requireUser } from "@/lib/api-server";
 import type { Me } from "@/lib/api-types";
+
+import { DeleteAccountButton } from "./delete-account-button";
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -38,7 +41,9 @@ export default async function ProfilePage() {
       <dl className="flex w-full max-w-md flex-col gap-4">
         <Field label="Display name">{profile.displayName}</Field>
         <Field label="Bio">{profile.bio}</Field>
-        <Field label="Keywords">{profile.keywords.length > 0 ? profile.keywords.join(", ") : null}</Field>
+        <Field label="Keywords">
+          <KeywordChips keywords={profile.keywords} max={20} className="flex flex-wrap gap-1" />
+        </Field>
         <Field label="Location">{profile.location}</Field>
         <Field label="Live desire">{profile.liveDesire}</Field>
         <Field label="Supplementary info">{profile.supplementaryInfo}</Field>
@@ -46,6 +51,10 @@ export default async function ProfilePage() {
       </dl>
 
       <Button render={<Link href="/profile/edit" />}>Edit profile</Button>
+
+      <div className="w-full max-w-md border-t border-border pt-6">
+        <DeleteAccountButton />
+      </div>
     </main>
   );
 }

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -8,6 +8,7 @@ import { isRelationValue } from "@/lib/relation-value";
 import { getAppSettings } from "./app-settings";
 import { type ApiVariables, isAdmin, isUuid, requireAdmin, requireAuth } from "./auth-middleware";
 import { clearAvatar, encodeAvatar, MAX_AVATAR_UPLOAD_BYTES, replaceAvatar } from "./avatars";
+import { supabaseAdmin } from "@/lib/supabase/admin";
 import { db } from "./db";
 import { checkInvite, createInvite, getInvitesForCreator, revokeInvite, validateNote } from "./invites";
 import {
@@ -152,6 +153,35 @@ const api = new Hono<{ Variables: ApiVariables }>()
   .delete("/me/avatar", async (c) => {
     const user = c.get("user");
     await clearAvatar(user.id);
+    return c.json({ ok: true });
+  })
+  .delete("/me", async (c) => {
+    const user = c.get("user");
+
+    // Guard: admins must revoke their own admin flag first so we never
+    // orphan admin-only state or accidentally remove the last admin.
+    const profile = await getProfileForSelf(user.id);
+    if (profile?.isAdmin) {
+      return c.json({ error: "admins_cannot_self_delete" }, 403);
+    }
+
+    // Clear avatar from Storage before deleting the profile row.
+    await clearAvatar(user.id).catch(() => {});
+
+    // Delete the profile row. FK cascades remove profile_programs,
+    // relations, and invite_hints. Invites created by this member
+    // have createdBy set to null (set null FK).
+    await db.delete(profiles).where(eq(profiles.id, user.id));
+
+    // Delete the auth.users row — must come after profile since
+    // profiles.id references auth.users.id.
+    const { error } = await supabaseAdmin.auth.admin.deleteUser(user.id);
+    if (error) {
+      // Profile is already gone; log and return an error so the client
+      // knows the auth row wasn't cleaned up.
+      return c.json({ error: "auth_delete_failed", message: error.message }, 500);
+    }
+
     return c.json({ ok: true });
   })
   .post("/invites", async (c) => {


### PR DESCRIPTION
## Summary
- `DELETE /api/me` endpoint: clears avatar from Storage → deletes profile row (FK cascades handle program memberships, relations, invite_hints) → deletes `auth.users` row via Admin API
- Admin accounts return 403 with `admins_cannot_self_delete` — they must revoke their own admin flag first
- `/profile` shows a "Delete my account" link at the bottom, separated by a divider
- Clicking reveals a confirmation panel with a destructive button and cancel
- After deletion: redirects to `/` which bounces to `/signin` since the session is gone

## What cascades automatically
- `profile_programs` — cascade delete
- `relations` (both directions) — cascade delete  
- `invite_hints` — cascade delete
- `invites.created_by` — set null (invites stay, creator becomes anonymous)

## Test plan
- [ ] Sign in, go to `/profile`, click "Delete my account" — confirmation panel appears
- [ ] Click Cancel — panel disappears, no deletion
- [ ] Click "Yes, delete my account" — redirected to `/signin`
- [ ] Confirm user no longer exists in Supabase dashboard
- [ ] Confirm avatar removed from Storage bucket
- [ ] Admin account: confirm 403 error message shown

Closes #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)