### PR TITLE
Add #149 probe — MVCC + Supavisor backend instrumentation on GET /me

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -13,11 +13,14 @@ import { checkInvite, createInvite, getInvitesForCreator, revokeInvite, validate
 import {
   getProfileForMember,
   getProfileForSelf,
+  getProfileForSelfWithProbe,
   listMembers,
   markAgreementsSigned,
   markProgramsReviewed,
   markWebUpdated,
   parseEditableProfile,
+  type ProfileForSelf,
+  type ProfileReadProbe,
   toSlug,
   upsertProfile,
 } from "./profiles";
@@ -155,14 +158,40 @@ const api = new Hono<{ Variables: ApiVariables }>()
   })
   .get("/me", async (c) => {
     const user = c.get("user");
+    const debug = c.req.header("x-debug-timing") === "1";
 
-    let profile = await getProfileForSelf(user.id);
+    // #149 diagnostic: on debug-flagged requests, the read returns
+    // MVCC + connection metadata in the same statement, logged below
+    // so a failing welcome-flow trace can be cross-referenced with the
+    // backend the read landed on. Production traffic stays on the
+    // plain variant. Remove with the probe code once #149 is closed.
+    const load = async (): Promise<{ profile: ProfileForSelf | null; probe: ProfileReadProbe | null }> => {
+      if (debug) return getProfileForSelfWithProbe(user.id);
+      return { profile: await getProfileForSelf(user.id), probe: null };
+    };
+
+    let { profile, probe } = await load();
+    let stage: "initial" | "after-upsert" = "initial";
     if (!profile) {
       // Self-heal: profiles are normally inserted by /auth/callback
       // during sign-in. If that upsert failed but the session still
       // landed, the next authed request creates the row here.
       await upsertProfile(user);
-      profile = await getProfileForSelf(user.id);
+      ({ profile, probe } = await load());
+      stage = "after-upsert";
+    }
+
+    if (debug) {
+      console.log(
+        `[probe-149] route=me stage=${stage} user=${user.id} ` +
+          `bio=${JSON.stringify(profile?.bio ?? null)} ` +
+          `agreements=${profile?.lastSignedAgreements ? "set" : "null"} ` +
+          `profile=${profile?.lastUpdatedProfile ? "set" : "null"} ` +
+          `programs=${profile?.lastReviewedPrograms ? "set" : "null"} ` +
+          `ctid=${probe?.ctid ?? ""} xmin=${probe?.xmin ?? ""} ` +
+          `inRecovery=${probe?.inRecovery ?? ""} ` +
+          `serverAddr=${probe?.serverAddr ?? ""} backendPid=${probe?.backendPid ?? ""}`,
+      );
     }
 
     return c.json({ id: user.id, email: user.email, profile });

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -136,6 +136,88 @@ export const getProfileForSelf = async (userId: string): Promise<ProfileForSelf 
   return profile;
 };
 
+// MVCC + connection metadata captured alongside a profile read. Logged
+// at the GET /me call site when the `x-debug-timing` debug header is
+// on, to diagnose #149: a welcome-flow read intermittently sees an
+// older snapshot of the same row a moments-earlier read saw populated.
+// xmin pins the txid of the visible tuple — different xmin across two
+// reads of the same row identifies a stale-snapshot read; inRecovery /
+// serverAddr / backendPid describe the Postgres backend the read
+// landed on, so we can tell whether requests scatter across Supavisor
+// backends or stick. Remove once #149 is closed.
+export type ProfileReadProbe = {
+  ctid: string;
+  xmin: string;
+  inRecovery: boolean;
+  serverAddr: string | null;
+  backendPid: number;
+};
+
+// Same SELECT as getProfileForSelf with the probe columns appended in
+// the same statement so the metadata unambiguously describes the
+// connection that served *this* read. Production GET /me still uses
+// the plain variant; this one runs only when the debug header is set.
+export const getProfileForSelfWithProbe = async (
+  userId: string,
+): Promise<{ profile: ProfileForSelf | null; probe: ProfileReadProbe | null }> => {
+  const [row] = await db
+    .select({
+      id: profiles.id,
+      displayName: profiles.displayName,
+      bio: profiles.bio,
+      keywords: profiles.keywords,
+      location: profiles.location,
+      supplementaryInfo: profiles.supplementaryInfo,
+      referredBy: profiles.referredBy,
+      referredByLegacy: profiles.referredByLegacy,
+      avatarPath: profiles.avatarPath,
+      emergencyContact: profiles.emergencyContact,
+      liveDesire: profiles.liveDesire,
+      isAdmin: profiles.isAdmin,
+      lastSignedAgreements: profiles.lastSignedAgreements,
+      lastUpdatedProfile: profiles.lastUpdatedProfile,
+      lastReviewedPrograms: profiles.lastReviewedPrograms,
+      lastUpdatedWeb: profiles.lastUpdatedWeb,
+      createdAt: profiles.createdAt,
+      updatedAt: profiles.updatedAt,
+      __ctid: sql<string>`ctid::text`,
+      __xmin: sql<string>`xmin::text`,
+      __inRecovery: sql<boolean>`pg_is_in_recovery()`,
+      __serverAddr: sql<string | null>`inet_server_addr()::text`,
+      __backendPid: sql<number>`pg_backend_pid()`,
+    })
+    .from(profiles)
+    .where(eq(profiles.id, userId));
+
+  if (!row) {
+    // No row — capture connection identity from a separate metadata
+    // query so callers still get backend info for missing-profile
+    // requests. May land on a different backend than the missing read.
+    const [meta] = (await db.execute(sql`
+      SELECT pg_is_in_recovery() AS "inRecovery",
+             inet_server_addr()::text AS "serverAddr",
+             pg_backend_pid() AS "backendPid"
+    `)) as unknown as { inRecovery: boolean; serverAddr: string | null; backendPid: number }[];
+    return {
+      profile: null,
+      probe: meta ? { ctid: "", xmin: "", ...meta } : null,
+    };
+  }
+
+  const { __ctid, __xmin, __inRecovery, __serverAddr, __backendPid, ...rest } = row;
+  const [profile] = await attachAvatarUrls([rest]);
+  return {
+    profile,
+    probe: {
+      ctid: __ctid,
+      xmin: __xmin,
+      inRecovery: __inRecovery,
+      serverAddr: __serverAddr,
+      backendPid: __backendPid,
+    },
+  };
+};
+
 // Bumps lastUpdatedWeb to now() on the user's profile. The Done button
 // at the bottom of /myweb is the only caller — clicking it captures
 // "I'm done updating my relations for now" and surfaces the user in

--- a/src/server/test-reset.ts
+++ b/src/server/test-reset.ts
@@ -112,5 +112,18 @@ export const resetE2EUsers = async (): Promise<{
     }),
   );
 
