### PR TITLE
Add 2-day cooldown to Dependabot github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    # Shorter than npm's 3 days: Actions bumps are lower-volume and
+    # tag-pinned, but a brief bake window still catches a freshly-published
+    # tag that gets retagged or yanked.
+    cooldown:
+      default-days: 2


### PR DESCRIPTION
Mirrors the npm side's cooldown at a shorter window. Actions bumps are lower-volume and tag-pinned, but a brief bake still catches a freshly-published tag that gets retagged or yanked.

Context: spot-checked PR #228 (npm minor-and-patch group) and confirmed the 3-day npm cooldown is working — Dependabot held back hono 4.12.20/21 (published ~14h before the PR opened) in favor of 4.12.19. The github-actions block had no cooldown at all, so this closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)