### PR TITLE
Fix shallow main fetch breaking merge-base in expand workflow

### DIFF
--- a/.github/workflows/forward-migrate-prod-schema-expansion.yml
+++ b/.github/workflows/forward-migrate-prod-schema-expansion.yml
@@ -65,7 +65,13 @@ jobs:
       - name: Show migrations to be applied
         run: |
           set -e
-          git fetch --depth=1 origin main
+          # No explicit `git fetch origin main` here — actions/checkout
+          # above ran with fetch-depth: 0, which fetches every branch
+          # (including main) at full depth. A `git fetch --depth=1
+          # origin main` would mark origin/main as shallow at its tip,
+          # which then breaks `git merge-base` for any dispatched ref
+          # whose merge-base with main is more than one commit back —
+          # the failure mode that surfaced in run 26247166397.
           changed=$(git diff --name-only origin/main...HEAD -- 'drizzle/*.sql')
           if [ -z "$changed" ]; then
             echo "::error::No new .sql migrations vs main. Nothing to apply."


### PR DESCRIPTION
## Summary

The expand workflow's prep job called `git fetch --depth=1 origin main` after `actions/checkout@v6` had already pulled every branch at full depth via `fetch-depth: 0`. The shallow refetch then marked `origin/main` as shallow at its tip, so `git merge-base origin/main HEAD` failed with "no merge base" whenever the dispatched ref's merge-base with main sat more than one commit behind main's tip.

Surfaced in [run 26247166397](https://github.com/Intentional-Society/is-app/actions/runs/26247166397) — dispatched against `hidden-accounts` after #253 had advanced main past that branch's merge-base.

## Fix

Drop the redundant shallow fetch. `actions/checkout@v6 with fetch-depth: 0` already brings all branches at full depth, and main can't have advanced between the checkout step and the next step in the same job.

The same bug was latent in the original (pre-split) workflow but didn't bite until main moved.

## Test plan

- [x] Confirmed `actions/checkout@v6 fetch-depth: 0` fetches all heads (run log shows every `origin/*` branch arriving in the initial fetch refspec `+refs/heads/*:refs/remotes/origin/*`).
- [ ] Reviewer: re-dispatch against `hidden-accounts` after merge and confirm prep completes and writes the migration summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)