### PR TITLE
Show relation strength and edit affordance on member profile pages (#241)

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -2,8 +2,11 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { Avatar } from "@/components/avatar";
-import { serverApiClient } from "@/lib/api-server";
+import { QueryProvider } from "@/components/query-provider";
+import { loadMe, serverApiClient } from "@/lib/api-server";
 import type { MemberProfile } from "@/lib/api-types";
+
+import { MemberRelationControl } from "./relation-control";
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -16,6 +19,8 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 export default async function MemberProfilePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  const me = await loadMe();
+  if (!me) redirect("/signin");
   const res = await serverApiClient.api.members[":id"].$get({ param: { id } });
   if (res.status === 401) redirect("/signin");
   if (!res.ok && res.status !== 404) throw new Error(`Failed to load member ${id}: ${res.status}`);
@@ -37,42 +42,53 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
   const { profile }: { profile: MemberProfile } = await res.json();
   const memberSince = new Date(profile.createdAt).getFullYear();
 
+  const isOwnProfile = me.id === profile.id;
+
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-md items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">{profile.displayName ?? "Member"}</h1>
-          <p className="text-sm text-muted-foreground">Member since {memberSince}</p>
+    <QueryProvider>
+      <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+        <div className="flex w-full max-w-md items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold">{profile.displayName ?? "Member"}</h1>
+            <p className="text-sm text-muted-foreground">Member since {memberSince}</p>
+          </div>
+          <Link href="/members" className="text-base text-muted-foreground hover:text-foreground">
+            ← Directory
+          </Link>
         </div>
-        <Link href="/members" className="text-base text-muted-foreground hover:text-foreground">
-          ← Directory
-        </Link>
-      </div>
 
-      <Avatar
-        name={profile.displayName}
-        url={profile.avatarUrl}
-        sizes="128px"
-        priority
-        className="flex h-32 w-32 items-center justify-center overflow-hidden rounded-full bg-muted text-3xl font-semibold text-muted-foreground"
-      />
+        <Avatar
+          name={profile.displayName}
+          url={profile.avatarUrl}
+          sizes="128px"
+          priority
+          className="flex h-32 w-32 items-center justify-center overflow-hidden rounded-full bg-muted text-3xl font-semibold text-muted-foreground"
+        />
 
-      <dl className="flex w-full max-w-md flex-col gap-4">
-        <Field label="Bio">{profile.bio}</Field>
-        <Field label="Keywords">{profile.keywords.length > 0 ? profile.keywords.join(", ") : null}</Field>
-        <Field label="Location">{profile.location}</Field>
-        <Field label="Live desire">{profile.liveDesire}</Field>
-        <Field label="Supplementary info">{profile.supplementaryInfo}</Field>
-      </dl>
+        {!isOwnProfile && (
+          <MemberRelationControl
+            memberId={profile.id}
+            memberName={profile.displayName}
+          />
+        )}
 
-      {profile.email && (
-        <a
-          href={`mailto:${profile.email}`}
-          className="text-base text-muted-foreground underline hover:text-foreground"
-        >
-          Send email
-        </a>
-      )}
-    </main>
+        <dl className="flex w-full max-w-md flex-col gap-4">
+          <Field label="Bio">{profile.bio}</Field>
+          <Field label="Keywords">{profile.keywords.length > 0 ? profile.keywords.join(", ") : null}</Field>
+          <Field label="Location">{profile.location}</Field>
+          <Field label="Live desire">{profile.liveDesire}</Field>
+          <Field label="Supplementary info">{profile.supplementaryInfo}</Field>
+        </dl>
+
+        {profile.email && (
+          <a
+            href={`mailto:${profile.email}`}
+            className="text-base text-muted-foreground underline hover:text-foreground"
+          >
+            Send email
+          </a>
+        )}
+      </main>
+    </QueryProvider>
   );
 }

--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 
 import { Avatar } from "@/components/avatar";
 import { QueryProvider } from "@/components/query-provider";
-import { loadMe, serverApiClient } from "@/lib/api-server";
+import { requireUser, serverApiClient } from "@/lib/api-server";
 import type { MemberProfile } from "@/lib/api-types";
 
 import { MemberRelationControl } from "./relation-control";
@@ -19,8 +19,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 export default async function MemberProfilePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const me = await loadMe();
-  if (!me) redirect("/signin");
+  const me = await requireUser();
   const res = await serverApiClient.api.members[":id"].$get({ param: { id } });
   if (res.status === 401) redirect("/signin");
   if (!res.ok && res.status !== 404) throw new Error(`Failed to load member ${id}: ${res.status}`);

