### PR TITLE
Fix docs-only CI skip: paths-filter predicate-quantifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          # `every`: a file counts toward `code` only if it matches all
+          # three patterns (AND). Without this, paths-filter ORs them and
+          # every file matches `**`, so `code` is always true.
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'


### PR DESCRIPTION
## Problem

The `CI` workflow's docs-only skip never fires — every PR runs the full lint + functional suite, including docs-only ones (e.g. #214).

The `dorny/paths-filter` `code` filter is:

```yaml
code:
  - '**'
  - '!docs/**'
  - '!CLAUDE.md'
```

This was written as an AND ("any file, except docs/CLAUDE.md"), but `dorny/paths-filter` defaults to the `some` quantifier, which **ORs** the patterns: a file matches `code` if it matches *any* rule. Every file matches `**`, so `code` is always `true` and the skip is dead code.

Introduced in #181 — the `code`/`echo` skip gating was added without `predicate-quantifier`.

## Fix

Add `predicate-quantifier: 'every'`, which makes the patterns AND per file (per the action's docs). A file then counts as `code` only if it matches `**` *and* `!docs/**` *and* `!CLAUDE.md` — a real non-docs file. `code` is `true` iff at least one such file changed:

- docs-only PR → `code: false` → skip fires
- code-only or mixed PR → `code: true` → tests run

## Verifying

This PR changes a workflow file, so `code` is `true` and the suite runs — that's correct, and confirms the run-tests path still works. The *skip* path is exercised by the next docs-only PR after this merges (the stale "Skipping deploys" doc section in `strategy-committing.md` still needs updating — that change makes a natural test case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
