### PR TITLE
Add hover tooltip to web graph nodes (#240)

### DIFF
--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -76,7 +76,10 @@ const HANDLE_STYLE = { opacity: 0, top: "50%", pointerEvents: "none" as const };
 
 function MemberNode({ data }: NodeProps<Node<MemberNodeData>>) {
   return (
-    <div className="flex flex-col items-center gap-1">
+    <div
+      className="flex flex-col items-center gap-1"
+      title={data.isCenter ? undefined : (data.displayName ?? undefined)}
+    >
       <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
       <Handle type="source" position={Position.Top} style={HANDLE_STYLE} />
       <Avatar


### PR DESCRIPTION
Closes #240

## Summary
- Adds a native `title` attribute to each member node in the web graph showing the member's display name on hover
- No tooltip on the center (self) node — the name is already visible there

## Test plan
- [ ] Open `/myweb` and hover over a connected member node — a tooltip with their name should appear
- [ ] Confirm the center node has no tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)