### PR TITLE
Add mailto contact link on member profile pages (#242)

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -64,6 +64,15 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
         <Field label="Live desire">{profile.liveDesire}</Field>
         <Field label="Supplementary info">{profile.supplementaryInfo}</Field>
       </dl>
+
+      {profile.email && (
+        <a
+          href={`mailto:${profile.email}`}
+          className="text-base text-muted-foreground underline hover:text-foreground"
+        >
+          Send email
+        </a>
+      )}
     </main>
   );
 }

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -4,7 +4,7 @@ import { and, asc, eq, isNotNull, or, sql } from "drizzle-orm";
 import { isUuid } from "./auth-middleware";
 import { attachAvatarUrls } from "./avatars";
 import { db } from "./db";
-import { profiles } from "./schema";
+import { authUsers, profiles } from "./schema";
 
 // avatarUrl is intentionally absent: the avatar is set through the
 // dedicated upload endpoint (POST /api/me/avatar), not as free-text
@@ -248,6 +248,7 @@ export type ProfileForMember = {
   supplementaryInfo: string | null;
   avatarUrl: string | null;
   liveDesire: string | null;
+  email: string | null;
   createdAt: Date;
 };
 
@@ -276,9 +277,11 @@ export const getProfileForMember = async (
       supplementaryInfo: profiles.supplementaryInfo,
       avatarPath: profiles.avatarPath,
       liveDesire: profiles.liveDesire,
+      email: authUsers.email,
       createdAt: profiles.createdAt,
     })
     .from(profiles)
+    .innerJoin(authUsers, eq(authUsers.id, profiles.id))
     .where(where);
 
   if (!row) return null;

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -16,8 +16,9 @@ import {
 // drizzle-kit is configured with schemaFilter: ["public"] so it will
 // not attempt to create or alter this table.
 const authSchema = pgSchema("auth");
-const authUsers = authSchema.table("users", {
+export const authUsers = authSchema.table("users", {
   id: uuid("id").primaryKey(),
+  email: text("email"),
 });
 
 // All public tables have RLS enabled with no policies. Drizzle connects as the

--- a/tests/functional/server/profiles.test.ts
+++ b/tests/functional/server/profiles.test.ts
@@ -153,6 +153,7 @@ describe("getProfileForMember", () => {
         "supplementaryInfo",
         "avatarUrl",
         "liveDesire",
+        "email",
         "createdAt",
       ].sort(),
     );


### PR DESCRIPTION
Closes #242

## Summary
- Adds a "Send email" link (`mailto:`) to member profile pages when the member has an email address on file
- Email is fetched via a join on `auth.users` in `getProfileForMember` — only visible to authenticated members (the existing auth guard on the page)
- `emergencyContact` remains self/admin-only; email is the contact affordance for peers

## Test plan
- [ ] Visit another member's profile — a "Send email" link should appear and open the system mail client
- [ ] Verify the link is absent if somehow no email is present
- [ ] Confirm `emergencyContact` is still NOT visible on another member's profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)