### PR TITLE
Hide test accounts via profiles.hidden (#168)

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -6,7 +6,7 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ## 2026-05-20 | James | Hidden accounts
 
-Admins can hide a profile from the `/admin` page; hidden profiles disappear from the directory, member profile pages, the suggestion feed, the personal web, and the invite-hint typeahead for non-admins. Admins still see them everywhere so the toggle stays reversible. New `profiles.hidden` column; new `PATCH /api/admin/profiles/:id` and `GET /api/admin/profiles/hidden`. #168.
+Admins can hide profiles from the `/admin` page; hidden profiles disappear from the directory, web, and suggestions for non-admins. #168.
 
 ## 2026-05-19 | James | Multi-step welcome flow
 

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-20 | James | Hidden accounts
+
+Admins can hide a profile from the `/admin` page; hidden profiles disappear from the directory, member profile pages, the suggestion feed, the personal web, and the invite-hint typeahead for non-admins. Admins still see them everywhere so the toggle stays reversible. New `profiles.hidden` column; new `PATCH /api/admin/profiles/:id` and `GET /api/admin/profiles/hidden`. #168.
+
 ## 2026-05-19 | James | Multi-step welcome flow
 
 Onboarding is now a sequence — agreements, profile, programs, then the personal web — with each step's completion recorded so the flow is resumable. Design: `docs/design-welcome.md` (#166).

--- a/drizzle/0007_add_profile_hidden.sql
+++ b/drizzle/0007_add_profile_hidden.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "profiles" ADD COLUMN "hidden" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,622 @@
+{
+  "id": "d6cccdc6-c2c0-4513-ae51-eb09128f4230",
+  "prevId": "c93124e3-ba67-497b-8424-c64c3f45056a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.invite_hints": {
+      "name": "invite_hints",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_hints_invite_id_invites_id_fk": {
+          "name": "invite_hints_invite_id_invites_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "invites",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_hints_ratee_id_profiles_id_fk": {
+          "name": "invite_hints_ratee_id_profiles_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_hints_invite_id_ratee_id_pk": {
+          "name": "invite_hints_invite_id_ratee_id_pk",
+          "columns": [
+            "invite_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by": {
+          "name": "redeemed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_value": {
+          "name": "creator_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_profiles_id_fk": {
+          "name": "invites_created_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_profiles_id_fk": {
+          "name": "invites_redeemed_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "redeemed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_redemption_pair": {
+          "name": "invites_redemption_pair",
+          "value": "(\"invites\".\"redeemed_by\" IS NULL) = (\"invites\".\"redeemed_at\" IS NULL)"
+        },
+        "invites_expires_after_created": {
+          "name": "invites_expires_after_created",
+          "value": "\"invites\".\"expires_at\" > \"invites\".\"created_at\""
+        },
+        "invites_creator_value_range": {
+          "name": "invites_creator_value_range",
+          "value": "\"invites\".\"creator_value\" IS NULL OR (\"invites\".\"creator_value\" BETWEEN 1 AND 4)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profile_programs": {
+      "name": "profile_programs",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_programs_profile_id_profiles_id_fk": {
+          "name": "profile_programs_profile_id_profiles_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_programs_program_id_programs_id_fk": {
+          "name": "profile_programs_program_id_programs_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_programs_profile_id_program_id_pk": {
+          "name": "profile_programs_profile_id_program_id_pk",
+          "columns": [
+            "profile_id",
+            "program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplementary_info": {
+          "name": "supplementary_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by": {
+          "name": "referred_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by_legacy": {
+          "name": "referred_by_legacy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_desire": {
+          "name": "live_desire",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_signed_agreements": {
+          "name": "last_signed_agreements",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_profile": {
+          "name": "last_updated_profile",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reviewed_programs": {
+          "name": "last_reviewed_programs",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_web": {
+          "name": "last_updated_web",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profiles_referred_by_profiles_id_fk": {
+          "name": "profiles_referred_by_profiles_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "referred_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_slug_unique": {
+          "name": "profiles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_slug_unique": {
+          "name": "programs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "rater_id": {
+          "name": "rater_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hint": {
+          "name": "is_hint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hinted_by": {
+          "name": "hinted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "relations_rater_id_profiles_id_fk": {
+          "name": "relations_rater_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "rater_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_ratee_id_profiles_id_fk": {
+          "name": "relations_ratee_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_hinted_by_profiles_id_fk": {
+          "name": "relations_hinted_by_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "hinted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "relations_rater_id_ratee_id_pk": {
+          "name": "relations_rater_id_ratee_id_pk",
+          "columns": [
+            "rater_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relations_no_self": {
+          "name": "relations_no_self",
+          "value": "\"relations\".\"rater_id\" != \"relations\".\"ratee_id\""
+        },
+        "relations_value_range": {
+          "name": "relations_value_range",
+          "value": "\"relations\".\"value\" IS NULL OR (\"relations\".\"value\" BETWEEN 1 AND 4)"
+        },
+        "relations_hint_state": {
+          "name": "relations_hint_state",
+          "value": "(NOT \"relations\".\"is_hint\" AND \"relations\".\"value\" IS NOT NULL)\n       OR (\"relations\".\"is_hint\" AND \"relations\".\"value\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1779223860997,
       "tag": "0006_add_welcome_markers",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1779343350896,
+      "tag": "0007_add_profile_hidden",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/admin/admin-hidden.tsx
+++ b/src/app/admin/admin-hidden.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+
+import { Avatar } from "@/components/avatar";
+import { MemberTypeahead } from "@/components/member-typeahead";
+import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api";
+import type { MemberSummary } from "@/lib/api-types";
+
+const HIDDEN_QUERY_KEY = ["admin", "hidden"] as const;
+const MEMBERS_QUERY_KEY = ["members"] as const;
+
+const fetchHidden = async (): Promise<MemberSummary[]> => {
+  const res = await apiClient.api.admin.profiles.hidden.$get();
+  if (!res.ok) throw new Error(`admin/profiles/hidden: ${res.status}`);
+  const body = await res.json();
+  return body.members;
+};
+
+export function AdminHidden() {
+  const queryClient = useQueryClient();
+  const [picked, setPicked] = useState<MemberSummary | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const hiddenQuery = useQuery({ queryKey: HIDDEN_QUERY_KEY, queryFn: fetchHidden });
+
+  const hiddenIds = useMemo(() => (hiddenQuery.data ?? []).map((m) => m.id), [hiddenQuery.data]);
+
+  const toggleMutation = useMutation({
+    mutationFn: async (vars: { id: string; hidden: boolean }) => {
+      const res = await apiClient.api.admin.profiles[":id"].$patch({
+        param: { id: vars.id },
+        json: { hidden: vars.hidden },
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `admin/profiles PATCH: ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      setPicked(null);
+      setErrorMessage(null);
+      // The members typeahead and the directory both depend on the
+      // hidden flag, so invalidate both alongside the hidden list.
+      queryClient.invalidateQueries({ queryKey: HIDDEN_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: MEMBERS_QUERY_KEY });
+    },
+    onError: (err) => {
+      setErrorMessage(err instanceof Error ? err.message : "Failed to update hidden state.");
+    },
+  });
+
+  const hide = () => {
+    if (!picked) return;
+    toggleMutation.mutate({ id: picked.id, hidden: true });
+  };
+
+  const submitDisabled = !picked || toggleMutation.isPending;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3 rounded border border-border p-3">
+        <p className="text-sm text-muted-foreground">
+          Hide an account so it stops showing up in the directory, the web, and the suggestion feed. Admins still see
+          hidden accounts everywhere; non-admins act as if the account never existed.
+        </p>
+        <MemberTypeahead
+          label="Account to hide"
+          triggerLabel="Pick a member…"
+          selectedLabel={picked?.displayName ?? null}
+          selectedIds={hiddenIds}
+          onSelect={setPicked}
+          disabled={toggleMutation.isPending}
+        />
+        <Button type="button" variant="secondary" disabled={submitDisabled} onClick={hide} className="self-start">
+          {toggleMutation.isPending ? "Hiding…" : "Hide"}
+        </Button>
+        {errorMessage && (
+          <p role="alert" className="text-sm text-destructive">
+            {errorMessage}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h3 className="text-base font-semibold uppercase tracking-wide text-muted-foreground">Hidden accounts</h3>
+        {hiddenQuery.isPending ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : hiddenQuery.isError ? (
+          <p role="alert" className="text-sm text-destructive">
+            Couldn't load hidden accounts.
+          </p>
+        ) : hiddenQuery.data.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No hidden accounts.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {hiddenQuery.data.map((m) => (
+              <li key={m.id} className="flex items-center gap-3 rounded border border-border p-2 text-sm">
+                <Avatar
+                  name={m.displayName}
+                  url={m.avatarUrl}
+                  className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-[10px] font-semibold text-muted-foreground"
+                />
+                <span>{m.displayName ?? "—"}</span>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="xs"
+                  className="ml-auto"
+                  disabled={toggleMutation.isPending}
+                  onClick={() => toggleMutation.mutate({ id: m.id, hidden: false })}
+                >
+                  Unhide
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { requireUser, serverApiClient } from "@/lib/api-server";
 
+import { AdminHidden } from "./admin-hidden";
 import { AdminHints } from "./admin-hints";
 
 export default async function AdminPage() {
@@ -47,6 +48,11 @@ export default async function AdminPage() {
       <section className="flex w-full max-w-xl flex-col gap-2">
         <h2 className="text-lg font-semibold">Web</h2>
         <AdminHints />
+      </section>
+
+      <section className="flex w-full max-w-xl flex-col gap-2">
+        <h2 className="text-lg font-semibold">Hidden accounts</h2>
+        <AdminHidden />
       </section>
     </main>
   );

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -14,6 +14,7 @@ import {
   getProfileForMember,
   getProfileForSelf,
   getProfileForSelfWithProbe,
+  listHiddenMembers,
   listMembers,
   markAgreementsSigned,
   markProgramsReviewed,
@@ -21,6 +22,7 @@ import {
   parseEditableProfile,
   type ProfileForSelf,
   type ProfileReadProbe,
+  setProfileHidden,
   toSlug,
   upsertProfile,
 } from "./profiles";
@@ -137,7 +139,36 @@ const adminRoutes = new Hono<{ Variables: ApiVariables }>()
     const result = await removeParticipant(c.req.param("id"), c.req.param("profileId"));
     if ("error" in result) return c.json({ error: result.error }, 404);
     return c.json({ ok: true });
-  });
+  })
+  .get("/profiles/hidden", async (c) => {
+    const members = await listHiddenMembers();
+    return c.json({ members });
+  })
+  // hono/validator typed body — same path-param + JSON inference reason
+  // as PATCH /programs/:id above.
+  .patch(
+    "/profiles/:id",
+    validator("json", (body, c) => {
+      if (!body || typeof body !== "object" || Array.isArray(body)) {
+        return c.json({ error: "body must be a JSON object" }, 400);
+      }
+      const hidden = (body as Record<string, unknown>).hidden;
+      if (typeof hidden !== "boolean") {
+        return c.json({ error: "hidden must be a boolean" }, 400);
+      }
+      return { hidden };
+    }),
+    async (c) => {
+      const profileId = c.req.param("id");
+      if (!isUuid(profileId)) {
+        return c.json({ error: "profileId must be a UUID" }, 400);
+      }
+      const { hidden } = c.req.valid("json");
+      const result = await setProfileHidden({ profileId, hidden });
+      if ("error" in result) return c.json({ error: result.error }, 404);
+      return c.json({ ok: true });
+    },
+  );
 
 const api = new Hono<{ Variables: ApiVariables }>()
   .basePath("/api")
@@ -361,12 +392,16 @@ const api = new Hono<{ Variables: ApiVariables }>()
     return c.json({ valid: false, reason: result.reason });
   })
   .get("/members", async (c) => {
-    const members = await listMembers();
+    const user = c.get("user");
+    const includeHidden = await isAdmin(user.id);
+    const members = await listMembers({ includeHidden });
     return c.json({ members });
   })
   .get("/members/:id", async (c) => {
+    const user = c.get("user");
     const memberId = c.req.param("id");
-    const profile = await getProfileForMember(memberId);
+    const includeHidden = await isAdmin(user.id);
+    const profile = await getProfileForMember(memberId, { includeHidden });
     if (!profile) return c.json({ error: "not_found" }, 404);
     return c.json({ profile });
   })
@@ -398,7 +433,8 @@ const api = new Hono<{ Variables: ApiVariables }>()
   })
   .get("/relations/candidates", async (c) => {
     const user = c.get("user");
-    const feed = await getRelationSuggestions(user.id);
+    const includeHidden = await isAdmin(user.id);
+    const feed = await getRelationSuggestions(user.id, { includeHidden });
     return c.json(feed);
   })
   .get("/relations/subgraph", async (c) => {
@@ -408,12 +444,14 @@ const api = new Hono<{ Variables: ApiVariables }>()
     const includeOutgoing = c.req.query("out") !== "false";
     const includeIncoming = c.req.query("in") === "true";
     const hops = c.req.query("hops") === "1" ? 1 : 2;
+    const includeHidden = await isAdmin(user.id);
 
     const subgraph = await getPersonalWeb({
       centerId: user.id,
       includeIncoming,
       includeOutgoing,
       hops,
+      includeHidden,
     });
     return c.json(subgraph);
   })

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -1,5 +1,5 @@
 import type { User } from "@supabase/supabase-js";
-import { asc, eq, isNotNull, or, sql } from "drizzle-orm";
+import { and, asc, eq, isNotNull, or, sql } from "drizzle-orm";
 
 import { isUuid } from "./auth-middleware";
 import { attachAvatarUrls } from "./avatars";
@@ -254,10 +254,16 @@ export type ProfileForMember = {
 // Accepts either a UUID or a slug so /members/aria-chen and
 // /members/<uuid> both work. UUID-shaped strings go straight to the id
 // column; anything else is treated as a slug lookup.
-export const getProfileForMember = async (idOrSlug: string): Promise<ProfileForMember | null> => {
-  const where = isUuid(idOrSlug)
+// includeHidden=true bypasses the profiles.hidden filter so admins can
+// view hidden test accounts; the API handler decides which to pass.
+export const getProfileForMember = async (
+  idOrSlug: string,
+  options: { includeHidden?: boolean } = {},
+): Promise<ProfileForMember | null> => {
+  const match = isUuid(idOrSlug)
     ? or(eq(profiles.id, idOrSlug), eq(profiles.slug, idOrSlug))
     : eq(profiles.slug, idOrSlug);
+  const where = options.includeHidden ? match : and(match, eq(profiles.hidden, false));
 
   const [row] = await db
     .select({
@@ -289,7 +295,11 @@ export type MemberSummary = {
   avatarUrl: string | null;
 };
 
-export const listMembers = async (): Promise<MemberSummary[]> => {
+// includeHidden=true returns hidden profiles too — admins only.
+export const listMembers = async (options: { includeHidden?: boolean } = {}): Promise<MemberSummary[]> => {
+  const where = options.includeHidden
+    ? isNotNull(profiles.displayName)
+    : and(isNotNull(profiles.displayName), eq(profiles.hidden, false));
   const rows = await db
     .select({
       id: profiles.id,
@@ -300,9 +310,45 @@ export const listMembers = async (): Promise<MemberSummary[]> => {
       avatarPath: profiles.avatarPath,
     })
     .from(profiles)
-    .where(isNotNull(profiles.displayName))
+    .where(where)
     .orderBy(asc(profiles.displayName));
   return (await attachAvatarUrls(rows)) as MemberSummary[];
+};
+
+export type HiddenMemberSummary = MemberSummary;
+
+// Hidden-only directory for the admin page. Includes profiles with
+// null displayName too, since a profile can be hidden before its owner
+// finishes onboarding.
+export const listHiddenMembers = async (): Promise<HiddenMemberSummary[]> => {
+  const rows = await db
+    .select({
+      id: profiles.id,
+      slug: profiles.slug,
+      displayName: profiles.displayName,
+      location: profiles.location,
+      keywords: profiles.keywords,
+      avatarPath: profiles.avatarPath,
+    })
+    .from(profiles)
+    .where(eq(profiles.hidden, true))
+    .orderBy(asc(profiles.displayName));
+  return (await attachAvatarUrls(rows)) as HiddenMemberSummary[];
+};
+
+export type SetProfileHiddenResult = { ok: true } | { error: "not_found" };
+
+export const setProfileHidden = async (params: {
+  profileId: string;
+  hidden: boolean;
+}): Promise<SetProfileHiddenResult> => {
+  const result = await db
+    .update(profiles)
+    .set({ hidden: params.hidden })
+    .where(eq(profiles.id, params.profileId))
+    .returning({ id: profiles.id });
+  if (result.length === 0) return { error: "not_found" };
+  return { ok: true };
 };
 
 // Placeholder. Same rationale as getProfileForMember — admin tooling

--- a/src/server/relations.ts
+++ b/src/server/relations.ts
@@ -103,7 +103,13 @@ const collectInto = <T extends { id: string }>(
 // IDs via `seen`. Sources 1–4 land in `suggestions` (signal-bearing);
 // source 5 lands in `otherMembers` (catch-all of the rest of the
 // directory) so the feed never goes empty while a member remains.
-export const getRelationSuggestions = async (userId: string): Promise<RelationSuggestionFeed> => {
+// includeHidden=true skips profiles.hidden filtering across all five
+// sources so admins still see hidden test accounts in suggestions.
+export const getRelationSuggestions = async (
+  userId: string,
+  options: { includeHidden?: boolean } = {},
+): Promise<RelationSuggestionFeed> => {
+  const notHidden = options.includeHidden ? sql`true` : sql`${profiles.hidden} = false`;
   const seen = new Set<string>([userId]);
   const suggestions: SuggestionCardRow[] = [];
   const otherMembers: SuggestionCardRow[] = [];
@@ -124,6 +130,7 @@ export const getRelationSuggestions = async (userId: string): Promise<RelationSu
           eq(relations.relateeId, userId),
           isNotNull(relations.value),
           noRelationFromUserTo(userId, relations.relatorId),
+          notHidden,
         ),
       )
       .orderBy(desc(relations.updatedAt)),
@@ -134,7 +141,7 @@ export const getRelationSuggestions = async (userId: string): Promise<RelationSu
       .select({ ...cardColumns, hintedBy: relations.hintedBy })
       .from(relations)
       .innerJoin(profiles, eq(profiles.id, relations.relateeId))
-      .where(and(eq(relations.relatorId, userId), eq(relations.isHint, true)))
+      .where(and(eq(relations.relatorId, userId), eq(relations.isHint, true), notHidden))
       .orderBy(desc(relations.updatedAt)),
     db
       .select({ referredBy: profiles.referredBy, lastUpdatedWeb: profiles.lastUpdatedWeb })
@@ -147,7 +154,7 @@ export const getRelationSuggestions = async (userId: string): Promise<RelationSu
     db
       .select(cardColumns)
       .from(profiles)
-      .where(and(ne(profiles.id, userId), noRelationFromUserTo(userId, profiles.id)))
+      .where(and(ne(profiles.id, userId), noRelationFromUserTo(userId, profiles.id), notHidden))
       .orderBy(sql`${profiles.lastUpdatedWeb} DESC NULLS LAST`, asc(profiles.displayName)),
   ]);
 
@@ -187,6 +194,7 @@ export const getRelationSuggestions = async (userId: string): Promise<RelationSu
               sql`${relations.value} >= 3`,
               ne(relations.relateeId, userId),
               noRelationFromUserTo(userId, relations.relateeId),
+              notHidden,
             ),
           )
           .orderBy(desc(relations.value), desc(relations.updatedAt))
@@ -202,6 +210,7 @@ export const getRelationSuggestions = async (userId: string): Promise<RelationSu
           ne(profiles.id, userId),
           noRelationFromUserTo(userId, profiles.id),
           myLastUpdated ? sql`${profiles.lastUpdatedWeb} > ${myLastUpdated.toISOString()}` : sql`true`,
+          notHidden,
         ),
       )
       .orderBy(desc(profiles.lastUpdatedWeb)),
@@ -264,15 +273,24 @@ const edgeKey = (e: { relatorId: string; relateeId: string }): string => `${e.re
 // feed, not the rendered web. centerId is parameterized so the same
 // component can later embed read-only on member profile pages (see
 // design-relations.md "Embedded subgraph displays").
+// includeHidden=true keeps hidden profiles in the graph — admins see
+// everything. When false, hidden profiles are excluded as nodes AND
+// edges touching them are dropped, so the rendered web never shows a
+// dangling edge to a vanished node.
 export const getPersonalWeb = async (params: {
   centerId: string;
   includeIncoming: boolean;
   includeOutgoing: boolean;
   hops: 1 | 2;
+  includeHidden?: boolean;
 }): Promise<Subgraph> => {
   const { centerId, includeIncoming, includeOutgoing, hops } = params;
+  const includeHidden = params.includeHidden ?? false;
 
-  // First hop — direct relations involving centerId.
+  // First hop — direct relations involving centerId. If the viewer is
+  // not an admin, the join to profiles on both endpoints is what filters
+  // an edge whose other end is hidden; we do that pruning in JS rather
+  // than two subquery joins.
   const firstHopWhere = (() => {
     if (includeIncoming && includeOutgoing) {
       return or(eq(relations.relatorId, centerId), eq(relations.relateeId, centerId));
@@ -291,18 +309,40 @@ export const getPersonalWeb = async (params: {
     .from(relations)
     .where(and(firstHopWhere, isNotNull(relations.value)));
 
+  // Determine which ids are hidden so we can drop them as nodes and as
+  // edge endpoints before rendering. Skipped entirely for admins.
+  const candidateIds = new Set<string>([centerId]);
+  for (const e of firstHop) {
+    candidateIds.add(e.relatorId);
+    candidateIds.add(e.relateeId);
+  }
+  const hiddenIds = new Set<string>();
+  if (!includeHidden && candidateIds.size > 0) {
+    const rows = await db
+      .select({ id: profiles.id })
+      .from(profiles)
+      .where(and(inArray(profiles.id, [...candidateIds]), eq(profiles.hidden, true)));
+    for (const r of rows) hiddenIds.add(r.id);
+  }
+  // Center is exempt — the viewer's own web always includes themselves,
+  // even if they were somehow hidden.
+  const isVisible = (id: string): boolean => id === centerId || !hiddenIds.has(id);
+
   const nodeIds = new Set<string>([centerId]);
   for (const e of firstHop) {
+    if (!isVisible(e.relatorId) || !isVisible(e.relateeId)) continue;
     nodeIds.add(e.relatorId);
     nodeIds.add(e.relateeId);
   }
 
-  const edges: SubgraphEdge[] = firstHop.map((e) => ({
-    relatorId: e.relatorId,
-    relateeId: e.relateeId,
-    // value is filtered IS NOT NULL in the WHERE, so the runtime cast is safe.
-    value: e.value as number,
-  }));
+  const edges: SubgraphEdge[] = firstHop
+    .filter((e) => isVisible(e.relatorId) && isVisible(e.relateeId))
+    .map((e) => ({
+      relatorId: e.relatorId,
+      relateeId: e.relateeId,
+      // value is filtered IS NOT NULL in the WHERE, so the runtime cast is safe.
+      value: e.value as number,
+    }));
 
   // Second hop — relations among the first-hop neighbors and to other
   // members they point at. Surfaces "their relations to each other and
@@ -320,8 +360,22 @@ export const getPersonalWeb = async (params: {
         .where(
           and(isNotNull(relations.value), inArray(relations.relatorId, firstHopIds), ne(relations.relateeId, centerId)),
         );
+      // Second-hop relatees can introduce new ids; mark any hidden ones
+      // so the filter below catches them too.
+      if (!includeHidden) {
+        const newIds = secondHop.map((e) => e.relateeId).filter((id) => !candidateIds.has(id));
+        if (newIds.length > 0) {
+          const rows = await db
+            .select({ id: profiles.id })
+            .from(profiles)
+            .where(and(inArray(profiles.id, newIds), eq(profiles.hidden, true)));
+          for (const r of rows) hiddenIds.add(r.id);
+          for (const id of newIds) candidateIds.add(id);
+        }
+      }
       const seen = new Set(edges.map(edgeKey));
       for (const e of secondHop) {
+        if (!isVisible(e.relatorId) || !isVisible(e.relateeId)) continue;
         const key = edgeKey(e);
         if (seen.has(key)) continue;
         seen.add(key);
@@ -444,7 +498,7 @@ export type PendingHint = {
 // the admin /admin Web section; the self-join across profiles is done
 // in JS (two queries) for the same reason getRelationSuggestions does
 // — Drizzle profile aliasing is more code than the joined volume here
-// is worth.
+// is worth. Admin-only caller, so no hidden filter is applied.
 export const listPendingHints = async (): Promise<PendingHint[]> => {
   const rows = await db
     .select({
@@ -540,7 +594,13 @@ export const validateInviteHints = async (params: {
   }
 
   const ids = [...seen];
-  const found = await db.select({ id: profiles.id }).from(profiles).where(inArray(profiles.id, ids));
+  // Hidden accounts are treated as "not a member" for invite-hint
+  // purposes — non-admins can't pick them in the typeahead, and the
+  // backend refuses them even if a hand-crafted request slips one in.
+  const found = await db
+    .select({ id: profiles.id })
+    .from(profiles)
+    .where(and(inArray(profiles.id, ids), eq(profiles.hidden, false)));
   if (found.length !== ids.length) return { error: "invalid", reason: "not_a_member" };
 
   return { ok: true, ids };

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -47,6 +47,10 @@ export const profiles = pgTable("profiles", {
   emergencyContact: text("emergency_contact"),
   liveDesire: text("live_desire"),
   isAdmin: boolean("is_admin").notNull().default(false),
+  // Hidden profiles are invisible to non-admin members everywhere —
+  // directory, suggestions, web, typeaheads. Admins still see them so
+  // the flag is reversible. See docs/devjournal.md (#168).
+  hidden: boolean("hidden").notNull().default(false),
   lastSignedAgreements: timestamp("last_signed_agreements", { withTimezone: true }),
   lastUpdatedProfile: timestamp("last_updated_profile", { withTimezone: true }),
   lastReviewedPrograms: timestamp("last_reviewed_programs", { withTimezone: true }),

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -45,10 +45,12 @@ test("admin can open the /admin hub without console errors", async ({ page }) =>
 
   await expect(page.getByRole("heading", { name: "Admin", level: 1 })).toBeVisible();
   await expect(page.getByRole("link", { name: "Manage programs" })).toBeVisible();
-  // AdminHints settling out of its "Loading…" state means its
-  // /api/admin/hints query resolved — any client-side error has had its
-  // chance to land in `errors`.
-  await expect(page.getByText("Loading…")).toBeHidden();
+  // All "Loading…" placeholders (AdminHints, AdminHidden) settling
+  // means every section's query has resolved — any client-side error
+  // has had its chance to land in `errors`. toHaveCount(0) avoids the
+  // strict-mode violation that `toBeHidden` would trigger when more
+  // than one section is loading at once.
+  await expect(page.getByText("Loading…")).toHaveCount(0);
   expect(errors).toEqual([]);
 });
 

--- a/tests/functional/server/admin.test.ts
+++ b/tests/functional/server/admin.test.ts
@@ -159,3 +159,117 @@ describe("GET /api/admin/hints", () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe("PATCH /api/admin/profiles/:id", () => {
+  let admin: string;
+  let nonAdmin: string;
+  let target: string;
+
+  beforeEach(async () => {
+    admin = randomUUID();
+    nonAdmin = randomUUID();
+    target = randomUUID();
+    await insertUserAndProfile(admin, { isAdmin: true });
+    await insertUserAndProfile(nonAdmin);
+    await insertUserAndProfile(target);
+    await db.update(profiles).set({ displayName: "Target" }).where(eq(profiles.id, target));
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(admin);
+    await deleteUserAndProfile(nonAdmin);
+    await deleteUserAndProfile(target);
+  });
+
+  it("hides and unhides a profile when called by an admin", async () => {
+    authAs(admin);
+    const hide = await app.request(`/api/admin/profiles/${target}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ hidden: true }),
+    });
+    expect(hide.status).toBe(200);
+    const [hidden] = await db.select({ hidden: profiles.hidden }).from(profiles).where(eq(profiles.id, target));
+    expect(hidden.hidden).toBe(true);
+
+    const unhide = await app.request(`/api/admin/profiles/${target}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ hidden: false }),
+    });
+    expect(unhide.status).toBe(200);
+    const [unhidden] = await db.select({ hidden: profiles.hidden }).from(profiles).where(eq(profiles.id, target));
+    expect(unhidden.hidden).toBe(false);
+  });
+
+  it("returns 400 when body is not { hidden: boolean }", async () => {
+    authAs(admin);
+    const res = await app.request(`/api/admin/profiles/${target}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ hidden: "true" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for non-admins", async () => {
+    authAs(nonAdmin);
+    const res = await app.request(`/api/admin/profiles/${target}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ hidden: true }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a non-existent profile id", async () => {
+    authAs(admin);
+    const res = await app.request(`/api/admin/profiles/${randomUUID()}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ hidden: true }),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/admin/profiles/hidden", () => {
+  let admin: string;
+  let nonAdmin: string;
+  let hidden: string;
+
+  beforeEach(async () => {
+    admin = randomUUID();
+    nonAdmin = randomUUID();
+    hidden = randomUUID();
+    await insertUserAndProfile(admin, { isAdmin: true });
+    await insertUserAndProfile(nonAdmin);
+    await insertUserAndProfile(hidden);
+    await db
+      .update(profiles)
+      .set({ displayName: "Hidden Test", hidden: true })
+      .where(eq(profiles.id, hidden));
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(admin);
+    await deleteUserAndProfile(nonAdmin);
+    await deleteUserAndProfile(hidden);
+  });
+
+  it("returns the hidden profile for admins", async () => {
+    authAs(admin);
+    const res = await app.request("/api/admin/profiles/hidden");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { members: Array<{ id: string }> };
+    expect(body.members.find((m) => m.id === hidden)).toBeDefined();
+  });
+
+  it("returns 404 for non-admins", async () => {
+    authAs(nonAdmin);
+    const res = await app.request("/api/admin/profiles/hidden");
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/functional/server/invites.test.ts
+++ b/tests/functional/server/invites.test.ts
@@ -378,6 +378,21 @@ describe("POST /api/invites", () => {
     expect(body.reason).toBe("not_a_member");
   });
 
+  it("rejects hints pointing at hidden profiles", async () => {
+    const h = randomUUID();
+    await insertUserAndProfile(h);
+    try {
+      await db.update(profiles).set({ hidden: true }).where(eq(profiles.id, h));
+      const res = await post({ note: "hidden hint should be rejected", hints: [h] });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("invalid_hints");
+      expect(body.reason).toBe("not_a_member");
+    } finally {
+      await deleteUserAndProfile(h);
+    }
+  });
+
   it("rejects duplicate ids in the hints list", async () => {
     const h = randomUUID();
     await insertUserAndProfile(h);

--- a/tests/functional/server/profiles.test.ts
+++ b/tests/functional/server/profiles.test.ts
@@ -4,7 +4,15 @@ import { eq, sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { db } from "@/server/db";
-import { getProfileForAdmin, getProfileForMember, getProfileForSelf, upsertProfile } from "@/server/profiles";
+import {
+  getProfileForAdmin,
+  getProfileForMember,
+  getProfileForSelf,
+  listHiddenMembers,
+  listMembers,
+  setProfileHidden,
+  upsertProfile,
+} from "@/server/profiles";
 import { profiles } from "@/server/schema";
 
 describe("upsertProfile", () => {
@@ -165,5 +173,63 @@ describe("getProfileForMember", () => {
 describe("getProfileForAdmin stub", () => {
   it("getProfileForAdmin throws NotImplemented", async () => {
     await expect(getProfileForAdmin()).rejects.toThrow(/NotImplemented/);
+  });
+});
+
+describe("profiles.hidden", () => {
+  let visibleId: string;
+  let hiddenId: string;
+
+  beforeEach(async () => {
+    visibleId = randomUUID();
+    hiddenId = randomUUID();
+    for (const id of [visibleId, hiddenId]) {
+      await db.execute(
+        sql`INSERT INTO auth.users (id, is_sso_user, is_anonymous) VALUES (${id}::uuid, false, false)`,
+      );
+    }
+    await db.insert(profiles).values({ id: visibleId, displayName: "Visible Vera" });
+    await db.insert(profiles).values({ id: hiddenId, displayName: "Hidden Henry", hidden: true });
+  });
+
+  afterEach(async () => {
+    for (const id of [visibleId, hiddenId]) {
+      await db.delete(profiles).where(eq(profiles.id, id));
+      await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+    }
+  });
+
+  it("defaults to false on insert", async () => {
+    const [row] = await db.select({ hidden: profiles.hidden }).from(profiles).where(eq(profiles.id, visibleId));
+    expect(row.hidden).toBe(false);
+  });
+
+  it("listMembers excludes hidden by default and includes when includeHidden=true", async () => {
+    const visible = await listMembers();
+    expect(visible.find((m) => m.id === hiddenId)).toBeUndefined();
+    expect(visible.find((m) => m.id === visibleId)).toBeDefined();
+
+    const all = await listMembers({ includeHidden: true });
+    expect(all.find((m) => m.id === hiddenId)).toBeDefined();
+  });
+
+  it("getProfileForMember returns null for hidden by default; returns the row when includeHidden=true", async () => {
+    expect(await getProfileForMember(hiddenId)).toBeNull();
+    const admin = await getProfileForMember(hiddenId, { includeHidden: true });
+    expect(admin?.id).toBe(hiddenId);
+  });
+
+  it("listHiddenMembers returns only hidden profiles", async () => {
+    const rows = await listHiddenMembers();
+    expect(rows.find((m) => m.id === hiddenId)).toBeDefined();
+    expect(rows.find((m) => m.id === visibleId)).toBeUndefined();
+  });
+
+  it("setProfileHidden flips the flag both ways and 404s for unknown ids", async () => {
+    expect(await setProfileHidden({ profileId: visibleId, hidden: true })).toEqual({ ok: true });
+    expect(await getProfileForMember(visibleId)).toBeNull();
+    expect(await setProfileHidden({ profileId: visibleId, hidden: false })).toEqual({ ok: true });
+    expect(await getProfileForMember(visibleId)).not.toBeNull();
+    expect(await setProfileHidden({ profileId: randomUUID(), hidden: true })).toEqual({ error: "not_found" });
   });
 });

--- a/tests/functional/server/relations.test.ts
+++ b/tests/functional/server/relations.test.ts
@@ -395,6 +395,103 @@ describe("getPersonalWeb", () => {
     expect(sub.nodes).toHaveLength(1);
     expect(sub.edges).toEqual([]);
   });
+
+  it("drops hidden nodes and any edge touching one (non-admin viewer)", async () => {
+    await updateRelationValue({ relatorId: center, relateeId: a, value: 3 });
+    await updateRelationValue({ relatorId: center, relateeId: b, value: 2 });
+    await db.update(profiles).set({ hidden: true }).where(eq(profiles.id, b));
+
+    const sub = await getPersonalWeb({
+      centerId: center,
+      includeIncoming: false,
+      includeOutgoing: true,
+      hops: 1,
+    });
+    expect(new Set(sub.nodes.map((n) => n.id))).toEqual(new Set([center, a]));
+    expect(sub.edges).toHaveLength(1);
+    expect(sub.edges[0]).toMatchObject({ relatorId: center, relateeId: a });
+  });
+
+  it("includeHidden=true keeps hidden nodes and their edges (admin viewer)", async () => {
+    await updateRelationValue({ relatorId: center, relateeId: a, value: 3 });
+    await updateRelationValue({ relatorId: center, relateeId: b, value: 2 });
+    await db.update(profiles).set({ hidden: true }).where(eq(profiles.id, b));
+
+    const sub = await getPersonalWeb({
+      centerId: center,
+      includeIncoming: false,
+      includeOutgoing: true,
+      hops: 1,
+      includeHidden: true,
+    });
+    expect(new Set(sub.nodes.map((n) => n.id))).toEqual(new Set([center, a, b]));
+    expect(sub.edges).toHaveLength(2);
+  });
+
+  it("hops=2 drops a hidden second-degree neighbor and the edge that reaches it", async () => {
+    const c = randomUUID();
+    await insertUserAndProfile(c, { displayName: "C" });
+    try {
+      await updateRelationValue({ relatorId: center, relateeId: a, value: 3 });
+      await updateRelationValue({ relatorId: a, relateeId: c, value: 4 });
+      await db.update(profiles).set({ hidden: true }).where(eq(profiles.id, c));
+
+      const sub = await getPersonalWeb({
+        centerId: center,
+        includeIncoming: false,
+        includeOutgoing: true,
+        hops: 2,
+      });
+      expect(sub.nodes.map((n) => n.id).includes(c)).toBe(false);
+      expect(sub.edges.some((e) => e.relateeId === c)).toBe(false);
+    } finally {
+      await deleteUserAndProfile(c);
+    }
+  });
+});
+
+describe("getRelationSuggestions — hidden filter", () => {
+  let me: string;
+  let visibleOther: string;
+  let hiddenOther: string;
+
+  beforeEach(async () => {
+    me = randomUUID();
+    visibleOther = randomUUID();
+    hiddenOther = randomUUID();
+    await insertUserAndProfile(me, { displayName: "Me" });
+    await insertUserAndProfile(visibleOther, { displayName: "Visible" });
+    await insertUserAndProfile(hiddenOther, { displayName: "Hidden" });
+    await db.update(profiles).set({ hidden: true }).where(eq(profiles.id, hiddenOther));
+  });
+
+  afterEach(async () => {
+    await deleteUserAndProfile(me);
+    await deleteUserAndProfile(visibleOther);
+    await deleteUserAndProfile(hiddenOther);
+  });
+
+  it("source 1 — addedYou skips hidden raters", async () => {
+    await updateRelationValue({ relatorId: visibleOther, relateeId: me, value: 3 });
+    await updateRelationValue({ relatorId: hiddenOther, relateeId: me, value: 4 });
+    const feed = await getRelationSuggestions(me);
+    const allIds = [...feed.suggestions, ...feed.otherMembers].map((c) => c.id);
+    expect(allIds).toContain(visibleOther);
+    expect(allIds).not.toContain(hiddenOther);
+  });
+
+  it("source 5 — everyoneElse skips hidden profiles", async () => {
+    const feed = await getRelationSuggestions(me);
+    const allIds = [...feed.suggestions, ...feed.otherMembers].map((c) => c.id);
+    expect(allIds).toContain(visibleOther);
+    expect(allIds).not.toContain(hiddenOther);
+  });
+
+  it("includeHidden=true keeps hidden profiles in the feed", async () => {
+    const feed = await getRelationSuggestions(me, { includeHidden: true });
+    const allIds = [...feed.suggestions, ...feed.otherMembers].map((c) => c.id);
+    expect(allIds).toContain(hiddenOther);
+  });
 });
 
 describe("materializeInviteRelations", () => {


### PR DESCRIPTION
## Summary

- New `profiles.hidden` column (default `false`). Admins can flip it from the new "Hidden accounts" section on `/admin` (typeahead to hide, list with Unhide buttons).
- Hidden profiles are invisible to non-admins everywhere — directory, member detail page, suggestion feed (all 5 sources), personal web (nodes + edges that touch a hidden profile are dropped so the graph stays self-consistent), and the invite-hint typeahead.
- Admins still see hidden profiles everywhere so the flag stays reversible.

## API surface

- `PATCH /api/admin/profiles/:id` — body `{ hidden: boolean }`.
- `GET /api/admin/profiles/hidden` — list of hidden profiles for the admin UI.
- Existing member-facing endpoints (`/api/members`, `/api/members/:id`, `/api/relations/candidates`, `/api/relations/subgraph`) compute the viewer's admin status and thread `includeHidden` to the data layer.

## Known awkwardness (intentionally not fixed here)

`/api/members` returns hidden profiles to admins because admins see everything. Every `MemberTypeahead` in the admin's own session — including the one on the invite-create form — therefore lists hidden members. The backend rejects an invite-hint pointing at a hidden profile (`validateInviteHints` filters them out, returning `not_a_member`), so this is functionally safe; an admin who picks a hidden member as an invite hint just gets a slightly cryptic 400. A cleaner fix would be an `?excludeHidden=true` query param on `/api/members` plus a distinct cache key — left for later.

## Out of scope

Per discussion on #168: this is just "pretend the account never existed" for hiding test data. No deactivation messaging, no past-tense rendering, no audit trail.

## Test plan

- [x] `npm run test:functional` — 200 passed (added: schema default, listMembers/getProfileForMember/listHiddenMembers/setProfileHidden, suggestion feed sources, personal-web pruning, admin PATCH and GET, invite-hint rejection for hidden targets)
- [x] `npm run test:e2e` — 25 passed (admin smoke updated to wait for both sections' loaders to clear)
- [x] `npx tsc --noEmit` clean
- [ ] Reviewer: confirm the visual flow on `/admin` — hide a test profile, verify it vanishes from `/members` for a non-admin browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)