### PR TITLE
Fix CodeQL dismiss-alerts SARIF path for javascript-typescript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,10 +35,17 @@ jobs:
 
     strategy:
       fail-fast: false
+      # `sarif` is the on-disk filename codeql-action/analyze writes for
+      # this language. It matches `language` for single-token languages
+      # (e.g. `actions`), but `javascript-typescript` is normalized down
+      # to `javascript.sarif` — so the two have to be tracked separately
+      # for the dismiss-alerts step below to find the file.
       matrix:
-        language:
-          - actions
-          - javascript-typescript
+        include:
+          - language: actions
+            sarif: actions.sarif
+          - language: javascript-typescript
+            sarif: javascript.sarif
 
     steps:
       - uses: actions/checkout@v6
@@ -77,6 +84,6 @@ jobs:
         uses: advanced-security/dismiss-alerts@046d6b48d2e43cf563f96f67332c47c432eff83e
         with:
           sarif-id: ${{ steps.analyze.outputs.sarif-id }}
-          sarif-file: sarif-results/${{ matrix.language }}.sarif
+          sarif-file: sarif-results/${{ matrix.sarif }}
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

PR #235 wired in `advanced-security/dismiss-alerts` using `sarif-results/${{ matrix.language }}.sarif`. That worked for the `actions` leg by coincidence but failed for `javascript-typescript`: codeql-action/analyze writes the file under the underlying CodeQL language id, so the js/ts leg's SARIF is `sarif-results/javascript.sarif`, not `sarif-results/javascript-typescript.sarif`. PR-time CI never exercised this because the dismiss step is guarded to `refs/heads/main`, so it only ran after the merge.

Restructure the matrix to carry both fields explicitly:

```yaml
matrix:
  include:
    - language: actions
      sarif: actions.sarif
    - language: javascript-typescript
      sarif: javascript.sarif
```

Direct evidence from the failing run ([job 77120823243](https://github.com/Intentional-Society/is-app/actions/runs/26210756895/job/77120823243)):

```
Post-processing sarif files: [".../sarif-results/javascript.sarif"]
...
sarif-file: sarif-results/javascript-typescript.sarif
Error: Path does not exist: sarif-results/javascript-typescript.sarif
```

## Not addressed here

The Node.js 20 deprecation warning on the same step is a separate issue. `advanced-security/dismiss-alerts` still declares `using: "node20"` on its latest release (v2.0.2) and on `main`; the workflow's pre-existing `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env keeps it running on Node 24 today, so it's warning-only. Worth filing upstream eventually but not blocking.

## Test plan

- [ ] Once merged, confirm the next push to `main` produces a green "Dismiss alerts marked suppressed in SARIF" step for both matrix legs.
- [ ] (Follow-on for #235's test plan) Verify alerts close once the in-source markers are tidied up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)