### PR TITLE
Apply Biome formatter and fix lint warnings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -34,7 +34,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "noNonNullAssertion": "error"
+      }
     }
   },
   "assist": {

--- a/biome.json
+++ b/biome.json
@@ -88,6 +88,16 @@
           }
         }
       }
+    },
+    {
+      "includes": ["tests/**", "scripts/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noNonNullAssertion": "off"
+          }
+        }
+      }
     }
   ]
 }

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -4,12 +4,17 @@ config({ path: ".env.local" });
 
 import { defineConfig } from "drizzle-kit";
 
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is not set — drizzle-kit needs it to connect.");
+}
+
 export default defineConfig({
   schema: "./src/server/schema.ts",
   out: "./drizzle",
   dialect: "postgresql",
   schemaFilter: ["public"],
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    url: databaseUrl,
   },
 });

--- a/scripts/ensure-docker.mjs
+++ b/scripts/ensure-docker.mjs
@@ -73,7 +73,7 @@ const main = async () => {
   }
 
   process.stderr.write(
-    `Timed out waiting for Docker daemon after ${DAEMON_READY_TIMEOUT_MS / 1000}s. ` + "Please check Docker Desktop.\n",
+    `Timed out waiting for Docker daemon after ${DAEMON_READY_TIMEOUT_MS / 1000}s. Please check Docker Desktop.\n`,
   );
   process.exit(1);
 };

