### PR TITLE
Show 'Invited by' on member profile pages (#203)

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import type { UrlObject } from "node:url";
 
 import { Avatar } from "@/components/avatar";
 import { serverApiClient } from "@/lib/api-server";
@@ -37,7 +38,9 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
   const { profile }: { profile: MemberProfile } = await res.json();
   const memberSince = new Date(profile.createdAt).getFullYear();
   const invitedBy = profile.invitedBy;
-  const inviterHref = invitedBy ? `/members/${invitedBy.slug ?? invitedBy.id}` : null;
+  const inviterHref: UrlObject | null = invitedBy
+    ? { pathname: `/members/${invitedBy.slug ?? invitedBy.id}` }
+    : null;
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">

--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -36,13 +36,27 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
 
   const { profile }: { profile: MemberProfile } = await res.json();
   const memberSince = new Date(profile.createdAt).getFullYear();
+  const invitedBy = profile.invitedBy;
+  const inviterHref = invitedBy ? `/members/${invitedBy.slug ?? invitedBy.id}` : null;
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
       <div className="flex w-full max-w-md items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">{profile.displayName ?? "Member"}</h1>
-          <p className="text-sm text-muted-foreground">Member since {memberSince}</p>
+          <p className="text-sm text-muted-foreground">
+            Member since {memberSince}
+            {invitedBy && inviterHref && (
+              <> · Invited by{" "}
+                <Link href={inviterHref} className="underline hover:no-underline">
+                  {invitedBy.displayName ?? "a member"}
+                </Link>
+              </>
+            )}
+            {!invitedBy && profile.referredByLegacy && (
+              <> · Invited by {profile.referredByLegacy}</>
+            )}
+          </p>
         </div>
         <Link href="/members" className="text-base text-muted-foreground hover:text-foreground">
           ← Directory

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -1,4 +1,5 @@
 import type { User } from "@supabase/supabase-js";
+import { alias } from "drizzle-orm/pg-core";
 import { asc, eq, isNotNull, or, sql } from "drizzle-orm";
 
 import { isUuid } from "./auth-middleware";
@@ -149,6 +150,8 @@ export type ProfileForMember = {
   avatarUrl: string | null;
   liveDesire: string | null;
   createdAt: Date;
+  invitedBy: { id: string; displayName: string | null; slug: string | null } | null;
+  referredByLegacy: string | null;
 };
 
 // Accepts either a UUID or a slug so /members/aria-chen and
@@ -158,6 +161,8 @@ export const getProfileForMember = async (idOrSlug: string): Promise<ProfileForM
   const where = isUuid(idOrSlug)
     ? or(eq(profiles.id, idOrSlug), eq(profiles.slug, idOrSlug))
     : eq(profiles.slug, idOrSlug);
+
+  const inviters = alias(profiles, "inviters");
 
   const [row] = await db
     .select({
@@ -171,13 +176,22 @@ export const getProfileForMember = async (idOrSlug: string): Promise<ProfileForM
       avatarPath: profiles.avatarPath,
       liveDesire: profiles.liveDesire,
       createdAt: profiles.createdAt,
+      referredByLegacy: profiles.referredByLegacy,
+      invitedById: profiles.referredBy,
+      invitedByName: inviters.displayName,
+      invitedBySlug: inviters.slug,
     })
     .from(profiles)
+    .leftJoin(inviters, eq(inviters.id, profiles.referredBy))
     .where(where);
 
   if (!row) return null;
-  const [profile] = await attachAvatarUrls([row]);
-  return profile;
+  const { invitedById, invitedByName, invitedBySlug, ...rest } = row;
+  const withAvatar = await attachAvatarUrls([rest]);
+  return {
+    ...withAvatar[0],
+    invitedBy: invitedById ? { id: invitedById, displayName: invitedByName, slug: invitedBySlug } : null,
+  };
 };
 
 export type MemberSummary = {

--- a/tests/functional/server/profiles.test.ts
+++ b/tests/functional/server/profiles.test.ts
@@ -143,6 +143,8 @@ describe("getProfileForMember", () => {
         "avatarUrl",
         "liveDesire",
         "createdAt",
+        "invitedBy",
+        "referredByLegacy",
       ].sort(),
     );
   });


### PR DESCRIPTION
## Summary
- Adds `invitedBy` (id, displayName, slug) and `referredByLegacy` to `ProfileForMember` via a self-join
- Member profile page shows: `Member since 2026 · Invited by Aria Chen` with a link to the inviter's profile
- Falls back to `referredByLegacy` (plain text) for pre-app members imported from the Google Sheet
- Shows nothing when `referredBy` is null (founding members, no referrer)

## Test plan
- [ ] Visit `/members/[id]` for a member who was invited — "Invited by [Name]" appears, linking to inviter's profile
- [ ] Visit profile of a founding member — no "Invited by" shown
- [ ] Click inviter link — navigates to their profile

Closes #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)