### PR TITLE
Re-center web graph on node click; navigate on double-click (#239)

### DIFF
--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -312,8 +312,16 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
         elementsSelectable={false}
         proOptions={{ hideAttribution: true }}
         onNodeClick={(_event, node) => {
-          // Center node has no profile destination distinct from "you
-          // are here" — clicking yourself is a no-op.
+          if (node.data.isCenter) return;
+          // Re-center the viewport on the clicked node so members can
+          // explore the graph without navigating away. Double-click
+          // navigates to the member's profile page.
+          flowRef.current?.setCenter(node.position.x, node.position.y, {
+            zoom: flowRef.current.getZoom(),
+            duration: 400,
+          });
+        }}
+        onNodeDoubleClick={(_event, node) => {
           if (node.data.isCenter) return;
           const slug = node.data.slug ?? node.data.id;
           router.push(`/members/${slug}`);


### PR DESCRIPTION
Closes #239

## Summary
- Single-click on a graph node now re-centers the canvas on that node (animated, 400 ms) instead of navigating away
- Double-click navigates to the member's profile page
- The center node (self) is still a no-op for both interactions

## Test plan
- [ ] Open `/myweb` and single-click a connected member node — canvas should smoothly pan/zoom to center on it
- [ ] Double-click the same node — should navigate to `/members/[slug]`
- [ ] Clicking the center (self) node should do nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)