### PR TITLE
Increase active invite cap from 10 to 50

### DIFF
--- a/src/app/invites/invites-panel.tsx
+++ b/src/app/invites/invites-panel.tsx
@@ -75,9 +75,11 @@ export function InvitesPanel({ me }: { me: Me }) {
         },
       });
       if (res.status === 429) {
+        const body = (await res.json().catch(() => ({}))) as { limit?: number };
+        const cap = body.limit ?? 50;
         setState({
           kind: "error",
-          message: "You already have 10 active invites. Revoke one first.",
+          message: `You already have ${cap} active invites. Revoke one first.`,
         });
         return;
       }

--- a/src/app/invites/invites-panel.tsx
+++ b/src/app/invites/invites-panel.tsx
@@ -76,11 +76,10 @@ export function InvitesPanel({ me }: { me: Me }) {
       });
       if (res.status === 429) {
         const body = (await res.json().catch(() => ({}))) as { limit?: number };
-        const cap = body.limit ?? 50;
-        setState({
-          kind: "error",
-          message: `You already have ${cap} active invites. Revoke one first.`,
-        });
+        const message = body.limit
+          ? `You already have ${body.limit} active invites. Revoke one first.`
+          : "You already have the maximum number of active invites. Revoke one first.";
+        setState({ kind: "error", message });
         return;
       }
       if (!res.ok) {

--- a/src/server/invites.ts
+++ b/src/server/invites.ts
@@ -14,7 +14,7 @@ const CODE_LENGTH = 10;
 // 32^10 ≈ 1.1e15 — sparse enough that collisions are vanishingly rare;
 // the unique constraint is the real safety net.
 
-const MAX_ACTIVE_INVITES_PER_USER = 10;
+const MAX_ACTIVE_INVITES_PER_USER = 50;
 const INVITE_LIFETIME_DAYS = 30;
 const MIN_NOTE_LENGTH = 10;
 

--- a/tests/e2e/invites.spec.ts
+++ b/tests/e2e/invites.spec.ts
@@ -71,7 +71,7 @@ test.describe("invites — authed member flow", () => {
     await page.getByLabel(/Note \(for your records/).fill("this should trigger the cap message");
     await page.getByRole("button", { name: "Create invite" }).click();
 
-    await expect(page.getByText(/You already have 10 active invites/)).toBeVisible();
+    await expect(page.getByText(/You already have \d+ active invites/)).toBeVisible();
   });
 });
 

--- a/tests/e2e/invites.spec.ts
+++ b/tests/e2e/invites.spec.ts
@@ -71,7 +71,7 @@ test.describe("invites — authed member flow", () => {
     await page.getByLabel(/Note \(for your records/).fill("this should trigger the cap message");
     await page.getByRole("button", { name: "Create invite" }).click();
 
-    await expect(page.getByText(/You already have \d+ active invites/)).toBeVisible();
+    await expect(page.getByText(/You already have 10 active invites/)).toBeVisible();
   });
 });
 

--- a/tests/functional/server/invites.test.ts
+++ b/tests/functional/server/invites.test.ts
@@ -83,13 +83,16 @@ describe("invites module", () => {
   });
 
   it("enforces the 50-active-invite cap", async () => {
-    for (let i = 0; i < 50; i++) {
-      const r = await createInvite({
-        createdBy: creatorId,
-        note: `friend number ${i} coming in`,
-      });
-      expect("code" in r).toBe(true);
-    }
+    // Seed 50 active invites directly to avoid 50 round-trips through
+    // the full createInvite path (count + generate + insert each time).
+    const rows = Array.from({ length: 50 }, (_, i) => ({
+      code: `CAP-TEST-${String(i).padStart(3, "0")}`,
+      createdBy: creatorId,
+      note: `friend number ${i} coming in`,
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    }));
+    await db.insert(invites).values(rows);
+
     const next = await createInvite({
       createdBy: creatorId,
       note: "one too many friends",
@@ -389,12 +392,15 @@ describe("POST /api/invites", () => {
   });
 
   it("returns 429 when the user is already at the active cap", async () => {
-    for (let i = 0; i < 50; i++) {
-      await createInvite({
-        createdBy: userId,
-        note: `existing invite number ${i}`,
-      });
-    }
+    // Seed 50 active invites directly for speed.
+    const rows = Array.from({ length: 50 }, (_, i) => ({
+      code: `API-CAP-${userId.slice(0, 4)}-${String(i).padStart(3, "0")}`,
+      createdBy: userId,
+      note: `existing invite number ${i}`,
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    }));
+    await db.insert(invites).values(rows);
+
     const res = await post({ note: "one more invite should be rejected" });
     expect(res.status).toBe(429);
     const body = await res.json();

--- a/tests/functional/server/invites.test.ts
+++ b/tests/functional/server/invites.test.ts
@@ -82,21 +82,21 @@ describe("invites module", () => {
     expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now());
   });
 
-  it("enforces the 10-active-invite cap", async () => {
-    for (let i = 0; i < 10; i++) {
+  it("enforces the 50-active-invite cap", async () => {
+    for (let i = 0; i < 50; i++) {
       const r = await createInvite({
         createdBy: creatorId,
         note: `friend number ${i} coming in`,
       });
       expect("code" in r).toBe(true);
     }
-    const eleventh = await createInvite({
+    const next = await createInvite({
       createdBy: creatorId,
       note: "one too many friends",
     });
-    expect(eleventh).toEqual({ error: "too_many_active", limit: 10 });
+    expect(next).toEqual({ error: "too_many_active", limit: 50 });
 
-    expect(await countActiveInvitesForCreator(creatorId)).toBe(10);
+    expect(await countActiveInvitesForCreator(creatorId)).toBe(50);
   });
 
   it("redeeming an invite frees the slot so the creator can mint another", async () => {
@@ -389,17 +389,17 @@ describe("POST /api/invites", () => {
   });
 
   it("returns 429 when the user is already at the active cap", async () => {
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 50; i++) {
       await createInvite({
         createdBy: userId,
         note: `existing invite number ${i}`,
       });
     }
-    const res = await post({ note: "eleventh invite should be rejected" });
+    const res = await post({ note: "one more invite should be rejected" });
     expect(res.status).toBe(429);
     const body = await res.json();
     expect(body.error).toBe("too_many_active_invites");
-    expect(body.limit).toBe(10);
+    expect(body.limit).toBe(50);
   });
 });
 


### PR DESCRIPTION
Bumps `MAX_ACTIVE_INVITES_PER_USER` from 10 to 50 per James's comment on #205 — members shouldn't need to worry about invite limits.

Also fixed the client error message to read the limit from the API response rather than hardcoding, so it won't need updating if the cap changes again.

Closes #205