### PR TITLE
Let admins delete programs that have no participants

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -6,7 +6,7 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ## 2026-05-18 | James | Program administration
 
-Admins manage programs at `/admin/programs`, with a per-program drill-down for editing and adding/removing participants. Deleting a program is intentionally out of scope.
+Admins manage programs at `/admin/programs`, with a per-program drill-down for editing and adding/removing participants.
 
 ## 2026-05-18 | James | Schema additions go through prod:db:expand
 

--- a/src/app/admin/programs/[id]/program-detail.tsx
+++ b/src/app/admin/programs/[id]/program-detail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { Avatar } from "@/components/avatar";
@@ -50,11 +51,14 @@ export function ProgramDetail({ programId }: { programId: string }) {
 
 function ProgramEditor({ program }: { program: AdminProgramDetail }) {
   const queryClient = useQueryClient();
+  const router = useRouter();
   const [name, setName] = useState(program.name);
   const [slug, setSlug] = useState(program.slug);
   const [description, setDescription] = useState(program.description ?? "");
   const [editError, setEditError] = useState<string | null>(null);
   const [participantError, setParticipantError] = useState<string | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const invalidate = () => queryClient.invalidateQueries({ queryKey: programQueryKey(program.id) });
 
@@ -128,6 +132,33 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
     },
   });
 
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      const res = await apiClient.api.admin.programs[":id"].$delete({
+        param: { id: program.id },
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(
+          body.error === "has_participants"
+            ? "Remove every participant before deleting this program."
+            : (body.error ?? `admin/programs DELETE: ${res.status}`),
+        );
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      // The list cache still holds the deleted program; drop it, then
+      // leave the now-dead detail page for the programs list.
+      queryClient.invalidateQueries({ queryKey: ["admin", "programs"] });
+      router.push("/admin/programs");
+    },
+    onError: (err) => {
+      setDeleteError(err instanceof Error ? err.message : "Failed to delete program.");
+      setConfirmingDelete(false);
+    },
+  });
+
   const trimmedName = name.trim();
   const trimmedSlug = slug.trim();
   const dirty =
@@ -152,6 +183,7 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
   };
 
   const participantIds = program.participants.map((p) => p.id);
+  const hasParticipants = program.participants.length > 0;
 
   return (
     <div className="flex w-full max-w-xl flex-col gap-6">
@@ -242,6 +274,53 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
               </li>
             ))}
           </ul>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3 rounded border border-destructive/40 p-3">
+        <h2 className="text-base font-semibold uppercase tracking-wide text-muted-foreground">Delete program</h2>
+        <p className="text-sm text-muted-foreground">
+          {hasParticipants
+            ? "Remove every participant before deleting. Programs in real use will get a dedicated retire flow later."
+            : "Permanently deletes this empty program. This can't be undone."}
+        </p>
+        {confirmingDelete ? (
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={deleteMutation.isPending}
+              onClick={() => deleteMutation.mutate()}
+            >
+              {deleteMutation.isPending ? "Deleting…" : "Yes, delete program"}
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={deleteMutation.isPending}
+              onClick={() => setConfirmingDelete(false)}
+            >
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={hasParticipants}
+            onClick={() => {
+              setDeleteError(null);
+              setConfirmingDelete(true);
+            }}
+            className="self-start"
+          >
+            Delete program
+          </Button>
+        )}
+        {deleteError && (
+          <p role="alert" className="text-sm text-destructive">
+            {deleteError}
+          </p>
         )}
       </section>
     </div>

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -22,6 +22,7 @@ import {
 import {
   addParticipant,
   createProgram,
+  deleteProgram,
   getProgramDetail,
   joinProgram,
   leaveProgram,
@@ -100,6 +101,13 @@ const adminRoutes = new Hono<{ Variables: ApiVariables }>()
       return c.json({ ok: true });
     },
   )