+  // #149 baseline: log the probe data on every successful reset (not
+  // only on the anomaly throw in tests/e2e/helpers/session.ts), so
+  // Vercel function logs accumulate a per-run record of which Supavisor
+  // backend the reset's read-back landed on. Across enough runs we can
+  // tell whether reads scatter across backends or stick, and spot any
+  // run where inRecovery or serverAddr drifts from the steady state.
+  console.log(
+    `[probe-149] route=reset users=${users.length} updatedIds=${JSON.stringify(updatedIds)} ` +
+      profilesAfter
+        .map((p) => `${p.email}=${JSON.stringify(p.rows.map((r) => ({ ctid: r.ctid, xmin: r.xmin, bio: r.bio, inRecovery: r.inRecovery, serverAddr: r.serverAddr, backendPid: r.backendPid })))}`)
+        .join(" "),
+  );
+
   return { reset: users.length, updatedIds, profiles: profilesAfter };
 };


### PR DESCRIPTION
Captures per-read MVCC + connection metadata for the welcome-flow's `GET /me` reads, so the next #149 failure can be attributed to the backend that served it. Closes the diagnostic gap that the existing reset probe left: the reset probe only describes the connection the reset's read-back landed on, never the connections used by the actual welcome-flow reads later in the test.

### Why now

Latest #149 trace ([comment](https://github.com/Intentional-Society/is-app/issues/149#issuecomment-4501764882)) ruled out write loss: the `markAgreementsSigned` write was provably visible to one read, then provably invisible to a later read of the same row, with nothing in app code touching the column between them. The clean architectural explanation — Supavisor routing reads to read replicas — was ruled out by confirming the project has no replicas configured. We're left with less-elegant candidates (Supavisor backend-state pollution, HA-standby quirks, postgres-js pool stuck connection) and can't reason our way to the answer; the next move is direct evidence on the next natural failure.

### What this changes

- `getProfileForSelfWithProbe()` — sibling of `getProfileForSelf`, same SELECT with `ctid`, `xmin`, `pg_is_in_recovery()`, `inet_server_addr()`, `pg_backend_pid()` appended as `sql<T>` columns. Metadata is from the read's actual statement, not a separate roundtrip (critical: a separate statement under the transaction pooler can land on a different backend).
- `GET /me` checks `x-debug-timing === "1"`; when set, uses the probe variant and emits a `[probe-149] route=me ...` line per request. Plain `getProfileForSelf` still serves production traffic.
- `resetE2EUsers` logs its probe data on every successful run, not only on the anomaly throw, so logs accumulate a baseline of connection variability across CI runs.

The `x-debug-timing` header is already set by Playwright on every test request, so CI runs emit the probe data automatically with no config change.

### What to look for on a failing run

```
vercel logs <preview-url> --no-follow --since 1h --query "[probe-149]" --expand
```

Two welcome-flow `GET /me` reads bracketing the failing `completeWelcome`:

- **Different `xmin` on the same row** → a backend served a stale snapshot of the primary; that's the read-side cousin of the Supavisor transaction-pooler issues.
- **Same `xmin` with the field flipped** → a writer we haven't named yet; deeper bug.
- **`inRecovery=true` ever** → some connection landed on a non-primary backend (with no user replicas configured, this would be unexpected; HA-standby quirk).
- **`backendPid` / `serverAddr` scatter** across the two reads → Supavisor multiplexing, expected; but if both fall on the same backend and still disagree, the bug is below the pooler.

### Removal

Remove with the probe code once #149 is closed. Search for `[probe-149]` to find the call sites.

### Testing

- `npm run lint` — clean.
- `npx tsc --noEmit` — clean.
- `npm run test:functional` — 182/182 passed.
- `npm run test:e2e` — 25/25 passed (locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)