### PR TITLE
Add admin program administration (#139)

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-18 | James | Program administration
+
+Admins manage programs at `/admin/programs`, with a per-program drill-down for editing and adding/removing participants. Deleting a program is intentionally out of scope.
+
 ## 2026-05-18 | James | Schema additions go through prod:db:expand
 
 Updated `strategy-committing`: additive schema changes need manual action `npm run prod:db:expand` and then ship the schema and code in a single PR.

--- a/docs/doc-supabase.md
+++ b/docs/doc-supabase.md
@@ -32,7 +32,7 @@ The Playwright e2e suite signs in as two long-lived users instead of admin-provi
 **Accounts (seed these once via the Supabase dashboard → Authentication → Users → Add user):**
 
 - `e2e-regular@testfake.local` — standard member. Used by welcome/invites/signout/session-helper specs.
-- `e2e-admin@testfake.local` — admin member. Not yet used by any spec; reserved for future admin-surface tests. After creating the user, set `profiles.is_admin = true` for this row via the SQL editor.
+- `e2e-admin@testfake.local` — admin member. Used by `tests/e2e/admin.spec.ts`. **This account must have `profiles.is_admin = true`** — without it `/admin` calls `notFound()` and the admin specs fail. The `profiles` row is created on first sign-in (via the `/api/me` self-heal); set the flag for it in the SQL editor.
 
 Both users should be created with "Auto Confirm User" checked so they can sign in with a password immediately.
 
@@ -44,7 +44,7 @@ Both users should be created with "Auto Confirm User" checked so they can sign i
 
 **Blast radius if leaked:**
 
-- Passwords: attacker can sign in as one of two fake accounts. Regular sees its own profile + up to 10 self-created invites. Admin sees whatever admin surface exists (currently a `NotImplemented` stub). Rotate by changing the password in the Supabase dashboard.
+- Passwords: attacker can sign in as one of two fake accounts. Regular sees its own profile + up to 10 self-created invites. Admin additionally sees the admin surface (app settings, relation hints, program administration). Rotate by changing the password in the Supabase dashboard.
 - Reset token: attacker can wipe the profile fields + delete invites for those two accounts, on any environment (preview and prod share the same Supabase). Rotate by generating a new string and updating both the GH secret and Vercel env var.
 
 **Reset endpoint:** `POST /api/_test/reset`, token-gated. Defined in `src/server/test-reset.ts`; the Playwright setup project (`tests/e2e/reset.setup.ts`) calls it once at the top of every run. The token is the sole gate — preview and prod share one Supabase, so an environment gate would be theatre against a token that already mutates prod data either way. The destructive scope is fixed at the seeded e2e users, not arbitrary rows.

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -36,7 +36,12 @@ export default async function AdminPage() {
 
       <section className="flex w-full max-w-xl flex-col gap-2">
         <h2 className="text-lg font-semibold">Programs</h2>
-        <p className="text-sm text-muted-foreground">Coming soon.</p>
+        <Link
+          href="/admin/programs"
+          className="text-sm text-muted-foreground underline hover:text-foreground hover:no-underline"
+        >
+          Manage programs →
+        </Link>
       </section>
 
       <section className="flex w-full max-w-xl flex-col gap-2">

--- a/src/app/admin/programs/[id]/page.tsx
+++ b/src/app/admin/programs/[id]/page.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { requireUser } from "@/lib/api-server";
+
+import { ProgramDetail } from "./program-detail";
+
+export default async function AdminProgramDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const me = await requireUser();
+  // Generic 404 for non-admins, matching the /admin hub page.
+  if (!me.profile?.isAdmin) notFound();
+  const { id } = await params;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <div className="flex w-full max-w-xl items-center justify-between">
+        <h1 className="text-2xl font-bold">Program</h1>
+        <Link href="/admin/programs" className="text-base text-muted-foreground hover:text-foreground">
+          ← Programs
+        </Link>
+      </div>
+      <ProgramDetail programId={id} />
+    </main>
+  );
+}