--- a/src/app/members/[id]/relation-control.tsx
+++ b/src/app/members/[id]/relation-control.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/lib/api";
+import { RELATION_VALUE_LABELS, type RelationValue, isRelationValue } from "@/lib/relation-value";
+import { RelatingDialog } from "@/app/myweb/relating-dialog";
+import type { RelatingTarget } from "@/app/myweb/relating-dialog";
+
+type Props = {
+  memberId: string;
+  memberName: string | null;
+};
+
+export function MemberRelationControl({ memberId, memberName }: Props) {
+  const [dialogTarget, setDialogTarget] = useState<RelatingTarget | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["relations", "value", memberId],
+    queryFn: async () => {
+      const res = await apiClient.api.relations.value[":relateeId"].$get({
+        param: { relateeId: memberId },
+      });
+      if (!res.ok) throw new Error(`Failed to fetch relation: ${res.status}`);
+      return res.json();
+    },
+  });
+
+  const value = isRelationValue(data?.value) ? data.value : null;
+
+  return (
+    <>
+      <div className="flex items-center gap-3">
+        <span className="text-sm text-muted-foreground">
+          {isLoading
+            ? "Loading…"
+            : value !== null
+              ? `Connected · ${RELATION_VALUE_LABELS[value as RelationValue]}`
+              : "Not yet connected"}
+        </span>
+        <button
+          type="button"
+          onClick={() =>
+            setDialogTarget({ id: memberId, displayName: memberName, currentValue: value })
+          }
+          className="text-sm text-muted-foreground underline hover:no-underline"
+        >
+          {value !== null ? "Edit" : "Connect"}
+        </button>
+      </div>
+
+      <RelatingDialog
+        target={dialogTarget}
+        onClose={() => setDialogTarget(null)}
+      />
+    </>
+  );
+}

--- a/src/app/members/[id]/relation-control.tsx
+++ b/src/app/members/[id]/relation-control.tsx
@@ -4,9 +4,10 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "@/lib/api";
-import { RELATION_VALUE_LABELS, type RelationValue, isRelationValue } from "@/lib/relation-value";
+import { RELATION_VALUE_LABELS, isRelationValue } from "@/lib/relation-value";
 import { RelatingDialog } from "@/app/myweb/relating-dialog";
 import type { RelatingTarget } from "@/app/myweb/relating-dialog";
