### PR TITLE
Add change password section to profile edit page (#194)

### DIFF
--- a/src/app/profile/change-password-form.tsx
+++ b/src/app/profile/change-password-form.tsx
@@ -26,13 +26,19 @@ export function ChangePasswordForm() {
     }
     setStatus({ kind: "submitting" });
     const supabase = createClient();
-    const { error } = await supabase.auth.updateUser({ password });
-    if (error) {
-      setStatus({ kind: "error", message: error.message });
-    } else {
-      setStatus({ kind: "success" });
-      setPassword("");
-      setConfirm("");
+    try {
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) {
+        setStatus({ kind: "error", message: error.message });
+      } else {
+        setStatus({ kind: "success" });
+        setPassword("");
+        setConfirm("");
+      }
+    } catch {
+      // A thrown error (network drop, CORS) bypasses the returned { error };
+      // catch it so the button doesn't stick on "Saving…" with no feedback.
+      setStatus({ kind: "error", message: "Something went wrong. Please try again." });
     }
   };
 
@@ -65,7 +71,7 @@ export function ChangePasswordForm() {
       />
 
       <Button type="submit" disabled={disabled} className="mt-1">
-        {disabled ? "Saving…" : "Update password"}
+        {disabled ? "Saving…" : "Set/update password"}
       </Button>
 
       {status.kind === "success" && (

--- a/src/app/profile/change-password-form.tsx
+++ b/src/app/profile/change-password-form.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { createClient } from "@/lib/supabase/client";
+
+type Status = { kind: "idle" } | { kind: "submitting" } | { kind: "success" } | { kind: "error"; message: string };
+
+export function ChangePasswordForm() {
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (password.length < 8) {
+      setStatus({ kind: "error", message: "Password must be at least 8 characters." });
+      return;
+    }
+    if (password !== confirm) {
+      setStatus({ kind: "error", message: "Passwords do not match." });
+      return;
+    }
+    setStatus({ kind: "submitting" });
+    const supabase = createClient();
+    const { error } = await supabase.auth.updateUser({ password });
+    if (error) {
+      setStatus({ kind: "error", message: error.message });
+    } else {
+      setStatus({ kind: "success" });
+      setPassword("");
+      setConfirm("");
+    }
+  };
+
+  const disabled = status.kind === "submitting";
+
+  return (
+    <form onSubmit={handleSubmit} className="flex w-full flex-col gap-3">
+      <Label htmlFor="new-password">New password</Label>
+      <Input
+        id="new-password"
+        type="password"
+        autoComplete="new-password"
+        placeholder="At least 8 characters"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        disabled={disabled}
+        required
+      />
+
+      <Label htmlFor="confirm-password">Confirm new password</Label>
+      <Input
+        id="confirm-password"
+        type="password"
+        autoComplete="new-password"
+        placeholder="Repeat password"
+        value={confirm}
+        onChange={(e) => setConfirm(e.target.value)}
+        disabled={disabled}
+        required
+      />
+
+      <Button type="submit" disabled={disabled} className="mt-1">
+        {disabled ? "Saving…" : "Update password"}
+      </Button>
+
+      {status.kind === "success" && (
+        <p role="status" className="text-sm text-success">Password updated.</p>
+      )}
+      {status.kind === "error" && (
+        <p role="alert" className="text-sm text-destructive">{status.message}</p>
+      )}
+    </form>
+  );
+}

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -39,9 +39,9 @@ export default async function EditProfilePage() {
       />
 
       <div className="flex w-full max-w-md flex-col gap-3 border-t border-border pt-6">
-        <h2 className="text-base font-semibold">Change password</h2>
+        <h2 className="text-base font-semibold">Set or change password</h2>
         <p className="text-sm text-muted-foreground">
-          Leave blank if you prefer to sign in with magic links.
+          If you prefer signing in via email, you don't need a password.
         </p>
         <ChangePasswordForm />
       </div>

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -4,6 +4,7 @@ import { requireUser } from "@/lib/api-server";
 import type { Me } from "@/lib/api-types";
 
 import { AvatarUploader } from "../avatar-uploader";
+import { ChangePasswordForm } from "../change-password-form";
 import { ProfileForm } from "../profile-form";
 
 export default async function EditProfilePage() {
@@ -36,6 +37,14 @@ export default async function EditProfilePage() {
           liveDesire: profile.liveDesire ?? "",
         }}
       />
+
+      <div className="flex w-full max-w-md flex-col gap-3 border-t border-border pt-6">
+        <h2 className="text-base font-semibold">Change password</h2>
+        <p className="text-sm text-muted-foreground">
+          Leave blank if you prefer to sign in with magic links.
+        </p>
+        <ChangePasswordForm />
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- New `ChangePasswordForm` component on `/profile/edit` below the main profile fields
- Validates min length (8 chars) and password match client-side before submitting
- Calls `supabase.auth.updateUser({ password })` on success
- Shows "Password updated." or an error message inline
- No backend changes needed — uses existing Supabase client auth

## Test plan
- [ ] Go to `/profile/edit` — "Change password" section visible below profile fields
- [ ] Submit mismatched passwords — error shown, no API call
- [ ] Submit < 8 chars — error shown
- [ ] Submit valid matching passwords — "Password updated." shown
- [ ] Sign out and back in with new password — works

Closes #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)