### PR TITLE
Update docs: CI docs-skip is one path-aware workflow

### DIFF
--- a/docs/strategy-committing.md
+++ b/docs/strategy-committing.md
@@ -32,12 +32,7 @@ Failure modes all default to deploying (the safe direction):
 
 Playwright e2e skips downstream because it's triggered by Vercel's `deployment_status` event, which only fires on a real deploy.
 
-CI (lint + functional tests) is also skipped on docs-only PRs, but the mechanism is different from Vercel's. Branch protection requires the "Lint & Functional Tests" status check, so a plain `paths-ignore` on `ci.yml` would leave the check stuck at "expected" and block merge. The fix is two workflow files:
-
-- `ci.yml` — runs the real tests, with `paths-ignore: ['docs/**', 'CLAUDE.md']`.
-- `ci-docs-skip.yml` — a no-op job whose `name` matches ("Lint & Functional Tests"), with the inverse `paths: ['docs/**', 'CLAUDE.md']`.
-
-Their path filters union to "everything," so exactly one (or, on mixed PRs, both) triggers. Either way, a status check called "Lint & Functional Tests" reports success and branch protection is satisfied.
+CI (lint + functional tests) is also skipped on docs-only PRs, but the mechanism differs from Vercel's. Branch protection requires the "Lint & Functional Tests" status check, so `ci.yml` can't simply not run — the check would stay stuck at "expected" and block merge. Instead it always runs, and the job itself decides whether to do any work: a `dorny/paths-filter` step sets a `code` output — true when the PR changes any file outside `docs/` and `CLAUDE.md` — and every subsequent step (Node and Supabase setup, `npm install`, `lint`, `typecheck`, migrations, the functional tests) is gated on `code == 'true'`. A docs-only PR skips them all and still reports success, satisfying branch protection.
 
 ## Schema and data migrations: expand-contract pattern
 


### PR DESCRIPTION
## What

The "Skipping deploys for docs-only changes" section of `strategy-committing.md` still described the pre-#181 design — two workflow files (`ci.yml` plus a no-op `ci-docs-skip.yml`). #181 consolidated those into a single `ci.yml` whose steps are gated on a `dorny/paths-filter` `code` output. This rewrites the section to match.

## Doubles as a test of #215

This PR is docs-only, so it should exercise the docs-skip that #215 just fixed. Expect the **Lint & Functional Tests** job to run the `dorny/paths-filter` step, hit `echo "Docs-only PR — …skipped."`, and skip `npm install` / `lint` / `typecheck` / the tests — while still reporting success. If it instead runs the full suite, #215 didn't take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