+  .delete("/programs/:id", async (c) => {
+    const result = await deleteProgram(c.req.param("id"));
+    if ("error" in result) {
+      return c.json({ error: result.error }, result.error === "not_found" ? 404 : 409);
+    }
+    return c.json({ ok: true });
+  })
   .post(
     "/programs/:id/participants",
     validator("json", (body, c) => {

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, ne, sql } from "drizzle-orm";
+import { and, asc, eq, ne, notExists, sql } from "drizzle-orm";
 
 import { isUuid } from "./auth-middleware";
 import { attachAvatarUrls } from "./avatars";
@@ -102,8 +102,9 @@ export const leaveProgram = async (
 // --- Admin program administration (issue #139) ---------------------
 //
 // The functions above are member-facing: browse, join, leave. Below is
-// the admin surface — create/edit programs and manage who is enrolled.
-// Deleting a program is intentionally out of scope.
+// the admin surface — create/edit programs, manage who is enrolled, and
+// delete empty programs. Programs with participants are kept; a richer
+// "retire" flow for live programs comes later.
 
 export type AdminProgram = {
   id: string;
@@ -354,6 +355,39 @@ export const addParticipant = async (
 
   if (result.length === 0) return { error: "already_member" };
   return { ok: true };
+};
+
+// Deletes a program only while it has no participants — the guardrail
+// for clearing out test data and mistakes without touching live ones.
+// The "no participants" check rides on the DELETE as a NOT EXISTS
+// subquery so it's atomic: a join landing between a separate check and
+// the delete can't slip a participant past the FK cascade.
+export const deleteProgram = async (
+  programId: string,
+): Promise<{ ok: true } | { error: "not_found" | "has_participants" }> => {
+  if (!isUuid(programId)) return { error: "not_found" };
+
+  const deleted = await db
+    .delete(programs)
+    .where(
+      and(
+        eq(programs.id, programId),
+        notExists(
+          db
+            .select({ one: sql`1` })
+            .from(profilePrograms)
+            .where(eq(profilePrograms.programId, programId)),
+        ),
+      ),
+    )
+    .returning({ id: programs.id });
+
+  if (deleted.length > 0) return { ok: true };
+
+  // Nothing deleted: the program is either gone or still has
+  // participants. Re-read to tell 404 apart from 409 for the caller.
+  const [program] = await db.select({ id: programs.id }).from(programs).where(eq(programs.id, programId));
+  return program ? { error: "has_participants" } : { error: "not_found" };
 };
 
 export const removeParticipant = async (

--- a/tests/functional/server/admin-programs.test.ts
+++ b/tests/functional/server/admin-programs.test.ts
@@ -242,6 +242,58 @@ describe("Admin programs API", () => {
     });
   });
 
+  describe("DELETE /api/admin/programs/:id", () => {
+    const del = (id: string) => app.request(`/api/admin/programs/${id}`, { method: "DELETE" });
+
+    it("deletes a program that has no participants", async () => {
+      const programId = await seedProgram("Disposable Program");
+
+      authAs(admin);
+      const res = await del(programId);
+      expect(res.status).toBe(200);
+
+      const rows = await db.select().from(programs).where(eq(programs.id, programId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("returns 409 and leaves the program intact when it has participants", async () => {
+      const programId = await seedProgram("Occupied Program");
+      await db.insert(profilePrograms).values({ profileId: member, programId });
+
+      authAs(admin);
+      const res = await del(programId);
+      expect(res.status).toBe(409);
+      expect((await res.json()) as { error: string }).toEqual({ error: "has_participants" });
+
+      // The program and the enrollment both survive a rejected delete.
+      const rows = await db.select().from(programs).where(eq(programs.id, programId));
+      expect(rows).toHaveLength(1);
+      const enrolled = await db
+        .select()
+        .from(profilePrograms)
+        .where(eq(profilePrograms.programId, programId));
+      expect(enrolled).toHaveLength(1);
+    });
+
+    it("returns 404 for a non-existent program", async () => {
+      authAs(admin);
+      const res = await del(randomUUID());
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 404 for a non-admin", async () => {
+      const programId = await seedProgram("Guarded Delete Program");
+
+      authAs(nonAdmin);
+      const res = await del(programId);
+      expect(res.status).toBe(404);
+
+      // The guard rejects before any delete runs.
+      const rows = await db.select().from(programs).where(eq(programs.id, programId));
+      expect(rows).toHaveLength(1);
+    });
+  });
+
   describe("POST /api/admin/programs/:id/participants", () => {
     const addParticipant = (programId: string, profileId: string) =>
       app.request(`/api/admin/programs/${programId}/participants`, {


### PR DESCRIPTION
A robustness add-on to #139 (program administration): admins can delete a program from its `/admin/programs/[id]` detail page, but **only while it has no participants**. The intent is clearing test data and mistakes — live programs will get a dedicated "retire" flow later.

## Changes

- **`src/server/programs.ts`** — new `deleteProgram(programId)`. The "no participants" check rides on the `DELETE` itself as a `NOT EXISTS` subquery, so the guarantee is atomic: a join landing between a separate check and the delete can't slip a participant past the FK cascade. Returns `not_found` or `has_participants`.
- **`src/server/api.ts`** — new `DELETE /api/admin/programs/:id` → `200` ok, `404` not_found, `409` has_participants. Sits under the existing `requireAdmin` guard.
- **`src/app/admin/programs/[id]/program-detail.tsx`** — a "Delete program" section. The button is disabled while participants exist (with an explanatory line), and otherwise gated behind a two-click confirm. On success it invalidates the list cache and routes back to `/admin/programs`.
- **`tests/functional/server/admin-programs.test.ts`** — 4 tests: deletes an empty program, `409` + intact state when occupied, `404` missing, `404` non-admin.
- **`docs/devjournal.md`** — drops the now-false "deletion is out of scope" line from the 2026-05-18 entry.

## Testing

`npm test` green locally — 174 functional + 25 e2e. e2e suite untouched: `admin.spec.ts` is deliberately smoke-only and defers program-admin behavior to the functional tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)