### PR TITLE
Clear the three open code- and secret-scanning alerts

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,6 @@
+# Skip secret scanning on .env.local.example: it holds only the
+# deterministic local-dev defaults produced by `npx supabase start`
+# (see that file's header comment), not real credentials. Excluding it
+# stops the Supabase local key from raising recurring alerts.
+paths-ignore:
+  - ".env.local.example"

--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,6 +1,0 @@
-# Skip secret scanning on .env.local.example: it holds only the
-# deterministic local-dev defaults produced by `npx supabase start`
-# (see that file's header comment), not real credentials. Excluding it
-# stops the Supabase local key from raising recurring alerts.
-paths-ignore:
-  - ".env.local.example"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,16 +45,17 @@ jobs:
           node-version: 24
           cache: npm
 
-      - uses: supabase/setup-cli@a4d563a017eb7e7da097c40c441f85dbdcc4411f # v2.0.1
-        if: steps.filter.outputs.code == 'true'
-        with:
-          version: latest
-
-      - if: steps.filter.outputs.code == 'true'
-        run: supabase start
-
+      # The `supabase` devDependency is the same native binary that
+      # supabase/setup-cli would download — its postinstall fetches it
+      # from supabase/cli releases. Running it via npm keeps the CLI
+      # version locked in package-lock.json (and tracked by Dependabot)
+      # rather than floating behind `version: latest`, and removes one
+      # third-party Action from the supply chain.
       - if: steps.filter.outputs.code == 'true'
         run: npm install
+
+      - if: steps.filter.outputs.code == 'true'
+        run: npx supabase start
 
       - if: steps.filter.outputs.code == 'true'
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           node-version: 24
           cache: npm
 
-      - uses: supabase/setup-cli@v2
+      - uses: supabase/setup-cli@a4d563a017eb7e7da097c40c441f85dbdcc4411f # v2.0.1
         if: steps.filter.outputs.code == 'true'
         with:
           version: latest

--- a/src/server/invites.ts
+++ b/src/server/invites.ts
@@ -6,11 +6,11 @@ import { db } from "./db";
 import { validateInviteHints } from "./relations";
 import { invites } from "./schema";
 
-// Alphabet: 23 uppercase letters (no I, O — visually confusable with 1/0)
-// plus 8 digits (no 0, 1 — same reason). 31 chars.
+// Alphabet: 24 uppercase letters (no I, O — visually confusable with
+// 1/0) plus 8 digits (no 0, 1 — same reason). 32 chars.
 const CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const CODE_LENGTH = 10;
-// 31^10 ≈ 8.2e14 — sparse enough that collisions are vanishingly rare;
+// 32^10 ≈ 1.1e15 — sparse enough that collisions are vanishingly rare;
 // the unique constraint is the real safety net.
 
 const MAX_ACTIVE_INVITES_PER_USER = 10;
@@ -29,11 +29,22 @@ export type InviteForCreator = {
   status: InviteStatus;
 };
 
+// Rejection sampling. A random byte is 0–255; mapping it onto the
+// alphabet with plain modulo would over-represent the low indices
+// unless the alphabet size divides 256 evenly. Discard any byte at or
+// above `cutoff` (the largest multiple of the alphabet size that fits
+// in a byte), then index by an equal-width bucket — every kept byte is
+// then uniformly distributed, whatever the alphabet size.
 const generateInviteCode = (): string => {
-  const bytes = crypto.getRandomValues(new Uint8Array(CODE_LENGTH));
+  const cutoff = 256 - (256 % CODE_ALPHABET.length);
+  const bucket = cutoff / CODE_ALPHABET.length;
   let out = "";
-  for (const b of bytes) {
-    out += CODE_ALPHABET[b % CODE_ALPHABET.length];
+  while (out.length < CODE_LENGTH) {
+    for (const b of crypto.getRandomValues(new Uint8Array(CODE_LENGTH))) {
+      if (b >= cutoff) continue;
+      out += CODE_ALPHABET[Math.floor(b / bucket)];
+      if (out.length === CODE_LENGTH) break;
+    }
   }
   return out;
 };

--- a/src/server/invites.ts
+++ b/src/server/invites.ts
@@ -1,3 +1,4 @@
+import { randomInt } from "node:crypto";
 import { and, count, desc, eq, gt, isNull, sql } from "drizzle-orm";
 
 import { isRelationValue, type RelationValue } from "@/lib/relation-value";
@@ -29,22 +30,14 @@ export type InviteForCreator = {
   status: InviteStatus;
 };
 
-// Rejection sampling. A random byte is 0–255; mapping it onto the
-// alphabet with plain modulo would over-represent the low indices
-// unless the alphabet size divides 256 evenly. Discard any byte at or
-// above `cutoff` (the largest multiple of the alphabet size that fits
-// in a byte), then index by an equal-width bucket — every kept byte is
-// then uniformly distributed, whatever the alphabet size.
+// randomInt does uniform bounded sampling (rejection sampling
+// internally), so indexing the alphabet with its result is unbiased
+// for any alphabet size — no hand-rolled modulo or scaling on the raw
+// random bytes, which is what CodeQL flags as a biasing operation.
 const generateInviteCode = (): string => {
-  const cutoff = 256 - (256 % CODE_ALPHABET.length);
-  const bucket = cutoff / CODE_ALPHABET.length;
   let out = "";
-  while (out.length < CODE_LENGTH) {
-    for (const b of crypto.getRandomValues(new Uint8Array(CODE_LENGTH))) {
-      if (b >= cutoff) continue;
-      out += CODE_ALPHABET[Math.floor(b / bucket)];
-      if (out.length === CODE_LENGTH) break;
-    }
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    out += CODE_ALPHABET[randomInt(CODE_ALPHABET.length)];
   }
   return out;
 };


### PR DESCRIPTION
Cleans up the three open items in the repo's Security & quality section.

## Code scanning

- **#8 — Unpinned 3rd party Action** (`ci.yml`): drops `supabase/setup-cli` entirely and runs `npx supabase start` against the `supabase` devDependency that `npm install` already provides. Same native binary either way (the action downloads from `supabase/cli` releases; the npm postinstall does too), but the version is now locked in `package-lock.json` and tracked by Dependabot instead of floating behind `version: latest`. CI is also now consistent with how every off-CI script invokes the CLI (`scripts/ensure-supabase.mjs`, `dev:db:stop`, `dev:db:reset`).
- **#6 — Biased cryptographic random** (`invites.ts`): `generateInviteCode` now uses `node:crypto`'s `randomInt(0, alphabet.length)` per character — the standard library's rejection-sampling implementation, which CodeQL recognises as unbiased. The previous modulo was already unbiased in practice (`256 % 32 == 0`), but the code comment miscounted the alphabet as 31, which would have made a future edit subtly wrong. Comment and entropy figure (`32^10 ≈ 1.1e15`) corrected.

## Secret scanning

- **#1 — Supabase Secret Key**: the flagged value in `.env.local.example` is the deterministic local-dev default produced by `npx supabase start` (the file's own header explains this), not a real credential — production uses a separate key in Vercel env. The fix is to dismiss the existing alert as `used_in_tests`: GitHub's secret scanning is per-value with multiple locations attached, so a closed alert stays closed when the same value reappears in a new commit. No repo config needed; secret scanning stays enabled on `.env.local.example` so future additions (`CI_RESET_TOKEN`, `E2E_*_PASSWORD`, anything new) remain covered. The alert will be dismissed in the Security tab once this PR merges.

## Testing

`npm test` — functional + e2e passing, lint and typecheck clean. CI itself exercises the new `npx supabase start` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
