### PR TITLE
Wire dismiss-alerts into CodeQL so // lgtm[…] markers close alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,28 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL analysis
+        id: analyze
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
+          # Write SARIF to a known path so the dismiss-alerts step can
+          # read the in-source suppression markers (see below).
+          output: sarif-results
+
+      # Closes alerts whose source lines carry a `// lgtm[<rule>]` or
+      # `// codeql[<rule>]` suppression marker. CodeQL parses those
+      # markers into the SARIF `suppressions[]` field, but the standard
+      # codeql-action pipeline does not act on them — this step does.
+      # Guarded to main because dismissals are a repo-global property:
+      # running on a PR or feature branch would dismiss main's alerts
+      # based on unmerged code.
+      - name: Dismiss alerts marked suppressed in SARIF
+        if: github.ref == 'refs/heads/main'
+        # v2.0.2 — GitHub-owned but in the advanced-security org
+        # rather than github/, so SHA-pin to lock the version.
+        uses: advanced-security/dismiss-alerts@046d6b48d2e43cf563f96f67332c47c432eff83e
+        with:
+          sarif-id: ${{ steps.analyze.outputs.sarif-id }}
+          sarif-file: sarif-results/${{ matrix.language }}.sarif
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Adds an `advanced-security/dismiss-alerts` step after the CodeQL `analyze` step. CodeQL already parses `// lgtm[<rule>]` and `// codeql[<rule>]` markers into the SARIF `suppressions[]` field; this step reads the same SARIF and PATCHes the matching alerts to "won't fix / Suppressed via SARIF" so the in-source markers actually do something visible in the Security tab.
- Guarded to `github.ref == 'refs/heads/main'` because dismissals are a repo-global property — PR runs would otherwise dismiss main's alerts based on unmerged code. The weekly schedule still benefits.
- Action pinned to v2.0.2's commit SHA (`046d6b48`). The `advanced-security` org is GitHub-owned but separate from `github/`, so the pin locks the version and side-steps the `actions/unpinned-tag` rule's allowlist question.

## Follow-up (not in this PR)

`scripts/update-email-templates.mjs` has a `// lgtm[js/file-access-to-http]` marker at end-of-line that (a) only covers one of the three open rules on that file and (b) per the dismiss-alerts README, end-of-line placement can briefly flutter the alert. Once this PR lands and we confirm the workflow actually dismisses something, I'll move the markers to the line above and add coverage for `js/http-to-file-access`.

## Test plan

- [ ] Merge → confirm the CodeQL run on `main` produces a "Dismiss alerts marked suppressed in SARIF" step that completes successfully.
- [ ] Verify alerts #16/#17/#18 (`scripts/update-email-templates.mjs`) close automatically once the follow-up markers land — they're our canary that the wiring actually works end-to-end.
- [ ] Check the run does NOT execute on PR branches (the `if:` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)