--- a/src/app/admin/admin-hints.tsx
+++ b/src/app/admin/admin-hints.tsx
@@ -86,8 +86,8 @@ export function AdminHints() {
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-3 rounded border border-border p-3">
         <p className="text-sm text-muted-foreground">
-          Seed a hint that <em>relator</em> might know <em>target</em>. The hint surfaces on the relator's
-          suggestion feed; they convert it by rating, or it stays pending.
+          Seed a hint that <em>relator</em> might know <em>target</em>. The hint surfaces on the relator's suggestion
+          feed; they convert it by rating, or it stays pending.
         </p>
         <MemberTypeahead
           label="Relator (whose feed gets the hint)"
@@ -147,9 +147,7 @@ export function AdminHints() {
                   variant="destructive"
                   size="xs"
                   disabled={deleteMutation.isPending}
-                  onClick={() =>
-                    deleteMutation.mutate({ relatorId: h.relator.id, relateeId: h.relatee.id })
-                  }
+                  onClick={() => deleteMutation.mutate({ relatorId: h.relator.id, relateeId: h.relatee.id })}
                 >
                   Withdraw
                 </Button>

--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -89,7 +89,9 @@ export default function ResetPasswordPage() {
         </Button>
 
         {status.kind === "error" && (
-          <p role="alert" className="text-sm text-destructive">{status.message}</p>
+          <p role="alert" className="text-sm text-destructive">
+            {status.message}
+          </p>
         )}
       </form>
     </main>

--- a/src/app/members/members-list.tsx
+++ b/src/app/members/members-list.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import type { UrlObject } from "node:url";
 import Link from "next/link";
+import { useState } from "react";
 
 import { Avatar } from "@/components/avatar";
 import { KeywordChips } from "@/components/keyword-chips";
@@ -56,9 +56,7 @@ export function MembersList({ members }: { members: MemberSummary[] }) {
       />
 
       {filtered.length === 0 ? (
-        <p className="text-muted-foreground">
-          {query ? "No members match your search." : "No members yet."}
-        </p>
+        <p className="text-muted-foreground">{query ? "No members match your search." : "No members yet."}</p>
       ) : (
         <ul className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {filtered.map((member) => (

--- a/src/app/myweb/welcome-tour.tsx
+++ b/src/app/myweb/welcome-tour.tsx
@@ -37,10 +37,7 @@ const STEPS: Step[] = [
 // (skip / close / next-on-last-step) leaves passive teardowns alone.
 export function WelcomeTour({ run, onClose }: { run: boolean; onClose: () => void }) {
   const handleEvent = (data: EventData) => {
-    if (
-      data.type === "tour:end" &&
-      (data.action === "skip" || data.action === "close" || data.action === "next")
-    ) {
+    if (data.type === "tour:end" && (data.action === "skip" || data.action === "close" || data.action === "next")) {
       onClose();
     }
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,9 +57,7 @@ function NavCard({ href, title, description }: NavCardProps) {
       href={href}
       className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-5 transition-all hover:border-primary/40 hover:bg-accent hover:shadow-sm"
     >
-      <h2 className="text-lg font-semibold text-card-foreground group-hover:text-accent-foreground">
-        {title}
-      </h2>
+      <h2 className="text-lg font-semibold text-card-foreground group-hover:text-accent-foreground">{title}</h2>
       <p className="text-sm text-muted-foreground">{description}</p>
     </Link>
   );
@@ -72,37 +70,15 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
     <main className="flex min-h-screen flex-col items-center gap-8 p-8 pt-12">
       <div className="flex flex-col items-center gap-2">
         <h1 className="text-3xl font-bold">{greeting}</h1>
-        <p className="font-serif italic text-muted-foreground">
-          What would you like to do?
-        </p>
+        <p className="font-serif italic text-muted-foreground">What would you like to do?</p>
       </div>
 
       <div className="grid w-full max-w-lg gap-4 sm:grid-cols-2">
-        <NavCard
-          href="/myweb"
-          title="My web"
-          description="See your connections and relational map."
-        />
-        <NavCard
-          href="/profile"
-          title="My profile"
-          description="View and edit your community profile."
-        />
-        <NavCard
-          href="/members"
-          title="Member directory"
-          description="Browse and connect with other members."
-        />
-        <NavCard
-          href="/programs"
-          title="Programs"
-          description="Explore and join community programs."
-        />
-        <NavCard
-          href="/invites"
-          title="Invite a friend"
-          description="Generate invite codes for new members."
-        />
+        <NavCard href="/myweb" title="My web" description="See your connections and relational map." />
+        <NavCard href="/profile" title="My profile" description="View and edit your community profile." />
+        <NavCard href="/members" title="Member directory" description="Browse and connect with other members." />
+        <NavCard href="/programs" title="Programs" description="Explore and join community programs." />
+        <NavCard href="/invites" title="Invite a friend" description="Generate invite codes for new members." />
       </div>
     </main>
   );

--- a/src/app/profile/avatar-uploader.tsx
+++ b/src/app/profile/avatar-uploader.tsx
@@ -66,17 +66,7 @@ const cropToWebp = async (src: string, area: Area): Promise<Blob> => {
   const canvas = document.createElement("canvas");
   canvas.width = OUTPUT_DIMENSION;
   canvas.height = OUTPUT_DIMENSION;
-  getContext(canvas).drawImage(
-    img,
-    area.x,
-    area.y,
-    area.width,
-    area.height,
-    0,
-    0,
-    OUTPUT_DIMENSION,
-    OUTPUT_DIMENSION,
-  );
+  getContext(canvas).drawImage(img, area.x, area.y, area.width, area.height, 0, 0, OUTPUT_DIMENSION, OUTPUT_DIMENSION);
   const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/webp", 0.88));
   if (!blob) throw new Error("could not encode image");
   return blob;

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -8,7 +8,11 @@ import { ProfileForm } from "../profile-form";
 
 export default async function EditProfilePage() {
   const me: Me = await requireUser();
-  const profile = me.profile!;
+  // /api/me self-heals a missing profile row, so this is effectively
+  // unreachable — the guard keeps the type honest and fails loudly if
+  // that invariant ever breaks.
+  if (!me.profile) throw new Error("authenticated user has no profile");
+  const profile = me.profile;
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -17,7 +17,11 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 export default async function ProfilePage() {
   const me: Me = await requireUser();
-  const profile = me.profile!;
+  // /api/me self-heals a missing profile row, so this is effectively
+  // unreachable — the guard keeps the type honest and fails loudly if
+  // that invariant ever breaks.
+  if (!me.profile) throw new Error("authenticated user has no profile");
+  const profile = me.profile;
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">

--- a/src/app/profile/profile-form.tsx
+++ b/src/app/profile/profile-form.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 
 import { ProfileFields } from "@/components/profile-fields";
 import { Button } from "@/components/ui/button";
-import { useProfileForm, type ProfileFormValues } from "@/lib/use-profile-form";
+import { type ProfileFormValues, useProfileForm } from "@/lib/use-profile-form";
 
 export function ProfileForm({ initial }: { initial: ProfileFormValues }) {
   const router = useRouter();

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -15,7 +15,9 @@ export default async function ProgramsPage() {
           ← Back
         </Link>
       </div>
-      <p className="w-full max-w-5xl text-base text-muted-foreground">Browse programs and join the ones that interest you.</p>
+      <p className="w-full max-w-5xl text-base text-muted-foreground">
+        Browse programs and join the ones that interest you.
+      </p>
       <ProgramsList />
     </main>
   );

--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useState } from "react";
 
+import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api";
 import type { Program } from "@/lib/api-types";
-import { Button } from "@/components/ui/button";
 
 type ListState = { kind: "loading" } | { kind: "loaded"; programs: Program[] } | { kind: "error"; message: string };
 
@@ -31,17 +31,13 @@ function ProgramCard({
         <h2 className="text-lg font-semibold">{program.name}</h2>
         <p className="text-xs text-muted-foreground">
           {program.memberCount} {program.memberCount === 1 ? "member" : "members"}
-          {program.joined && program.joinedAt && (
-            <> · Joined {formatDate(program.joinedAt)}</>
-          )}
+          {program.joined && program.joinedAt && <> · Joined {formatDate(program.joinedAt)}</>}
         </p>
       </div>
 
       {description && (
         <div className="flex flex-col gap-1">
-          <p className="font-serif text-sm text-muted-foreground leading-relaxed">
-            {visibleDescription}
-          </p>
+          <p className="font-serif text-sm text-muted-foreground leading-relaxed">{visibleDescription}</p>
           {isLong && (
             <button
               type="button"
@@ -66,12 +62,7 @@ function ProgramCard({
             {pending ? "Leaving…" : "Leave program"}
           </Button>
         ) : (
-          <Button
-            type="button"
-            disabled={pending}
-            onClick={() => onJoin(program.id)}
-            className="w-full"
-          >
+          <Button type="button" disabled={pending} onClick={() => onJoin(program.id)} className="w-full">
             {pending ? "Joining…" : "Join program"}
           </Button>
         )}
@@ -104,7 +95,9 @@ export function ProgramsList() {
       }
     }
     void fetchPrograms();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [reloadKey]);
 
   const reload = () => setReloadKey((k) => k + 1);
@@ -143,13 +136,20 @@ export function ProgramsList() {
   };
 
   if (state.kind === "loading") return <p className="text-sm text-muted-foreground">Loading programs…</p>;
-  if (state.kind === "error") return <p role="alert" className="text-sm text-destructive">{state.message}</p>;
+  if (state.kind === "error")
+    return (
+      <p role="alert" className="text-sm text-destructive">
+        {state.message}
+      </p>
+    );
   if (state.programs.length === 0) return <p className="text-sm text-muted-foreground">No programs available yet.</p>;
 
   return (
     <div className="flex w-full max-w-5xl flex-col gap-4">
       {actionError && (
-        <p role="alert" className="text-sm text-destructive">{actionError}</p>
+        <p role="alert" className="text-sm text-destructive">
+          {actionError}
+        </p>
       )}
       <ul className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {state.programs.map((program) => (

--- a/src/app/welcome/welcome-form.tsx
+++ b/src/app/welcome/welcome-form.tsx
@@ -7,8 +7,8 @@ import { ProfileFields } from "@/components/profile-fields";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useProfileForm, type ProfileFormValues } from "@/lib/use-profile-form";
 import { createClient } from "@/lib/supabase/client";
+import { type ProfileFormValues, useProfileForm } from "@/lib/use-profile-form";
 
 export function WelcomeForm({ initial }: { initial: ProfileFormValues }) {
   const router = useRouter();

--- a/src/components/member-typeahead.tsx
+++ b/src/components/member-typeahead.tsx
@@ -6,14 +6,7 @@ import { useId, useMemo, useState } from "react";
 
 import { Avatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { apiClient } from "@/lib/api";

--- a/src/components/profile-fields.tsx
+++ b/src/components/profile-fields.tsx
@@ -95,9 +95,7 @@ export function ProfileFields({ fields, setters, disabled }: Props) {
         onChange={(e) => setters.setEmergencyContact(e.target.value)}
         disabled={disabled}
       />
-      <p className="text-sm text-muted-foreground">
-        Visible only to you and admins in case of emergency.
-      </p>
+      <p className="text-sm text-muted-foreground">Visible only to you and admins in case of emergency.</p>
     </>
   );
 }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,36 +1,24 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Command as CommandPrimitive } from "cmdk"
+import { Command as CommandPrimitive } from "cmdk";
+import { CheckIcon, SearchIcon } from "lucide-react";
+import type * as React from "react";
 
-import { cn } from "@/lib/utils"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
-import {
-  InputGroup,
-  InputGroupAddon,
-} from "@/components/ui/input-group"
-import { SearchIcon, CheckIcon } from "lucide-react"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { InputGroup, InputGroupAddon } from "@/components/ui/input-group";
+import { cn } from "@/lib/utils";
 
-function Command({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive>) {
+function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
   return (
     <CommandPrimitive
       data-slot="command"
       className={cn(
         "flex size-full flex-col overflow-hidden rounded-xl! bg-popover p-1 text-popover-foreground",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CommandDialog({
@@ -41,11 +29,11 @@ function CommandDialog({
   showCloseButton = false,
   ...props
 }: Omit<React.ComponentProps<typeof Dialog>, "children"> & {
-  title?: string
-  description?: string
-  className?: string
-  showCloseButton?: boolean
-  children: React.ReactNode
+  title?: string;
+  description?: string;
+  className?: string;
+  showCloseButton?: boolean;
+  children: React.ReactNode;
 }) {
   return (
     <Dialog {...props}>
@@ -54,31 +42,22 @@ function CommandDialog({
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
       <DialogContent
-        className={cn(
-          "top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0",
-          className
-        )}
+        className={cn("top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0", className)}
         showCloseButton={showCloseButton}
       >
         {children}
       </DialogContent>
     </Dialog>
-  )
+  );
 }
 
-function CommandInput({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+function CommandInput({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Input>) {
   return (
     <div data-slot="command-input-wrapper" className="p-1 pb-0">
       <InputGroup className="h-8! rounded-lg! border-input/30 bg-input/30 shadow-none! *:data-[slot=input-group-addon]:pl-2!">
         <CommandPrimitive.Input
           data-slot="command-input"
-          className={cn(
-            "w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
-            className
-          )}
+          className={cn("w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50", className)}
           {...props}
         />
         <InputGroupAddon>
@@ -86,111 +65,89 @@ function CommandInput({
         </InputGroupAddon>
       </InputGroup>
     </div>
-  )
+  );
 }
 
-function CommandList({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.List>) {
+function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
   return (
     <CommandPrimitive.List
       data-slot="command-list"
-      className={cn(
-        "no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none",
-        className
-      )}
+      className={cn("no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none", className)}
       {...props}
     />
-  )
+  );
 }
 
-function CommandEmpty({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+function CommandEmpty({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
   return (
     <CommandPrimitive.Empty
       data-slot="command-empty"
       className={cn("py-6 text-center text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
-function CommandGroup({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+function CommandGroup({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Group>) {
   return (
     <CommandPrimitive.Group
       data-slot="command-group"
       className={cn(
         "overflow-hidden p-1 text-foreground **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function CommandSeparator({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+function CommandSeparator({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Separator>) {
   return (
     <CommandPrimitive.Separator
       data-slot="command-separator"
       className={cn("-mx-1 h-px bg-border", className)}
       {...props}
     />
-  )
+  );
 }
 
-function CommandItem({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+function CommandItem({ className, children, ...props }: React.ComponentProps<typeof CommandPrimitive.Item>) {
   return (
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
         "group/command-item relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-muted data-selected:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-selected:*:[svg]:text-foreground",
-        className
+        className,
       )}
       {...props}
     >
       {children}
       <CheckIcon className="ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" />
     </CommandPrimitive.Item>
-  )
+  );
 }
 
-function CommandShortcut({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function CommandShortcut({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       data-slot="command-shortcut"
       className={cn(
         "ml-auto text-xs tracking-widest text-muted-foreground group-data-selected/command-item:text-foreground",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
   Command,
   CommandDialog,
-  CommandInput,
-  CommandList,
   CommandEmpty,
   CommandGroup,
+  CommandInput,
   CommandItem,
-  CommandShortcut,
+  CommandList,
   CommandSeparator,
-}
+  CommandShortcut,
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,42 +1,39 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { XIcon } from "lucide-react";
+import type * as React from "react";
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
 function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
 function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
 function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
-function DialogOverlay({
-  className,
-  ...props
-}: DialogPrimitive.Backdrop.Props) {
+function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) {
   return (
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
         "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
@@ -45,7 +42,7 @@ function DialogContent({
   showCloseButton = true,
   ...props
 }: DialogPrimitive.Popup.Props & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <DialogPortal>
@@ -54,7 +51,7 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className
+          className,
         )}
         {...props}
       >
@@ -62,32 +59,19 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            render={
-              <Button
-                variant="ghost"
-                className="absolute top-2 right-2"
-                size="icon-sm"
-              />
-            }
+            render={<Button variant="ghost" className="absolute top-2 right-2" size="icon-sm" />}
           >
-            <XIcon
-            />
+            <XIcon />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Popup>
     </DialogPortal>
-  )
+  );
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="dialog-header"
-      className={cn("flex flex-col gap-2", className)}
-      {...props}
-    />
-  )
+  return <div data-slot="dialog-header" className={cn("flex flex-col gap-2", className)} {...props} />;
 }
 
 function DialogFooter({
@@ -96,54 +80,44 @@ function DialogFooter({
   children,
   ...props
 }: React.ComponentProps<"div"> & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <div
       data-slot="dialog-footer"
       className={cn(
         "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
-        className
+        className,
       )}
       {...props}
     >
       {children}
-      {showCloseButton && (
-        <DialogPrimitive.Close render={<Button variant="primary" />}>
-          Close
-        </DialogPrimitive.Close>
-      )}
+      {showCloseButton && <DialogPrimitive.Close render={<Button variant="primary" />}>Close</DialogPrimitive.Close>}
     </div>
-  )
+  );
 }
 
 function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn(
-        "font-heading text-base leading-none font-medium",
-        className
-      )}
+      className={cn("font-heading text-base leading-none font-medium", className)}
       {...props}
     />
-  )
+  );
 }
 
-function DialogDescription({
-  className,
-  ...props
-}: DialogPrimitive.Description.Props) {
+function DialogDescription({ className, ...props }: DialogPrimitive.Description.Props) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn(
         "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -157,4 +131,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-}
+};

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -1,12 +1,12 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 
 function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -15,11 +15,11 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       role="group"
       className={cn(
         "group/input-group relative flex h-8 w-full min-w-0 items-center rounded-lg border border-input transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:bg-input/50 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-disabled:bg-input/80 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 const inputGroupAddonVariants = cva(
@@ -27,21 +27,18 @@ const inputGroupAddonVariants = cva(
   {
     variants: {
       align: {
-        "inline-start":
-          "order-first pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]",
-        "inline-end":
-          "order-last pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem]",
+        "inline-start": "order-first pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]",
+        "inline-end": "order-last pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem]",
         "block-start":
           "order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2",
-        "block-end":
-          "order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2",
+        "block-end": "order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2",
       },
     },
     defaultVariants: {
       align: "inline-start",
     },
-  }
-)
+  },
+);
 
 function InputGroupAddon({
   className,
@@ -56,32 +53,28 @@ function InputGroupAddon({
       className={cn(inputGroupAddonVariants({ align }), className)}
       onClick={(e) => {
         if ((e.target as HTMLElement).closest("button")) {
-          return
+          return;
         }
-        e.currentTarget.parentElement?.querySelector("input")?.focus()
+        e.currentTarget.parentElement?.querySelector("input")?.focus();
       }}
       {...props}
     />
-  )
+  );
 }
 
-const inputGroupButtonVariants = cva(
-  "flex items-center gap-2 text-sm shadow-none",
-  {
-    variants: {
-      size: {
-        xs: "h-6 gap-1 rounded-[calc(var(--radius)-3px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
-        sm: "",
-        "icon-xs":
-          "size-6 rounded-[calc(var(--radius)-3px)] p-0 has-[>svg]:p-0",
-        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
-      },
+const inputGroupButtonVariants = cva("flex items-center gap-2 text-sm shadow-none", {
+  variants: {
+    size: {
+      xs: "h-6 gap-1 rounded-[calc(var(--radius)-3px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+      sm: "",
+      "icon-xs": "size-6 rounded-[calc(var(--radius)-3px)] p-0 has-[>svg]:p-0",
+      "icon-sm": "size-8 p-0 has-[>svg]:p-0",
     },
-    defaultVariants: {
-      size: "xs",
-    },
-  }
-)
+  },
+  defaultVariants: {
+    size: "xs",
+  },
+});
 
 function InputGroupButton({
   className,
@@ -91,7 +84,7 @@ function InputGroupButton({
   ...props
 }: Omit<React.ComponentProps<typeof Button>, "size" | "type"> &
   VariantProps<typeof inputGroupButtonVariants> & {
-    type?: "button" | "submit" | "reset"
+    type?: "button" | "submit" | "reset";
   }) {
   return (
     <Button
@@ -101,7 +94,7 @@ function InputGroupButton({
       className={cn(inputGroupButtonVariants({ size }), className)}
       {...props}
     />
-  )
+  );
 }
 
 function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
@@ -109,50 +102,37 @@ function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
     <span
       className={cn(
         "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function InputGroupInput({
-  className,
-  ...props
-}: React.ComponentProps<"input">) {
+function InputGroupInput({ className, ...props }: React.ComponentProps<"input">) {
   return (
     <Input
       data-slot="input-group-control"
       className={cn(
         "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function InputGroupTextarea({
-  className,
-  ...props
-}: React.ComponentProps<"textarea">) {
+function InputGroupTextarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (
     <Textarea
       data-slot="input-group-control"
       className={cn(
         "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupText,
-  InputGroupInput,
-  InputGroupTextarea,
-}
+export { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupText, InputGroupTextarea };

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,16 +1,16 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+import type * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Popover({ ...props }: PopoverPrimitive.Root.Props) {
-  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
 function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
 function PopoverContent({
@@ -21,10 +21,7 @@ function PopoverContent({
   sideOffset = 4,
   ...props
 }: PopoverPrimitive.Popup.Props &
-  Pick<
-    PopoverPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  Pick<PopoverPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">) {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Positioner
@@ -38,53 +35,31 @@ function PopoverContent({
           data-slot="popover-content"
           className={cn(
             "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-            className
+            className,
           )}
           {...props}
         />
       </PopoverPrimitive.Positioner>
     </PopoverPrimitive.Portal>
-  )
+  );
 }
 
 function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="popover-header"
-      className={cn("flex flex-col gap-0.5 text-sm", className)}
-      {...props}
-    />
-  )
+  return <div data-slot="popover-header" className={cn("flex flex-col gap-0.5 text-sm", className)} {...props} />;
 }
 
 function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
-  return (
-    <PopoverPrimitive.Title
-      data-slot="popover-title"
-      className={cn("font-medium", className)}
-      {...props}
-    />
-  )
+  return <PopoverPrimitive.Title data-slot="popover-title" className={cn("font-medium", className)} {...props} />;
 }
 
-function PopoverDescription({
-  className,
-  ...props
-}: PopoverPrimitive.Description.Props) {
+function PopoverDescription({ className, ...props }: PopoverPrimitive.Description.Props) {
   return (
     <PopoverPrimitive.Description
       data-slot="popover-description"
       className={cn("text-muted-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
-export {
-  Popover,
-  PopoverContent,
-  PopoverDescription,
-  PopoverHeader,
-  PopoverTitle,
-  PopoverTrigger,
-}
+export { Popover, PopoverContent, PopoverDescription, PopoverHeader, PopoverTitle, PopoverTrigger };

--- a/src/lib/sentry-scrub.ts
+++ b/src/lib/sentry-scrub.ts
@@ -21,8 +21,8 @@ export const scrubServerEvent = (event: ErrorEvent): ErrorEvent => {
   if (!event.request) return event;
   delete event.request.cookies;
   if (event.request.headers) {
-    delete event.request.headers["authorization"];
-    delete event.request.headers["cookie"];
+    delete event.request.headers.authorization;
+    delete event.request.headers.cookie;
   }
   return event;
 };

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,5 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 
+import { supabaseUrl } from "./env";
+
 // Privileged Supabase client for server-side Storage operations
 // (signing, upload, delete). It authenticates with the secret key, so
 // it bypasses Storage RLS — consistent with how `db` connects as a
@@ -7,6 +9,11 @@ import { createClient } from "@supabase/supabase-js";
 // by placement and convention (like `src/server/db.ts`):
 // SUPABASE_SECRET_KEY is not a NEXT_PUBLIC var, so it never reaches the
 // client bundle. Do not import this into client code.
-export const supabaseAdmin = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SECRET_KEY!, {
+const secretKey = process.env.SUPABASE_SECRET_KEY;
+if (!secretKey) {
+  throw new Error("supabaseAdmin requires SUPABASE_SECRET_KEY to be set.");
+}
+
+export const supabaseAdmin = createClient(supabaseUrl, secretKey, {
   auth: { persistSession: false, autoRefreshToken: false },
 });

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,4 +1,5 @@
 import { createBrowserClient } from "@supabase/ssr";
 
-export const createClient = () =>
-  createBrowserClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!);
+import { supabasePublishableKey, supabaseUrl } from "./env";
+
+export const createClient = () => createBrowserClient(supabaseUrl, supabasePublishableKey);

--- a/src/lib/supabase/env.ts
+++ b/src/lib/supabase/env.ts
@@ -1,0 +1,19 @@
+// Validated Supabase connection values, shared by every Supabase client
+// (browser, server, middleware, Hono auth fallback).
+//
+// The `process.env.NEXT_PUBLIC_*` reads stay literal so Next.js still
+// inlines them into the client bundle at build time. The only thing
+// this module adds is a fail-fast, named error — instead of letting an
+// `undefined` flow into a Supabase client and surface as a confusing
+// failure much later.
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+
+if (!url || !publishableKey) {
+  throw new Error(
+    "Missing Supabase env vars: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY must be set.",
+  );
+}
+
+export const supabaseUrl = url;
+export const supabasePublishableKey = publishableKey;

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from "next/server";
 
 import { timed } from "@/lib/timing";
 
+import { supabasePublishableKey, supabaseUrl } from "./env";
 import { encodeUser, SUPABASE_USER_HEADER } from "./server-user";
 
 type CookieToSet = { name: string; value: string; options: Record<string, unknown> };
@@ -16,25 +17,21 @@ export const updateSession = async (request: NextRequest) => {
 
   const cookieUpdates: CookieToSet[] = [];
 
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll();
-        },
-        setAll(cookiesToSet) {
-          for (const c of cookiesToSet) {
-            // Mutate request.cookies so Server Components called later
-            // in this same render see the refreshed token.
-            request.cookies.set(c.name, c.value);
-            cookieUpdates.push(c);
-          }
-        },
+  const supabase = createServerClient(supabaseUrl, supabasePublishableKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        for (const c of cookiesToSet) {
+          // Mutate request.cookies so Server Components called later
+          // in this same render see the refreshed token.
+          request.cookies.set(c.name, c.value);
+          cookieUpdates.push(c);
+        }
       },
     },
-  );
+  });
 
   const {
     data: { user },

--- a/src/lib/supabase/server-user.ts
+++ b/src/lib/supabase/server-user.ts
@@ -11,8 +11,7 @@ import { createClient } from "@/lib/supabase/server";
 // second supabase.auth.getUser() round-trip.
 export const SUPABASE_USER_HEADER = "x-supabase-user";
 
-export const encodeUser = (user: User): string =>
-  Buffer.from(JSON.stringify(user), "utf8").toString("base64");
+export const encodeUser = (user: User): string => Buffer.from(JSON.stringify(user), "utf8").toString("base64");
 
 export const decodeUser = (encoded: string | null | undefined): User | null => {
   if (!encoded) return null;

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,28 +1,26 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
+import { supabasePublishableKey, supabaseUrl } from "./env";
+
 export const createClient = async () => {
   const cookieStore = await cookies();
 
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll();
-        },
-        setAll(cookiesToSet) {
-          try {
-            cookiesToSet.forEach(({ name, value, options }) => {
-              cookieStore.set(name, value, options);
-            });
-          } catch {
-            // Called from a Server Component — safe to ignore if
-            // middleware is refreshing sessions.
-          }
-        },
+  return createServerClient(supabaseUrl, supabasePublishableKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            cookieStore.set(name, value, options);
+          });
+        } catch {
+          // Called from a Server Component — safe to ignore if
+          // middleware is refreshing sessions.
+        }
       },
     },
-  );
+  });
 };

--- a/src/lib/timing.ts
+++ b/src/lib/timing.ts
@@ -8,14 +8,9 @@
 // boolean check. The helper is meant to stay in the codebase so we
 // don't have to re-instrument every time something feels slow.
 
-const enabled = (request: { headers: Headers }): boolean =>
-  request.headers.get("x-debug-timing") === "1";
+const enabled = (request: { headers: Headers }): boolean => request.headers.get("x-debug-timing") === "1";
 
-export const timed = async <T>(
-  request: { headers: Headers },
-  label: string,
-  fn: () => Promise<T>,
-): Promise<T> => {
+export const timed = async <T>(request: { headers: Headers }, label: string, fn: () => Promise<T>): Promise<T> => {
   if (!enabled(request)) return fn();
   const start = performance.now();
   try {

--- a/src/lib/use-profile-form.ts
+++ b/src/lib/use-profile-form.ts
@@ -69,7 +69,15 @@ export function useProfileForm(initial: ProfileFormValues) {
 
   return {
     fields: { displayName, bio, keywordsText, location, supplementaryInfo, emergencyContact, liveDesire },
-    setters: { setDisplayName, setBio, setKeywordsText, setLocation, setSupplementaryInfo, setEmergencyContact, setLiveDesire },
+    setters: {
+      setDisplayName,
+      setBio,
+      setKeywordsText,
+      setLocation,
+      setSupplementaryInfo,
+      setEmergencyContact,
+      setLiveDesire,
+    },
     status,
     setStatus,
     submit,

--- a/src/server/auth-middleware.ts
+++ b/src/server/auth-middleware.ts
@@ -3,6 +3,7 @@ import type { User } from "@supabase/supabase-js";
 import { eq } from "drizzle-orm";
 import type { MiddlewareHandler } from "hono";
 
+import { supabasePublishableKey, supabaseUrl } from "@/lib/supabase/env";
 import { decodeUser, SUPABASE_USER_HEADER } from "@/lib/supabase/server-user";
 
 import { db } from "./db";
@@ -79,16 +80,12 @@ export const requireAuth: MiddlewareHandler<{ Variables: ApiVariables }> = async
     // path that still routes through requireAuth.
     const cookies = parseCookieHeader(c.req.raw.headers.get("cookie"));
 
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!,
-      {
-        cookies: {
-          getAll: () => cookies,
-          setAll: () => {},
-        },
+    const supabase = createServerClient(supabaseUrl, supabasePublishableKey, {
+      cookies: {
+        getAll: () => cookies,
+        setAll: () => {},
       },
-    );
+    });
 
     const {
       data: { user: fetched },

--- a/src/server/avatars.ts
+++ b/src/server/avatars.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-
 import { eq } from "drizzle-orm";
 import sharp from "sharp";
 
@@ -110,10 +109,7 @@ export const replaceAvatar = async (userId: string, webp: Buffer): Promise<strin
     .upload(path, webp, { contentType: "image/webp", upsert: false });
   if (uploadError) throw uploadError;
 
-  const [existing] = await db
-    .select({ avatarPath: profiles.avatarPath })
-    .from(profiles)
-    .where(eq(profiles.id, userId));
+  const [existing] = await db.select({ avatarPath: profiles.avatarPath }).from(profiles).where(eq(profiles.id, userId));
   // Single autocommit statement — safe on the transaction pooler.
   await db.update(profiles).set({ avatarPath: path }).where(eq(profiles.id, userId));
 
@@ -126,10 +122,7 @@ export const replaceAvatar = async (userId: string, webp: Buffer): Promise<strin
 
 // Clears a user's avatar: nulls the column, then removes the object.
 export const clearAvatar = async (userId: string): Promise<void> => {
-  const [existing] = await db
-    .select({ avatarPath: profiles.avatarPath })
-    .from(profiles)
-    .where(eq(profiles.id, userId));
+  const [existing] = await db.select({ avatarPath: profiles.avatarPath }).from(profiles).where(eq(profiles.id, userId));
   if (!existing?.avatarPath) return;
 
   await db.update(profiles).set({ avatarPath: null }).where(eq(profiles.id, userId));

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -16,7 +16,7 @@ const connectionString =
 // globalThis branch is bypassed, so a single fresh client is created
 // once at process start as usual.
 declare global {
-  // biome-ignore lint: globalThis augmentation requires `var`
+  // globalThis augmentation requires `var` — `let`/`const` don't declare a global.
   var __pgClient: ReturnType<typeof postgres> | undefined;
 }
 

--- a/src/server/relations.ts
+++ b/src/server/relations.ts
@@ -18,7 +18,7 @@ import { isRelationValue, type RelationValue } from "@/lib/relation-value";
 import { isUuid } from "./auth-middleware";
 import { attachAvatarUrls } from "./avatars";
 import { db } from "./db";
-import { inviteHints, invites, profiles, relations } from "./schema";
+import { inviteHints, profiles, relations } from "./schema";
 
 // Validates the optional `relationValue` body field shared by POST
 // /api/invites and any future route that accepts an optional 1..4.
@@ -548,14 +548,8 @@ export const validateInviteHints = async (params: {
 
 // Tx | typeof db lets the materializer run inside the auth-callback
 // transaction or, in tests, directly against the connection.
-type Tx = PgTransaction<
-  // biome-ignore lint/suspicious/noExplicitAny: Drizzle's published
-  // postgres-js transaction type is genuinely `PgTransaction<any, any, any>`
-  // for consumers; the wide generic surface is unavoidable here.
-  any,
-  any,
-  any
->;
+// biome-ignore lint/suspicious/noExplicitAny: Drizzle's published postgres-js transaction type is genuinely `PgTransaction<any, any, any>` for consumers; the wide generic surface is unavoidable here.
+type Tx = PgTransaction<any, any, any>;
 
 export const materializeInviteRelations = async (
   tx: Tx | typeof db,

--- a/tests/e2e/avatar.spec.ts
+++ b/tests/e2e/avatar.spec.ts
@@ -51,7 +51,5 @@ test("a member can upload, crop, and see their profile picture", async ({ page }
   await page.goto("/profile");
   const avatarImg = page.locator("main img").first();
   await expect(avatarImg).toBeVisible();
-  await expect
-    .poll(() => avatarImg.evaluate((el) => (el as HTMLImageElement).naturalWidth))
-    .toBeGreaterThan(0);
+  await expect.poll(() => avatarImg.evaluate((el) => (el as HTMLImageElement).naturalWidth)).toBeGreaterThan(0);
 });

--- a/tests/e2e/invites.spec.ts
+++ b/tests/e2e/invites.spec.ts
@@ -103,7 +103,7 @@ test.describe("/signup — unauthed invite flow", () => {
       await memberPage.getByRole("button", { name: "Create invite" }).click();
       const codeLocator = memberPage.locator("code").first();
       await expect(codeLocator).toHaveText(/^[A-HJ-NP-Z2-9]{10}$/);
-      code = (await codeLocator.textContent())!.trim();
+      code = ((await codeLocator.textContent()) ?? "").trim();
     } finally {
       await memberContext.close();
     }

--- a/tests/functional/sentry-scrub.test.ts
+++ b/tests/functional/sentry-scrub.test.ts
@@ -86,8 +86,8 @@ describe("scrubServerEvent", () => {
     const result = scrubServerEvent(event);
 
     expect(result.request?.cookies).toBeUndefined();
-    expect(result.request?.headers?.["authorization"]).toBeUndefined();
-    expect(result.request?.headers?.["cookie"]).toBeUndefined();
+    expect(result.request?.headers?.authorization).toBeUndefined();
+    expect(result.request?.headers?.cookie).toBeUndefined();
   });
 
   it("preserves non-sensitive headers", () => {

--- a/tests/functional/server/admin.test.ts
+++ b/tests/functional/server/admin.test.ts
@@ -126,7 +126,9 @@ describe("GET /api/admin/hints", () => {
     authAs(admin);
     const res = await app.request("/api/admin/hints");
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { hints: Array<{ relator: { id: string }; relatee: { id: string }; hintedBy: { id: string } | null }> };
+    const body = (await res.json()) as {
+      hints: Array<{ relator: { id: string }; relatee: { id: string }; hintedBy: { id: string } | null }>;
+    };
     // The endpoint lists every pending hint in the DB, so other rows
     // (from parallel test files or stale local-dev state) may appear.
     // Filter to this test's seeded UUIDs before asserting.

--- a/tests/functional/server/api-me.test.ts
+++ b/tests/functional/server/api-me.test.ts
@@ -185,7 +185,7 @@ describe("PUT /api/me/last-updated-web", () => {
 
     const [row] = await db.select().from(profiles).where(eq(profiles.id, testUserId));
     expect(row.lastUpdatedWeb).not.toBeNull();
-    expect(row.lastUpdatedWeb!.getTime()).toBeGreaterThanOrEqual(before.getTime() - 1000);
+    expect(row.lastUpdatedWeb?.getTime() ?? 0).toBeGreaterThanOrEqual(before.getTime() - 1000);
   });
 
   it("re-clicking Done bumps the timestamp forward", async () => {
@@ -196,6 +196,6 @@ describe("PUT /api/me/last-updated-web", () => {
     await app.request("/api/me/last-updated-web", { method: "PUT" });
     const [second] = await db.select().from(profiles).where(eq(profiles.id, testUserId));
 
-    expect(second.lastUpdatedWeb!.getTime()).toBeGreaterThan(first.lastUpdatedWeb!.getTime());
+    expect(second.lastUpdatedWeb?.getTime() ?? 0).toBeGreaterThan(first.lastUpdatedWeb?.getTime() ?? 0);
   });
 });

--- a/tests/functional/server/profiles.test.ts
+++ b/tests/functional/server/profiles.test.ts
@@ -88,7 +88,7 @@ describe("getProfileForSelf", () => {
     // future refactors and locks in emergencyContact visibility for
     // self. Programs are deliberately NOT a profile field.
     expect(profile).not.toBeNull();
-    expect(Object.keys(profile!).sort()).toEqual(
+    expect(Object.keys(profile ?? {}).sort()).toEqual(
       [
         "id",
         "displayName",
@@ -131,7 +131,7 @@ describe("getProfileForMember", () => {
     const profile = await getProfileForMember(memberId);
     expect(profile).not.toBeNull();
     expect(profile?.displayName).toBe("Test Member");
-    expect(Object.keys(profile!).sort()).toEqual(
+    expect(Object.keys(profile ?? {}).sort()).toEqual(
       [
         "id",
         "slug",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,19 +19,9 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    ".next/types/**/*.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx", ".next/dev/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
+import path from "node:path";
 import react from "@vitejs/plugin-react";
-import path from "path";
 import { defineConfig } from "vitest/config";
 
 const alias = { "@": path.resolve(__dirname, "./src") };


### PR DESCRIPTION
## What

Repo-wide Biome cleanup. Lint warnings: **36 (+7 infos) → 0 (+1 config info)**.

## Formatter

Ran `biome check --write` across the repo. CI runs `biome lint` but never a format check, so files had drifted from `biome.json` (lineWidth 120, semicolons, import ordering). Much of this diff is that reformat — collapsed wrapped lines, semicolons added to the shadcn UI components, sorted imports. **No logic changes.**

## Lint fixes

| Fix | Rule |
|---|---|
| Repositioned a mis-placed `biome-ignore` so it actually suppresses the 3 `any`s in `relations.ts`'s `Tx` type | `noExplicitAny` |
| Dropped an unused `invites` import | `noUnusedImports` |
| `["authorization"]` → `.authorization` | `useLiteralKeys` |
| `"path"` → `"node:path"` | `useNodejsImportProtocol` |
| Merged a string concatenation | `useTemplate` |
| Inert `biome-ignore` in `db.ts` → plain comment (kept the rationale) | `suppressions/unused` |
| `x!` → `x?.… ?? fallback` in test files | `noNonNullAssertion` |

## `noNonNullAssertion` — taken to zero, then promoted to `error`

- **New `src/lib/supabase/env.ts`** validates the shared Supabase URL + publishable key once and fails fast with a named error. The browser/server/middleware/Hono-auth clients import the validated values. The `process.env.NEXT_PUBLIC_*` reads stay literal, so Next.js still inlines them into the client bundle.
- `admin.ts` and `drizzle.config.ts` get local guards for their own env vars.
- The profile pages guard `me.profile` instead of asserting it.
- `noNonNullAssertion` is turned **off for `tests/**` and `scripts/**`** in `biome.json` — `!` after an assertion or in a one-off script is not worth churning.
- With the count at zero, the rule is **promoted from warning to `error`** — a new `!` now fails CI instead of accumulating as another ignored warning.

## Verification

Full `npm test` green: lint (0 warnings/errors), typecheck, functional, 23 e2e.

## Follow-up suggestion

Adding a `biome check` (format) step to `ci.yml` would stop the format drift recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)