+import { relationValueQueryKey } from "@/app/myweb/query-keys";
 
 type Props = {
   memberId: string;
@@ -16,8 +17,8 @@ type Props = {
 export function MemberRelationControl({ memberId, memberName }: Props) {
   const [dialogTarget, setDialogTarget] = useState<RelatingTarget | null>(null);
 
-  const { data, isLoading } = useQuery({
-    queryKey: ["relations", "value", memberId],
+  const { data, isLoading, isError } = useQuery({
+    queryKey: relationValueQueryKey(memberId),
     queryFn: async () => {
       const res = await apiClient.api.relations.value[":relateeId"].$get({
         param: { relateeId: memberId },
@@ -35,9 +36,11 @@ export function MemberRelationControl({ memberId, memberName }: Props) {
         <span className="text-sm text-muted-foreground">
           {isLoading
             ? "Loading…"
-            : value !== null
-              ? `Connected · ${RELATION_VALUE_LABELS[value as RelationValue]}`
-              : "Not yet connected"}
+            : isError
+              ? "Couldn't load connection"
+              : value !== null
+                ? `Connected · ${RELATION_VALUE_LABELS[value].headline}`
+                : "Not yet connected"}
         </span>
         <button
           type="button"

--- a/src/app/myweb/query-keys.ts
+++ b/src/app/myweb/query-keys.ts
@@ -1,6 +1,8 @@
 export const RELATION_CANDIDATES_QUERY_KEY = ["relations", "candidates"] as const;
 export const RELATION_SUBGRAPH_QUERY_KEY = ["relations", "subgraph"] as const;
 
+export const relationValueQueryKey = (relateeId: string) => ["relations", "value", relateeId] as const;
+
 export type SubgraphViewOptions = {
   includeIncoming: boolean;
   hops: 1 | 2;

--- a/src/app/myweb/relating-dialog.tsx
+++ b/src/app/myweb/relating-dialog.tsx
@@ -9,7 +9,7 @@ import { apiClient } from "@/lib/api";
 import type { RelationCandidatesFeed } from "@/lib/api-types";
 import { RELATION_VALUE_LABELS, RELATION_VALUES, type RelationValue } from "@/lib/relation-value";
 
-import { RELATION_CANDIDATES_QUERY_KEY, RELATION_SUBGRAPH_QUERY_KEY } from "./query-keys";
+import { RELATION_CANDIDATES_QUERY_KEY, RELATION_SUBGRAPH_QUERY_KEY, relationValueQueryKey } from "./query-keys";
 
 export type RelatingTarget = {
   id: string;
@@ -57,12 +57,15 @@ export function RelatingDialog({ target, onClose }: Props) {
         queryClient.setQueryData(RELATION_CANDIDATES_QUERY_KEY, ctx.previous);
       }
     },
-    onSettled: () => {
+    onSettled: (_data, _err, { relateeId }) => {
       // Re-sync candidates and subgraph so any newly-revealed cards
       // (e.g. inviter's connections opened up by this rating) appear
       // and the graph picks up the new edge once it exists.
       queryClient.invalidateQueries({ queryKey: RELATION_CANDIDATES_QUERY_KEY });
       queryClient.invalidateQueries({ queryKey: RELATION_SUBGRAPH_QUERY_KEY });
+      // Refresh any per-member value reads (e.g. the member-profile control)
+      // so the displayed strength reflects the edit.
+      queryClient.invalidateQueries({ queryKey: relationValueQueryKey(relateeId) });
     },
   });
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -46,6 +46,7 @@ import {
   deleteRelationHint,
   getPersonalWeb,
   getRelationSuggestions,
+  getRelationValue,
   listPendingHints,
   parseOptionalRelationValue,
   updateRelationValue,
@@ -467,6 +468,13 @@ const api = new Hono<{ Variables: ApiVariables }>()
       includeHidden,
     });
     return c.json(subgraph);
+  })
+  .get("/relations/value/:relateeId", async (c) => {
+    const user = c.get("user");
+    const relateeId = c.req.param("relateeId");
+    if (!isUuid(relateeId)) return c.json({ error: "relateeId must be a UUID" }, 400);
+    const value = await getRelationValue({ relatorId: user.id, relateeId });
+    return c.json({ value });
   })
   // hono/validator typed body — without it, Hono's RPC inference on a
   // route with a path param rejects the `json` key on the typed call.

--- a/src/server/relations.ts
+++ b/src/server/relations.ts
@@ -406,6 +406,23 @@ const isForeignKeyViolation = (err: unknown): boolean => {
   return (err as { cause?: { code?: string } }).cause?.code === "23503";
 };
 
+export const getRelationValue = async (params: {
+  relatorId: string;
+  relateeId: string;
+}): Promise<RelationValue | null> => {
+  const [row] = await db
+    .select({ value: relations.value })
+    .from(relations)
+    .where(
+      and(
+        eq(relations.relatorId, params.relatorId),
+        eq(relations.relateeId, params.relateeId),
+        eq(relations.isHint, false),
+      ),
+    );
+  return isRelationValue(row?.value) ? row.value : null;
+};
+
 export type UpdateRelationValueResult = { ok: true } | { error: "self_relating" | "relatee_not_found" };
 
 export const updateRelationValue = async (params: {

--- a/tests/functional/client/member-relation-control.test.tsx
+++ b/tests/functional/client/member-relation-control.test.tsx
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  apiClient: {
+    api: {
+      relations: {
+        value: {
+          ":relateeId": {
+            $get: vi.fn(),
+            $put: vi.fn(),
+          },
+        },
+      },
+    },
+  },
+}));
+
+import { apiClient } from "@/lib/api";
+import { MemberRelationControl } from "@/app/members/[id]/relation-control";
+
+const $get = vi.mocked(apiClient.api.relations.value[":relateeId"].$get);
+
+const mockValue = (value: number | null) => {
+  $get.mockResolvedValue({ ok: true, json: async () => ({ value }) } as never);
+};
+
+const mockFailure = () => {
+  $get.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) } as never);
+};
+
+const renderControl = (ui: ReactNode) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+describe("MemberRelationControl", () => {
+  it("shows the relation strength headline for an existing relation", async () => {
+    mockValue(2);
+    renderControl(<MemberRelationControl memberId="m1" memberName="Ada" />);
+
+    // Regression guard: the label must render the headline string, not the
+    // RELATION_VALUE_LABELS object (which stringifies to "[object Object]").
+    expect(await screen.findByText("Connected · Talked 1-on-1")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
+  });
+
+  it("shows a connect affordance when there is no relation", async () => {
+    mockValue(null);
+    renderControl(<MemberRelationControl memberId="m1" memberName="Ada" />);
+
+    expect(await screen.findByText("Not yet connected")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Connect" })).toBeVisible();
+  });
+
+  it("surfaces a load error instead of masking it as 'not connected'", async () => {
+    mockFailure();
+    renderControl(<MemberRelationControl memberId="m1" memberName="Ada" />);
+
+    expect(await screen.findByText("Couldn't load connection")).toBeVisible();
+  });
+});

--- a/tests/functional/server/relations.test.ts
+++ b/tests/functional/server/relations.test.ts
@@ -15,6 +15,7 @@ import { createInvite } from "@/server/invites";
 import {
   getPersonalWeb,
   getRelationSuggestions,
+  getRelationValue,
   materializeInviteRelations,
   updateRelationValue,
 } from "@/server/relations";
@@ -133,6 +134,42 @@ describe("updateRelationValue", () => {
   it("rejects rating a non-existent ratee", async () => {
     const r = await updateRelationValue({ relatorId, relateeId: randomUUID(), value: 3 });
     expect(r).toEqual({ error: "relatee_not_found" });
+  });
+});
+
+describe("getRelationValue", () => {
+  let relatorId: string;
+  let relateeId: string;
+
+  beforeEach(async () => {
+    relatorId = randomUUID();
+    relateeId = randomUUID();
+    await insertUserAndProfile(relatorId);
+    await insertUserAndProfile(relateeId);
+  });
+
+  afterEach(async () => {
+    await deleteUserAndProfile(relatorId);
+    await deleteUserAndProfile(relateeId);
+  });
+
+  it("returns the value of a confirmed relation", async () => {
+    await updateRelationValue({ relatorId, relateeId, value: 3 });
+    expect(await getRelationValue({ relatorId, relateeId })).toBe(3);
+  });
+
+  it("returns null when no relation exists", async () => {
+    expect(await getRelationValue({ relatorId, relateeId })).toBeNull();
+  });
+
+  it("is directional — does not read the reverse edge", async () => {
+    await updateRelationValue({ relatorId: relateeId, relateeId: relatorId, value: 4 });
+    expect(await getRelationValue({ relatorId, relateeId })).toBeNull();
+  });
+
+  it("ignores hint rows (value-less, isHint=true)", async () => {
+    await db.insert(relations).values({ relatorId, relateeId, value: null, isHint: true, hintedBy: relateeId });
+    expect(await getRelationValue({ relatorId, relateeId })).toBeNull();
   });
 });
 
@@ -647,6 +684,44 @@ describe("materializeInviteRelations", () => {
 
     const rels = await db.select().from(relations).where(eq(relations.relateeId, redeemer));
     expect(rels).toEqual([]);
+  });
+});
+
+describe("GET /api/relations/value/:relateeId", () => {
+  let me: string;
+  let other: string;
+
+  beforeEach(async () => {
+    me = randomUUID();
+    other = randomUUID();
+    await insertUserAndProfile(me);
+    await insertUserAndProfile(other);
+    authAs(me);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(me);
+    await deleteUserAndProfile(other);
+  });
+
+  const get = (relateeId: string) => app.request(`/api/relations/value/${relateeId}`);
+
+  it("returns the value of an existing relation", async () => {
+    await updateRelationValue({ relatorId: me, relateeId: other, value: 2 });
+    const res = await get(other);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ value: 2 });
+  });
+
+  it("returns null when no relation exists", async () => {
+    const res = await get(other);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ value: null });
+  });
+
+  it("rejects a malformed UUID in the path", async () => {
+    expect((await get("not-a-uuid")).status).toBe(400);
   });
 });
 


### PR DESCRIPTION
Closes #241

## Summary
- Adds a `MemberRelationControl` client component to member profile pages showing whether the viewer is connected to that member and at what strength (Acquaintance / Friend / Close friend)
- Clicking the control opens the existing `RelatingDialog` to set or update the relation
- Hidden when viewing your own profile
- Fetches relation via new `GET /api/relations/value/:relateeId` endpoint

## Test plan
- [ ] Visit a member profile where you have an existing relation — should show "Connected · [strength]" with an Edit button
- [ ] Visit a member profile where you have no relation — should show "Not yet connected" with a Connect button
- [ ] Click Edit/Connect — `RelatingDialog` should open and save correctly
- [ ] Visit your own profile — relation control should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)