### PR TITLE
Surface PR link and migration SQL on expand-schema approval gate

### DIFF
--- a/.github/workflows/forward-migrate-prod-schema-expansion.yml
+++ b/.github/workflows/forward-migrate-prod-schema-expansion.yml
@@ -1,4 +1,5 @@
 name: Forward-migrate prod schema (expansion)
+run-name: "Expand prod schema for ${{ inputs.ref }}"
 
 # Manually triggered. Applies additive (expand) drizzle migrations to
 # the prod DB ahead of opening a PR, so previews can exercise new code
@@ -6,6 +7,13 @@ name: Forward-migrate prod schema (expansion)
 # the DB it queries — see docs/strategy-committing.md). Contract
 # migrations do NOT use this workflow — they ride the standard
 # merge-to-main path so they only apply once the new code is live.
+#
+# Two jobs: `prep` runs ungated and surfaces the PR link, migration
+# diff, and destructive-migration guard to the reviewer; `migrate`
+# carries the prod-db environment gate and only runs the actual
+# drizzle-kit migrate after approval. Splitting them lets the reviewer
+# see the migration SQL and refuse early on a destructive pattern,
+# rather than approving first and discovering the workflow self-rejects.
 
 on:
   workflow_dispatch:
@@ -17,12 +25,17 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read    # prep job's `gh pr list` lookup
 
 jobs:
-  migrate:
-    name: Apply expand migrations to production DB
+  prep:
+    name: Preview migrations and look up PR
     runs-on: ubuntu-latest
-    environment: prod-db    # required-reviewer gate lives here
+    outputs:
+      # Surfaced to the gated job as `environment.url`, which becomes
+      # the clickable link on the approval card. Falls back to the repo
+      # root when the dispatched ref has no open PR (e.g., direct SHA).
+      pr_url: ${{ steps.lookup.outputs.pr_url }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -31,37 +44,64 @@ jobs:
           # against main for the show-migrations + destructive-guard
           # steps below.
           fetch-depth: 0
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-      - run: npm ci
+
+      - name: Look up PR for ref
+        id: lookup
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          pr=$(gh pr list --repo "${{ github.repository }}" \
+                          --head "${{ inputs.ref }}" \
+                          --state open \
+                          --json url --jq '.[0].url' \
+                || true)
+          if [ -z "$pr" ]; then
+            pr="https://github.com/${{ github.repository }}"
+          fi
+          echo "pr_url=$pr" >> "$GITHUB_OUTPUT"
+          echo "PR: $pr"
 
       - name: Show migrations to be applied
         run: |
           set -e
           git fetch --depth=1 origin main
-          echo "## Migration files changed vs main"
-          git diff --stat origin/main...HEAD -- drizzle/ || true
           changed=$(git diff --name-only origin/main...HEAD -- 'drizzle/*.sql')
           if [ -z "$changed" ]; then
-            echo "No new .sql migrations vs main. Nothing to apply — failing fast."
+            echo "::error::No new .sql migrations vs main. Nothing to apply."
             exit 1
           fi
-          echo ""
-          echo "## Migration file contents"
-          for f in $changed; do
-            echo "----- $f -----"
-            cat "$f"
+          # Both stdout (job log) and $GITHUB_STEP_SUMMARY (visible on
+          # the run page before approval — gives the reviewer the diff
+          # to read while deciding).
+          {
+            echo "## Migrations to apply"
             echo ""
-          done
+            echo "**Dispatched ref:** \`${{ inputs.ref }}\`"
+            echo "**PR:** ${{ steps.lookup.outputs.pr_url }}"
+            echo ""
+            echo "### Changed files"
+            echo '```'
+            git diff --stat origin/main...HEAD -- drizzle/
+            echo '```'
+            echo ""
+            echo "### Migration SQL"
+            for f in $changed; do
+              echo ""
+              echo "#### \`$f\`"
+              echo '```sql'
+              cat "$f"
+              echo '```'
+            done
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Guard against destructive migrations
         run: |
           set -e
           # Expand-only workflow. Contract migrations (DROP, RENAME, type
           # changes) must ride the merge-to-main path so they only apply
-          # once the new code is live.
+          # once the new code is live. Catching this in the pre-gate job
+          # means a reviewer never approves a run that's going to refuse.
           patterns='drop column|drop table|drop constraint|rename column|rename to|alter column.*drop'
           matches=$(git diff origin/main...HEAD -- 'drizzle/*.sql' | grep -iE "^\+[^+].*($patterns)" || true)
           if [ -n "$matches" ]; then
@@ -70,6 +110,23 @@ jobs:
             echo "$matches"
             exit 1
           fi
+
+  migrate:
+    name: Apply expand migrations to production DB
+    needs: prep
+    runs-on: ubuntu-latest
+    environment:
+      name: prod-db    # required-reviewer gate lives here
+      url: ${{ needs.prep.outputs.pr_url }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
 
       - name: Run drizzle-kit migrate
         run: node scripts/migrate.mjs


### PR DESCRIPTION
## Summary

Splits `forward-migrate-prod-schema-expansion.yml` into two jobs so the prod-db reviewer has context *before* approving:

- **`prep`** (ungated) — checks out the dispatched ref, looks up the open PR via `gh pr list --head`, runs the migration preview, and runs the destructive-migration guard. Writes a markdown summary (PR link + changed files + full SQL of every new migration) to `$GITHUB_STEP_SUMMARY`. Surfaces `pr_url` as a job output.
- **`migrate`** (`needs: prep`, gated on `prod-db`) — consumes `needs.prep.outputs.pr_url` as `environment.url`, runs `drizzle-kit migrate`.

Also adds a top-level `run-name: "Expand prod schema for ${{ inputs.ref }}"` so the Actions list shows the dispatched ref directly.

## What changes for the reviewer

- Actions list title: branch/SHA is visible without clicking in.
- Approval card: "View deployment" link → opens the PR the migration is coming from. Falls back to the repo root if the ref has no open PR (e.g., a direct SHA).
- Workflow run page (before approval): markdown summary with the migration SQL.
- A destructive migration (`DROP COLUMN`, `RENAME`, etc.) fails `prep`, so reviewers no longer get pinged for a run that would self-reject post-approval.

## Tested

The `gh pr list --head $ref` lookup verified against three cases:
- Open PR (`hidden-accounts`) → returns the PR URL.
- Branch with no open PR (`main`) → empty stdout, exit 0 → fallback fires.
- A SHA (realistic non-branch dispatch) → empty stdout, exit 0 → fallback fires.

No 3rd-party actions added — `actions/checkout@v6` and `actions/setup-node@v6` are the same first-party actions the workflow already used. `gh` is preinstalled on the runner.

## Permissions

Adds `pull-requests: read` so `gh pr list` works. The existing `contents: read` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)