--- a/src/app/admin/programs/[id]/program-detail.tsx
+++ b/src/app/admin/programs/[id]/program-detail.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { Avatar } from "@/components/avatar";
+import { MemberTypeahead } from "@/components/member-typeahead";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { apiClient } from "@/lib/api";
+import type { AdminProgramDetail } from "@/lib/api-types";
+
+const programQueryKey = (id: string) => ["admin", "programs", id] as const;
+
+const fetchProgram = async (id: string): Promise<AdminProgramDetail> => {
+  const res = await apiClient.api.admin.programs[":id"].$get({ param: { id } });
+  // Distinct sentinel so the caller can tell "missing" from "broke".
+  if (res.status === 404) throw new Error("not_found");
+  if (!res.ok) throw new Error(`admin/programs/${id}: ${res.status}`);
+  const body = await res.json();
+  return body.program;
+};
+
+export function ProgramDetail({ programId }: { programId: string }) {
+  const query = useQuery({
+    queryKey: programQueryKey(programId),
+    queryFn: () => fetchProgram(programId),
+    // A 404 is a final answer, not a transient failure.
+    retry: false,
+  });
+
+  if (query.isPending) {
+    return <p className="w-full max-w-xl text-sm text-muted-foreground">Loading…</p>;
+  }
+  if (query.isError) {
+    const missing = query.error instanceof Error && query.error.message === "not_found";
+    return (
+      <p role="alert" className="w-full max-w-xl text-sm text-destructive">
+        {missing ? "Program not found." : "Couldn't load this program."}
+      </p>
+    );
+  }
+
+  // Remount the editor when the program identity changes so its local
+  // form state re-seeds from the freshly loaded values.
+  return <ProgramEditor key={query.data.id} program={query.data} />;
+}
+
+function ProgramEditor({ program }: { program: AdminProgramDetail }) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState(program.name);
+  const [slug, setSlug] = useState(program.slug);
+  const [description, setDescription] = useState(program.description ?? "");
+  const [editError, setEditError] = useState<string | null>(null);
+  const [participantError, setParticipantError] = useState<string | null>(null);
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: programQueryKey(program.id) });
+
+  const updateMutation = useMutation({
+    mutationFn: async (vars: { name: string; slug: string; description: string | null }) => {
+      const res = await apiClient.api.admin.programs[":id"].$patch({
+        param: { id: program.id },
+        json: vars,
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(
+          body.error === "slug_conflict"
+            ? "A program with a similar name already exists."
+            : (body.error ?? `admin/programs PATCH: ${res.status}`),
+        );
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      setEditError(null);
+      invalidate();
+    },
+    onError: (err) => {
+      setEditError(err instanceof Error ? err.message : "Failed to save program.");
+    },
+  });
+
+  const addMutation = useMutation({
+    mutationFn: async (profileId: string) => {
+      const res = await apiClient.api.admin.programs[":id"].participants.$post({
+        param: { id: program.id },
+        json: { profileId },
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(
+          body.error === "already_member"
+            ? "That member is already a participant."
+            : (body.error ?? `add participant: ${res.status}`),
+        );
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      setParticipantError(null);
+      invalidate();
+    },
+    onError: (err) => {
+      setParticipantError(err instanceof Error ? err.message : "Failed to add participant.");
+    },
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: async (profileId: string) => {
+      const res = await apiClient.api.admin.programs[":id"].participants[":profileId"].$delete({
+        param: { id: program.id, profileId },
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `remove participant: ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      setParticipantError(null);
+      invalidate();
+    },
+    onError: (err) => {
+      setParticipantError(err instanceof Error ? err.message : "Failed to remove participant.");
+    },
+  });
+
+  const trimmedName = name.trim();
+  const trimmedSlug = slug.trim();
+  const dirty =
+    trimmedName !== program.name ||
+    trimmedSlug !== program.slug ||
+    description.trim() !== (program.description ?? "");
+
+  const save = () => {
+    if (!trimmedName) {
+      setEditError("Name is required.");
+      return;
+    }
+    if (!trimmedSlug) {
+      setEditError("Slug is required.");
+      return;
+    }
+    updateMutation.mutate({
+      name: trimmedName,
+      slug: trimmedSlug,
+      description: description.trim() || null,
+    });
+  };
+
+  const participantIds = program.participants.map((p) => p.id);
+
+  return (
+    <div className="flex w-full max-w-xl flex-col gap-6">
+      <section className="flex flex-col gap-3 rounded border border-border p-3">
+        <h2 className="text-base font-semibold uppercase tracking-wide text-muted-foreground">Details</h2>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-name">Name</Label>
+          <Input
+            id="program-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={updateMutation.isPending}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-slug">Slug</Label>
+          <Input
+            id="program-slug"
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            disabled={updateMutation.isPending}
+          />
+          <p className="text-xs text-muted-foreground">Used in URLs — lowercase letters, numbers, and hyphens.</p>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-description">Description</Label>
+          <Textarea
+            id="program-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            disabled={updateMutation.isPending}
+          />
+        </div>
+        <Button
+          type="button"
+          variant="secondary"
+          disabled={updateMutation.isPending || !dirty || !trimmedName || !trimmedSlug}
+          onClick={save}
+          className="self-start"
+        >
+          {updateMutation.isPending ? "Saving…" : "Save changes"}
+        </Button>
+        {editError && (
+          <p role="alert" className="text-sm text-destructive">
+            {editError}
+          </p>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-base font-semibold uppercase tracking-wide text-muted-foreground">
+          Participants ({program.participants.length})
+        </h2>
+        <MemberTypeahead
+          label="Add a participant"
+          triggerLabel="Pick a member…"
+          selectedIds={participantIds}
+          onSelect={(m) => addMutation.mutate(m.id)}
+          disabled={addMutation.isPending}
+        />
+        {participantError && (
+          <p role="alert" className="text-sm text-destructive">
+            {participantError}
+          </p>
+        )}
+        {program.participants.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No participants yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {program.participants.map((p) => (
+              <li key={p.id} className="flex items-center gap-3 rounded border border-border p-2 text-sm">
+                <Avatar
+                  name={p.displayName}
+                  url={p.avatarUrl}
+                  className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-[10px] font-semibold text-muted-foreground"
+                />
+                <span>{p.displayName ?? "—"}</span>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="xs"
+                  disabled={removeMutation.isPending}
+                  onClick={() => removeMutation.mutate(p.id)}
+                  className="ml-auto"
+                >
+                  Remove
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/programs/page.tsx
+++ b/src/app/admin/programs/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { requireUser } from "@/lib/api-server";
+
+import { ProgramsAdmin } from "./programs-admin";
+
+export default async function AdminProgramsPage() {
+  const me = await requireUser();
+  // Generic 404 for non-admins, matching the /admin hub page.
+  if (!me.profile?.isAdmin) notFound();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <div className="flex w-full max-w-xl items-center justify-between">
+        <h1 className="text-2xl font-bold">Programs</h1>
+        <Link href="/admin" className="text-base text-muted-foreground hover:text-foreground">
+          ← Admin
+        </Link>
+      </div>
+      <ProgramsAdmin />
+    </main>
+  );
+}

--- a/src/app/admin/programs/programs-admin.tsx
+++ b/src/app/admin/programs/programs-admin.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { apiClient } from "@/lib/api";
+import type { AdminProgram } from "@/lib/api-types";
+
+const PROGRAMS_QUERY_KEY = ["admin", "programs"] as const;
+
+const fetchPrograms = async (): Promise<AdminProgram[]> => {
+  const res = await apiClient.api.admin.programs.$get();
+  if (!res.ok) throw new Error(`admin/programs: ${res.status}`);
+  const body = await res.json();
+  return body.programs;
+};
+
+export function ProgramsAdmin() {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [description, setDescription] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const programsQuery = useQuery({ queryKey: PROGRAMS_QUERY_KEY, queryFn: fetchPrograms });
+
+  const createMutation = useMutation({
+    mutationFn: async (vars: { name: string; slug: string; description: string | null }) => {
+      const res = await apiClient.api.admin.programs.$post({ json: vars });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(
+          body.error === "slug_conflict"
+            ? "A program with a similar name already exists."
+            : (body.error ?? `admin/programs POST: ${res.status}`),
+        );
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      setName("");
+      setSlug("");
+      setDescription("");
+      setErrorMessage(null);
+      queryClient.invalidateQueries({ queryKey: PROGRAMS_QUERY_KEY });
+    },
+    onError: (err) => {
+      setErrorMessage(err instanceof Error ? err.message : "Failed to create program.");
+    },
+  });
+
+  const submit = () => {
+    const trimmedName = name.trim();
+    const trimmedSlug = slug.trim();
+    if (!trimmedName) {
+      setErrorMessage("Name is required.");
+      return;
+    }
+    if (!trimmedSlug) {
+      setErrorMessage("Slug is required.");
+      return;
+    }
+    createMutation.mutate({
+      name: trimmedName,
+      slug: trimmedSlug,
+      description: description.trim() || null,
+    });
+  };
+
+  return (
+    <div className="flex w-full max-w-xl flex-col gap-6">
+      <section className="flex flex-col gap-3 rounded border border-border p-3">
+        <h2 className="text-base font-semibold uppercase tracking-wide text-muted-foreground">New program</h2>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-name">Name</Label>
+          <Input
+            id="program-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Program name"
+            disabled={createMutation.isPending}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-slug">Slug</Label>
+          <Input
+            id="program-slug"
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            placeholder="program-slug"
+            disabled={createMutation.isPending}
+          />
+          <p className="text-xs text-muted-foreground">Used in URLs — lowercase letters, numbers, and hyphens.</p>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-description">Description</Label>
+          <Textarea
+            id="program-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What is this program about?"
+            disabled={createMutation.isPending}
+          />
+        </div>
+        <Button
+          type="button"
+          variant="secondary"
+          disabled={createMutation.isPending || !name.trim() || !slug.trim()}
+          onClick={submit}
+          className="self-start"
+        >
+          {createMutation.isPending ? "Creating…" : "Create program"}
+        </Button>
+        {errorMessage && (
+          <p role="alert" className="text-sm text-destructive">
+            {errorMessage}
+          </p>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-base font-semibold uppercase tracking-wide text-muted-foreground">All programs</h2>
+        {programsQuery.isPending ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : programsQuery.isError ? (
+          <p role="alert" className="text-sm text-destructive">
+            Couldn't load programs.
+          </p>
+        ) : programsQuery.data.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No programs yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {programsQuery.data.map((p) => (
+              <li key={p.id}>
+                <Link
+                  href={`/admin/programs/${p.id}`}
+                  className="flex items-center gap-3 rounded border border-border p-3 hover:bg-muted/50"
+                >
+                  <span className="flex flex-col">
+                    <span className="text-sm font-semibold">{p.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {p.memberCount} {p.memberCount === 1 ? "participant" : "participants"}
+                    </span>
+                  </span>
+                  <span aria-hidden="true" className="ml-auto text-muted-foreground">
+                    →
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -19,6 +19,18 @@ export type ProgramsResponse = InferResponseType<(typeof apiClient.api.programs)
 
 export type Program = ProgramsResponse["programs"][number];
 
+export type AdminProgram = InferResponseType<
+  (typeof apiClient.api.admin.programs)["$get"],
+  200
+>["programs"][number];
+
+export type AdminProgramDetail = InferResponseType<
+  (typeof apiClient.api.admin.programs)[":id"]["$get"],
+  200
+>["program"];
+
+export type AdminProgramParticipant = AdminProgramDetail["participants"][number];
+
 export type RelationCandidatesFeed = InferResponseType<(typeof apiClient.api.relations.candidates)["$get"], 200>;
 
 export type RelationCandidate = RelationCandidatesFeed["suggestions"][number];

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -19,7 +19,19 @@ import {
   toSlug,
   upsertProfile,
 } from "./profiles";
-import { joinProgram, leaveProgram, listPrograms } from "./programs";
+import {
+  addParticipant,
+  createProgram,
+  getProgramDetail,
+  joinProgram,
+  leaveProgram,
+  listAllProgramsForAdmin,
+  listPrograms,
+  parseProgramCreate,
+  parseProgramUpdate,
+  removeParticipant,
+  updateProgram,
+} from "./programs";
 import {
   createRelationHint,
   deleteRelationHint,
@@ -46,6 +58,72 @@ const adminRoutes = new Hono<{ Variables: ApiVariables }>()
   .get("/hints", async (c) => {
     const hints = await listPendingHints();
     return c.json({ hints });
+  })
+  .get("/programs", async (c) => {
+    const programsList = await listAllProgramsForAdmin();
+    return c.json({ programs: programsList });
+  })
+  .post("/programs", async (c) => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid JSON" }, 400);
+    }
+    const parsed = parseProgramCreate(body);
+    if ("error" in parsed) return c.json({ error: parsed.error }, 400);
+
+    const result = await createProgram(parsed);
+    if ("error" in result) return c.json({ error: result.error }, 409);
+    return c.json({ program: result.program }, 201);
+  })
+  .get("/programs/:id", async (c) => {
+    const result = await getProgramDetail(c.req.param("id"));
+    if ("error" in result) return c.json({ error: result.error }, 404);
+    return c.json({ program: result.program });
+  })
+  // validator-typed body: Hono's RPC inference rejects a `json` key on a
+  // route that also has a path param unless the body is declared this
+  // way (same reason as PUT /relations/value/:relateeId below).
+  .patch(
+    "/programs/:id",
+    validator("json", (body, c) => {
+      const parsed = parseProgramUpdate(body);
+      if ("error" in parsed) return c.json({ error: parsed.error }, 400);
+      return parsed;
+    }),
+    async (c) => {
+      const result = await updateProgram(c.req.param("id"), c.req.valid("json"));
+      if ("error" in result) {
+        return c.json({ error: result.error }, result.error === "not_found" ? 404 : 409);
+      }
+      return c.json({ ok: true });
+    },
+  )
+  .post(
+    "/programs/:id/participants",
+    validator("json", (body, c) => {
+      if (!body || typeof body !== "object" || Array.isArray(body)) {
+        return c.json({ error: "body must be a JSON object" }, 400);
+      }
+      const profileId = (body as Record<string, unknown>).profileId;
+      if (typeof profileId !== "string" || !profileId) {
+        return c.json({ error: "profileId is required" }, 400);
+      }
+      return { profileId };
+    }),
+    async (c) => {
+      const result = await addParticipant(c.req.param("id"), c.req.valid("json").profileId);
+      if ("error" in result) {
+        return c.json({ error: result.error }, result.error === "already_member" ? 409 : 404);
+      }
+      return c.json({ ok: true });
+    },
+  )
+  .delete("/programs/:id/participants/:profileId", async (c) => {
+    const result = await removeParticipant(c.req.param("id"), c.req.param("profileId"));
+    if ("error" in result) return c.json({ error: result.error }, 404);
+    return c.json({ ok: true });
   });
 
 const api = new Hono<{ Variables: ApiVariables }>()

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -1,6 +1,7 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, asc, eq, ne, sql } from "drizzle-orm";
 
 import { isUuid } from "./auth-middleware";
+import { attachAvatarUrls } from "./avatars";
 import { db } from "./db";
 import { profilePrograms, profiles, programs } from "./schema";
 
@@ -95,5 +96,277 @@ export const leaveProgram = async (
 
   if (result.length === 0) return { error: "not_found" };
 
+  return { ok: true };
+};
+
+// --- Admin program administration (issue #139) ---------------------
+//
+// The functions above are member-facing: browse, join, leave. Below is
+// the admin surface — create/edit programs and manage who is enrolled.
+// Deleting a program is intentionally out of scope.
+
+export type AdminProgram = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  memberCount: number;
+  createdAt: string;
+};
+
+export type ProgramParticipant = {
+  id: string;
+  slug: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  assignedAt: string;
+};
+
+export type ProgramDetail = AdminProgram & { participants: ProgramParticipant[] };
+
+const MAX_PROGRAM_NAME = 120;
+const MAX_PROGRAM_SLUG = 80;
+const MAX_PROGRAM_DESCRIPTION = 2000;
+
+// Slugs are chosen by the admin, independently of the display name.
+// Enforce a URL-safe shape: lowercase alphanumerics in hyphen-separated
+// groups, with no leading, trailing, or doubled hyphens.
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SLUG_RULE = "slug must be lowercase letters, numbers, and hyphens";
+
+const trimmedString = (value: unknown): string | null =>
+  typeof value === "string" ? value.trim() : null;
+
+// Validates an admin-supplied slug. Returns the slug or an error string.
+const validateSlug = (slug: string): { slug: string } | { error: string } => {
+  if (slug.length > MAX_PROGRAM_SLUG) return { error: "slug is too long" };
+  if (!SLUG_PATTERN.test(slug)) return { error: SLUG_RULE };
+  return { slug };
+};
+
+// Parses a create-program body. Name and slug are both required and
+// chosen independently; description is optional, null when blank.
+export const parseProgramCreate = (
+  body: unknown,
+): { name: string; slug: string; description: string | null } | { error: string } => {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { error: "body must be a JSON object" };
+  }
+  const obj = body as Record<string, unknown>;
+  const name = trimmedString(obj.name);
+  if (!name) return { error: "name is required" };
+  if (name.length > MAX_PROGRAM_NAME) return { error: "name is too long" };
+
+  const slug = trimmedString(obj.slug);
+  if (!slug) return { error: "slug is required" };
+  const slugCheck = validateSlug(slug);
+  if ("error" in slugCheck) return slugCheck;
+
+  const description = trimmedString(obj.description);
+  if (description && description.length > MAX_PROGRAM_DESCRIPTION) {
+    return { error: "description is too long" };
+  }
+  return { name, slug, description: description || null };
+};
+
+// Parses an edit-program body. Every field is optional — only the keys
+// present are updated — but a present `name` or `slug` must be valid.
+export const parseProgramUpdate = (
+  body: unknown,
+): { name?: string; slug?: string; description?: string | null } | { error: string } => {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { error: "body must be a JSON object" };
+  }
+  const obj = body as Record<string, unknown>;
+  const result: { name?: string; slug?: string; description?: string | null } = {};
+
+  if ("name" in obj) {
+    const name = trimmedString(obj.name);
+    if (!name) return { error: "name must be a non-empty string" };
+    if (name.length > MAX_PROGRAM_NAME) return { error: "name is too long" };
+    result.name = name;
+  }
+  if ("slug" in obj) {
+    const slug = trimmedString(obj.slug);
+    if (!slug) return { error: "slug must be a non-empty string" };
+    const slugCheck = validateSlug(slug);
+    if ("error" in slugCheck) return slugCheck;
+    result.slug = slug;
+  }
+  if ("description" in obj) {
+    const description = trimmedString(obj.description);
+    if (description && description.length > MAX_PROGRAM_DESCRIPTION) {
+      return { error: "description is too long" };
+    }
+    result.description = description || null;
+  }
+  return result;
+};
+
+// Every program with its member count. Unlike listPrograms this carries
+// no per-user membership — admins manage programs, they don't join them.
+export const listAllProgramsForAdmin = async (): Promise<AdminProgram[]> => {
+  return db
+    .select({
+      id: programs.id,
+      slug: programs.slug,
+      name: programs.name,
+      description: programs.description,
+      createdAt: sql<string>`to_json(${programs.createdAt}) #>> '{}'`,
+      memberCount: sql<number>`(
+        SELECT count(*)::int FROM ${profilePrograms}
+        WHERE ${profilePrograms.programId} = ${programs.id}
+      )`,
+    })
+    .from(programs)
+    .orderBy(asc(programs.name));
+};
+
+export const createProgram = async (input: {
+  name: string;
+  slug: string;
+  description: string | null;
+}): Promise<{ program: AdminProgram } | { error: "slug_conflict" }> => {
+  const [existing] = await db.select({ id: programs.id }).from(programs).where(eq(programs.slug, input.slug));
+  if (existing) return { error: "slug_conflict" };
+
+  const [row] = await db
+    .insert(programs)
+    .values({ slug: input.slug, name: input.name, description: input.description })
+    .returning();
+
+  return {
+    program: {
+      id: row.id,
+      slug: row.slug,
+      name: row.name,
+      description: row.description,
+      memberCount: 0,
+      createdAt: row.createdAt.toISOString(),
+    },
+  };
+};
+
+export const updateProgram = async (
+  programId: string,
+  input: { name?: string; slug?: string; description?: string | null },
+): Promise<{ ok: true } | { error: "not_found" | "slug_conflict" }> => {
+  if (!isUuid(programId)) return { error: "not_found" };
+
+  const [program] = await db.select({ id: programs.id }).from(programs).where(eq(programs.id, programId));
+  if (!program) return { error: "not_found" };
+
+  const update: { name?: string; slug?: string; description?: string | null } = {};
+  if (input.name !== undefined) update.name = input.name;
+  if (input.description !== undefined) update.description = input.description;
+  if (input.slug !== undefined) {
+    // Reject a slug a different program already holds; the row keeping
+    // its own slug unchanged is fine.
+    const [clash] = await db
+      .select({ id: programs.id })
+      .from(programs)
+      .where(and(eq(programs.slug, input.slug), ne(programs.id, programId)));
+    if (clash) return { error: "slug_conflict" };
+    update.slug = input.slug;
+  }
+
+  if (Object.keys(update).length > 0) {
+    await db.update(programs).set(update).where(eq(programs.id, programId));
+  }
+  return { ok: true };
+};
+
+// A single program with its enrolled participants, for the admin
+// drill-down. Participants reuse the avatar-URL signing that listMembers
+// applies, so the UI renders the same avatars.
+export const getProgramDetail = async (
+  programId: string,
+): Promise<{ program: ProgramDetail } | { error: "not_found" }> => {
+  if (!isUuid(programId)) return { error: "not_found" };
+
+  const [program] = await db
+    .select({
+      id: programs.id,
+      slug: programs.slug,
+      name: programs.name,
+      description: programs.description,
+      createdAt: programs.createdAt,
+    })
+    .from(programs)
+    .where(eq(programs.id, programId));
+  if (!program) return { error: "not_found" };
+
+  const rows = await db
+    .select({
+      id: profiles.id,
+      slug: profiles.slug,
+      displayName: profiles.displayName,
+      avatarPath: profiles.avatarPath,
+      assignedAt: profilePrograms.assignedAt,
+    })
+    .from(profilePrograms)
+    .innerJoin(profiles, eq(profiles.id, profilePrograms.profileId))
+    .where(eq(profilePrograms.programId, programId))
+    .orderBy(asc(profiles.displayName));
+
+  const withUrls = await attachAvatarUrls(rows);
+  const participants: ProgramParticipant[] = withUrls.map((r) => ({
+    id: r.id,
+    slug: r.slug,
+    displayName: r.displayName,
+    avatarUrl: r.avatarUrl,
+    assignedAt: r.assignedAt.toISOString(),
+  }));
+
+  return {
+    program: {
+      id: program.id,
+      slug: program.slug,
+      name: program.name,
+      description: program.description,
+      createdAt: program.createdAt.toISOString(),
+      memberCount: participants.length,
+      participants,
+    },
+  };
+};
+
+export const addParticipant = async (
+  programId: string,
+  profileId: string,
+): Promise<
+  { ok: true } | { error: "program_not_found" | "profile_not_found" | "already_member" }
+> => {
+  if (!isUuid(programId)) return { error: "program_not_found" };
+  if (!isUuid(profileId)) return { error: "profile_not_found" };
+
+  const [program] = await db.select({ id: programs.id }).from(programs).where(eq(programs.id, programId));
+  if (!program) return { error: "program_not_found" };
+
+  const [profile] = await db.select({ id: profiles.id }).from(profiles).where(eq(profiles.id, profileId));
+  if (!profile) return { error: "profile_not_found" };
+
+  const result = await db
+    .insert(profilePrograms)
+    .values({ profileId, programId })
+    .onConflictDoNothing()
+    .returning({ profileId: profilePrograms.profileId });
+
+  if (result.length === 0) return { error: "already_member" };
+  return { ok: true };
+};
+
+export const removeParticipant = async (
+  programId: string,
+  profileId: string,
+): Promise<{ ok: true } | { error: "not_found" }> => {
+  if (!isUuid(programId) || !isUuid(profileId)) return { error: "not_found" };
+
+  const result = await db
+    .delete(profilePrograms)
+    .where(and(eq(profilePrograms.programId, programId), eq(profilePrograms.profileId, profileId)))
+    .returning({ profileId: profilePrograms.profileId });
+
+  if (result.length === 0) return { error: "not_found" };
   return { ok: true };
 };

--- a/src/server/test-reset.ts
+++ b/src/server/test-reset.ts
@@ -44,7 +44,7 @@ export const resetE2EUsers = async (): Promise<{
   updatedIds: string[];
   // Post-commit read-back per seeded user. `rows` holds every physical
   // profile row for that id: length 0 means no profile row at all (fine
-  // — e.g. e2e-admin, which no test signs in as), length > 1 means
+  // — no test has signed in as them yet this run), length > 1 means
   // duplicate tuples.
   profiles: { id: string; email: string; rows: ResetProbeRow[] }[];
 }> => {

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -9,8 +9,11 @@ import { resetSeededUsers, signInAs } from "./helpers/session";
 // server-component throw, a failed client fetch) without coupling to
 // their content. Deeper program-admin behaviour is covered by the
 // functional tests in tests/functional/server/admin-programs.test.ts.
-
-test.describe.configure({ mode: "serial" });
+//
+// Requires e2e-admin@testfake.local to have is_admin = true in the
+// target database — otherwise /admin and /admin/programs call
+// notFound() and the status assertions below fail fast. See
+// docs/doc-supabase.md.
 
 test.beforeEach(async ({ baseURL }) => {
   if (!baseURL) throw new Error("admin.spec.ts: baseURL is not configured");
@@ -35,14 +38,17 @@ test("admin can open the /admin hub without console errors", async ({ page }) =>
   await signInAs(page, "admin");
   const errors = collectPageErrors(page);
 
-  // The hub's AdminHints panel fetches /api/admin/hints on mount; wait
-  // for it so a client-side failure has a chance to surface.
-  const hintsLoaded = page.waitForResponse((r) => r.url().includes("/api/admin/hints"));
-  await page.goto("/admin");
-  await hintsLoaded;
+  const response = await page.goto("/admin");
+  // /admin calls notFound() for non-admins, so a 404 here means the
+  // seeded admin user has lost (or never had) its is_admin flag.
+  expect(response?.status(), "/admin returned 404 — is e2e-admin still flagged is_admin?").toBe(200);
 
   await expect(page.getByRole("heading", { name: "Admin", level: 1 })).toBeVisible();
   await expect(page.getByRole("link", { name: "Manage programs" })).toBeVisible();
+  // AdminHints settling out of its "Loading…" state means its
+  // /api/admin/hints query resolved — any client-side error has had its
+  // chance to land in `errors`.
+  await expect(page.getByText("Loading…")).toBeHidden();
   expect(errors).toEqual([]);
 });
 
@@ -50,11 +56,11 @@ test("admin can open the /admin/programs page without console errors", async ({ 
   await signInAs(page, "admin");
   const errors = collectPageErrors(page);
 
-  const programsLoaded = page.waitForResponse((r) => r.url().includes("/api/admin/programs"));
-  await page.goto("/admin/programs");
-  await programsLoaded;
+  const response = await page.goto("/admin/programs");
+  expect(response?.status(), "/admin/programs returned 404 — is e2e-admin still flagged is_admin?").toBe(200);
 
   await expect(page.getByRole("heading", { name: "Programs", level: 1 })).toBeVisible();
   await expect(page.getByRole("button", { name: "Create program" })).toBeVisible();
+  await expect(page.getByText("Loading…")).toBeHidden();
   expect(errors).toEqual([]);
 });

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1,0 +1,60 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import { resetSeededUsers, signInAs } from "./helpers/session";
+
+// Smoke test for the admin surface: the seeded admin user can reach the
+// /admin hub and the /admin/programs page, and neither logs a console
+// error nor throws an uncaught exception. Deliberately shallow — it
+// guards against the admin pages crashing on load (a broken import, a
+// server-component throw, a failed client fetch) without coupling to
+// their content. Deeper program-admin behaviour is covered by the
+// functional tests in tests/functional/server/admin-programs.test.ts.
+
+test.describe.configure({ mode: "serial" });
+
+test.beforeEach(async ({ baseURL }) => {
+  if (!baseURL) throw new Error("admin.spec.ts: baseURL is not configured");
+  await resetSeededUsers(baseURL);
+});
+
+// Records console errors and uncaught page exceptions from the moment it
+// is attached. Attach it after sign-in so the listener only sees the
+// page under test, not sign-in/redirect noise.
+function collectPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(`console.error: ${msg.text()}`);
+  });
+  page.on("pageerror", (err) => {
+    errors.push(`pageerror: ${err.message}`);
+  });
+  return errors;
+}
+
+test("admin can open the /admin hub without console errors", async ({ page }) => {
+  await signInAs(page, "admin");
+  const errors = collectPageErrors(page);
+
+  // The hub's AdminHints panel fetches /api/admin/hints on mount; wait
+  // for it so a client-side failure has a chance to surface.
+  const hintsLoaded = page.waitForResponse((r) => r.url().includes("/api/admin/hints"));
+  await page.goto("/admin");
+  await hintsLoaded;
+
+  await expect(page.getByRole("heading", { name: "Admin", level: 1 })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Manage programs" })).toBeVisible();
+  expect(errors).toEqual([]);
+});
+
+test("admin can open the /admin/programs page without console errors", async ({ page }) => {
+  await signInAs(page, "admin");
+  const errors = collectPageErrors(page);
+
+  const programsLoaded = page.waitForResponse((r) => r.url().includes("/api/admin/programs"));
+  await page.goto("/admin/programs");
+  await programsLoaded;
+
+  await expect(page.getByRole("heading", { name: "Programs", level: 1 })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Create program" })).toBeVisible();
+  expect(errors).toEqual([]);
+});

--- a/tests/e2e/helpers/session.ts
+++ b/tests/e2e/helpers/session.ts
@@ -91,7 +91,7 @@ export const resetSeededUsers = async (baseURL: string): Promise<void> => {
   // — in beforeEach, instead of 20s later at a /welcome timeout: a row
   // whose bio survived the reset (the #149 symptom), or duplicate
   // tuples for one id. A seeded user with no profile row at all (0 rows
-  // — e.g. e2e-admin, which no test signs in as) is fine, not flagged.
+  // — no test has signed in as them yet this run) is fine, not flagged.
   // The dump shows the surviving bio string (its value names the test
   // that wrote it, since each completeWelcome caller passes a distinct
   // bio), the tuple identity, and whether the read ran on a replica.

--- a/tests/functional/server/admin-programs.test.ts
+++ b/tests/functional/server/admin-programs.test.ts
@@ -1,0 +1,334 @@
+import { randomUUID } from "node:crypto";
+import type { User } from "@supabase/supabase-js";
+import { eq, inArray, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+import { createServerClient } from "@supabase/ssr";
+
+import app from "@/server/api";
+import { db } from "@/server/db";
+import { profilePrograms, profiles, programs } from "@/server/schema";
+
+const mockCreateServerClient = vi.mocked(createServerClient);
+
+const fakeUser = (id: string): User =>
+  ({
+    id,
+    email: `${id}@testfake.local`,
+    user_metadata: {},
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+  }) as User;
+
+const authAs = (userId: string | null) => {
+  mockCreateServerClient.mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? fakeUser(userId) : null },
+        error: null,
+      }),
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test mock shape
+  } as any);
+};
+
+const insertUserAndProfile = async (id: string, opts: { isAdmin?: boolean; displayName?: string } = {}) => {
+  await db.execute(
+    sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${id}::uuid, ${`${id}@testfake.local`}, false, false)`,
+  );
+  await db.insert(profiles).values({ id, isAdmin: opts.isAdmin ?? false, displayName: opts.displayName ?? null });
+};
+
+const deleteUserAndProfile = async (id: string) => {
+  await db.delete(profiles).where(eq(profiles.id, id));
+  await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+};
+
+describe("Admin programs API", () => {
+  let admin: string;
+  let nonAdmin: string;
+  let member: string;
+  // Programs created during a test (seeded or via the API) — torn down
+  // in afterEach so each test starts from a clean slate.
+  let createdProgramIds: string[];
+
+  const trackProgram = (id: string) => {
+    createdProgramIds.push(id);
+    return id;
+  };
+
+  // Seeds a program directly. The slug defaults to a random value so
+  // independent seeds never collide; pass an explicit slug when a test
+  // needs to exercise the derived-slug uniqueness check.
+  const seedProgram = async (name: string, slug?: string): Promise<string> => {
+    const id = randomUUID();
+    await db.insert(programs).values({ id, slug: slug ?? `seed-${id.slice(0, 8)}`, name });
+    return trackProgram(id);
+  };
+
+  beforeEach(async () => {
+    admin = randomUUID();
+    nonAdmin = randomUUID();
+    member = randomUUID();
+    createdProgramIds = [];
+    await insertUserAndProfile(admin, { isAdmin: true });
+    await insertUserAndProfile(nonAdmin);
+    await insertUserAndProfile(member, { displayName: "Morgan Member" });
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    if (createdProgramIds.length > 0) {
+      await db.delete(profilePrograms).where(inArray(profilePrograms.programId, createdProgramIds));
+      await db.delete(programs).where(inArray(programs.id, createdProgramIds));
+    }
+    await deleteUserAndProfile(admin);
+    await deleteUserAndProfile(nonAdmin);
+    await deleteUserAndProfile(member);
+  });
+
+  describe("GET /api/admin/programs", () => {
+    it("lists programs with member counts for an admin", async () => {
+      const programId = await seedProgram("Listed Program");
+      await db.insert(profilePrograms).values({ profileId: member, programId });
+
+      authAs(admin);
+      const res = await app.request("/api/admin/programs");
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as { programs: Array<{ id: string; memberCount: number }> };
+      const own = body.programs.find((p) => p.id === programId);
+      expect(own?.memberCount).toBe(1);
+    });
+
+    it("returns 404 for a non-admin", async () => {
+      authAs(nonAdmin);
+      const res = await app.request("/api/admin/programs");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /api/admin/programs", () => {
+    const post = (body: unknown) =>
+      app.request("/api/admin/programs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+    it("stores the name and slug as separate, admin-chosen values", async () => {
+      authAs(admin);
+      const res = await post({ name: "Deep Work Cohort", slug: "dw-2026", description: "Focus time." });
+      expect(res.status).toBe(201);
+
+      const body = (await res.json()) as { program: { id: string; slug: string; name: string } };
+      trackProgram(body.program.id);
+      expect(body.program.name).toBe("Deep Work Cohort");
+      expect(body.program.slug).toBe("dw-2026");
+    });
+
+    it("rejects a blank name with 400", async () => {
+      authAs(admin);
+      const res = await post({ name: "   ", slug: "blank-name" });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects a missing slug with 400", async () => {
+      authAs(admin);
+      const res = await post({ name: "No Slug Program" });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects a slug with invalid characters with 400", async () => {
+      authAs(admin);
+      const res = await post({ name: "Bad Slug Program", slug: "Not A Slug!" });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 409 when the slug collides with an existing program", async () => {
+      authAs(admin);
+      const first = await post({ name: "Mentorship", slug: "mentorship" });
+      const firstBody = (await first.json()) as { program: { id: string } };
+      trackProgram(firstBody.program.id);
+
+      const second = await post({ name: "Mentorship Two", slug: "mentorship" });
+      expect(second.status).toBe(409);
+      expect((await second.json()) as { error: string }).toEqual({ error: "slug_conflict" });
+    });
+
+    it("returns 404 for a non-admin", async () => {
+      authAs(nonAdmin);
+      const res = await post({ name: "Should Not Exist", slug: "should-not-exist" });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/admin/programs/:id", () => {
+    it("returns program detail with its participants", async () => {
+      const programId = await seedProgram("Detailed Program");
+      await db.insert(profilePrograms).values({ profileId: member, programId });
+
+      authAs(admin);
+      const res = await app.request(`/api/admin/programs/${programId}`);
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as {
+        program: { id: string; participants: Array<{ id: string; displayName: string | null }> };
+      };
+      expect(body.program.id).toBe(programId);
+      expect(body.program.participants).toHaveLength(1);
+      expect(body.program.participants[0]).toMatchObject({ id: member, displayName: "Morgan Member" });
+    });
+
+    it("returns 404 for a non-existent program", async () => {
+      authAs(admin);
+      const res = await app.request(`/api/admin/programs/${randomUUID()}`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PATCH /api/admin/programs/:id", () => {
+    const patch = (id: string, body: unknown) =>
+      app.request(`/api/admin/programs/${id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+    it("updates name, slug, and description independently", async () => {
+      const programId = await seedProgram("Old Name");
+
+      authAs(admin);
+      const res = await patch(programId, {
+        name: "New Name",
+        slug: "renamed-slug",
+        description: "Updated.",
+      });
+      expect(res.status).toBe(200);
+
+      const [row] = await db
+        .select({ name: programs.name, slug: programs.slug, description: programs.description })
+        .from(programs)
+        .where(eq(programs.id, programId));
+      expect(row).toMatchObject({ name: "New Name", slug: "renamed-slug", description: "Updated." });
+    });
+
+    it("rejects a slug with invalid characters with 400", async () => {
+      const programId = await seedProgram("Slug Validation Program");
+
+      authAs(admin);
+      const res = await patch(programId, { slug: "Has Spaces" });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 409 when a new slug collides with another program's slug", async () => {
+      await seedProgram("Slug Holder", "taken-slug");
+      const programId = await seedProgram("Slug Mover");
+
+      authAs(admin);
+      const res = await patch(programId, { slug: "taken-slug" });
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 404 for a non-existent program", async () => {
+      authAs(admin);
+      const res = await patch(randomUUID(), { name: "Whatever" });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /api/admin/programs/:id/participants", () => {
+    const addParticipant = (programId: string, profileId: string) =>
+      app.request(`/api/admin/programs/${programId}/participants`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ profileId }),
+      });
+
+    it("adds a participant", async () => {
+      const programId = await seedProgram("Joinable Program");
+
+      authAs(admin);
+      const res = await addParticipant(programId, member);
+      expect(res.status).toBe(200);
+
+      const rows = await db
+        .select()
+        .from(profilePrograms)
+        .where(eq(profilePrograms.programId, programId));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].profileId).toBe(member);
+    });
+
+    it("returns 409 when the member is already a participant", async () => {
+      const programId = await seedProgram("Already Joined Program");
+      await db.insert(profilePrograms).values({ profileId: member, programId });
+
+      authAs(admin);
+      const res = await addParticipant(programId, member);
+      expect(res.status).toBe(409);
+      expect((await res.json()) as { error: string }).toEqual({ error: "already_member" });
+    });
+
+    it("returns 404 when the profile does not exist", async () => {
+      const programId = await seedProgram("Phantom Member Program");
+
+      authAs(admin);
+      const res = await addParticipant(programId, randomUUID());
+      expect(res.status).toBe(404);
+      expect((await res.json()) as { error: string }).toEqual({ error: "profile_not_found" });
+    });
+
+    it("returns 404 when the program does not exist", async () => {
+      authAs(admin);
+      const res = await addParticipant(randomUUID(), member);
+      expect(res.status).toBe(404);
+      expect((await res.json()) as { error: string }).toEqual({ error: "program_not_found" });
+    });
+  });
+
+  describe("DELETE /api/admin/programs/:id/participants/:profileId", () => {
+    it("removes a participant", async () => {
+      const programId = await seedProgram("Removable Program");
+      await db.insert(profilePrograms).values({ profileId: member, programId });
+
+      authAs(admin);
+      const res = await app.request(`/api/admin/programs/${programId}/participants/${member}`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+
+      const rows = await db
+        .select()
+        .from(profilePrograms)
+        .where(eq(profilePrograms.programId, programId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("returns 404 when the member is not a participant", async () => {
+      const programId = await seedProgram("Empty Program");
+
+      authAs(admin);
+      const res = await app.request(`/api/admin/programs/${programId}/participants/${member}`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 404 for a non-admin", async () => {
+      const programId = await seedProgram("Guarded Program");
+      await db.insert(profilePrograms).values({ profileId: member, programId });
+
+      authAs(nonAdmin);
+      const res = await app.request(`/api/admin/programs/${programId}/participants/${member}`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+});


### PR DESCRIPTION
Closes #139.

## What

Admins can now create, edit, and manage participation in Programs.

- **`/admin/programs`** — list every program with its participant count; create new programs
- **`/admin/programs/[id]`** — edit a program's name, slug, and description; add/remove participants via the existing `MemberTypeahead`
- The `/admin` hub's Programs section now links here (was "Coming soon.")

## Decisions

- **Slugs are entered explicitly**, separate from the display name, so admins control the URL. Validated as lowercase letters/numbers/hyphens; uniqueness enforced.
- **No delete.** Editing and participant management only — removing a program is out of scope for this issue.

## API

New endpoints under the existing `requireAdmin` sub-router: `GET`/`POST /api/admin/programs`, `GET`/`PATCH /api/admin/programs/:id`, `POST`/`DELETE /api/admin/programs/:id/participants`.

## Tests

- `tests/functional/server/admin-programs.test.ts` — 21 tests: CRUD, slug validation/collisions, participant add/remove, non-admin 404s
- `tests/e2e/admin.spec.ts` — smoke tests that the admin user can open `/admin` and `/admin/programs` with no console errors
- Full suite green: 170 functional, 25 e2e, lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)