### PR TITLE
Polish programs (#226)

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-21 | James | Polish programs (#226)
+
+Four bundled improvements: new members are auto-subscribed to the weekly web update on first sign-in; programs gain `archivedAt` (hidden from members) and `signupsOpen` (gates self-serve join, closed by default); `profile_programs` becomes soft-deleted via `leftAt` so the original `assignedAt` survives leave/rejoin as a stable first-joined date; per-program detail pages live at `/programs/[slug]`.
+
 ## 2026-05-20 | James | Hidden accounts
 
 Admins can hide profiles from the `/admin` page; hidden profiles disappear from the directory, web, and suggestions for non-admins. #168.

--- a/drizzle/0008_add_programs_archive_signups.sql
+++ b/drizzle/0008_add_programs_archive_signups.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "programs" ADD COLUMN "archived_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "programs" ADD COLUMN "signups_open" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+-- Existing programs predate the closed-by-default policy and have been
+-- accepting self-serve joins, so open them. New programs created after
+-- this migration get the column default (false) and must be opened
+-- explicitly by an admin.
+UPDATE "programs" SET "signups_open" = true;

--- a/drizzle/0009_add_profile_programs_left_at.sql
+++ b/drizzle/0009_add_profile_programs_left_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "profile_programs" ADD COLUMN "left_at" timestamp with time zone;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,635 @@
+{
+  "id": "1f128df2-af01-4bd2-a33c-3303c509cd2f",
+  "prevId": "d6cccdc6-c2c0-4513-ae51-eb09128f4230",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.invite_hints": {
+      "name": "invite_hints",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_hints_invite_id_invites_id_fk": {
+          "name": "invite_hints_invite_id_invites_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "invites",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_hints_ratee_id_profiles_id_fk": {
+          "name": "invite_hints_ratee_id_profiles_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_hints_invite_id_ratee_id_pk": {
+          "name": "invite_hints_invite_id_ratee_id_pk",
+          "columns": [
+            "invite_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by": {
+          "name": "redeemed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_value": {
+          "name": "creator_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_profiles_id_fk": {
+          "name": "invites_created_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_profiles_id_fk": {
+          "name": "invites_redeemed_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "redeemed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_redemption_pair": {
+          "name": "invites_redemption_pair",
+          "value": "(\"invites\".\"redeemed_by\" IS NULL) = (\"invites\".\"redeemed_at\" IS NULL)"
+        },
+        "invites_expires_after_created": {
+          "name": "invites_expires_after_created",
+          "value": "\"invites\".\"expires_at\" > \"invites\".\"created_at\""
+        },
+        "invites_creator_value_range": {
+          "name": "invites_creator_value_range",
+          "value": "\"invites\".\"creator_value\" IS NULL OR (\"invites\".\"creator_value\" BETWEEN 1 AND 4)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profile_programs": {
+      "name": "profile_programs",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_programs_profile_id_profiles_id_fk": {
+          "name": "profile_programs_profile_id_profiles_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_programs_program_id_programs_id_fk": {
+          "name": "profile_programs_program_id_programs_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_programs_profile_id_program_id_pk": {
+          "name": "profile_programs_profile_id_program_id_pk",
+          "columns": [
+            "profile_id",
+            "program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplementary_info": {
+          "name": "supplementary_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by": {
+          "name": "referred_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by_legacy": {
+          "name": "referred_by_legacy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_desire": {
+          "name": "live_desire",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_signed_agreements": {
+          "name": "last_signed_agreements",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_profile": {
+          "name": "last_updated_profile",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reviewed_programs": {
+          "name": "last_reviewed_programs",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_web": {
+          "name": "last_updated_web",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profiles_referred_by_profiles_id_fk": {
+          "name": "profiles_referred_by_profiles_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "referred_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_slug_unique": {
+          "name": "profiles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signups_open": {
+          "name": "signups_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_slug_unique": {
+          "name": "programs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "rater_id": {
+          "name": "rater_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hint": {
+          "name": "is_hint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hinted_by": {
+          "name": "hinted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "relations_rater_id_profiles_id_fk": {
+          "name": "relations_rater_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "rater_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_ratee_id_profiles_id_fk": {
+          "name": "relations_ratee_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_hinted_by_profiles_id_fk": {
+          "name": "relations_hinted_by_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "hinted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "relations_rater_id_ratee_id_pk": {
+          "name": "relations_rater_id_ratee_id_pk",
+          "columns": [
+            "rater_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relations_no_self": {
+          "name": "relations_no_self",
+          "value": "\"relations\".\"rater_id\" != \"relations\".\"ratee_id\""
+        },
+        "relations_value_range": {
+          "name": "relations_value_range",
+          "value": "\"relations\".\"value\" IS NULL OR (\"relations\".\"value\" BETWEEN 1 AND 4)"
+        },
+        "relations_hint_state": {
+          "name": "relations_hint_state",
+          "value": "(NOT \"relations\".\"is_hint\" AND \"relations\".\"value\" IS NOT NULL)\n       OR (\"relations\".\"is_hint\" AND \"relations\".\"value\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,641 @@
+{
+  "id": "94eb3abb-3699-4c0a-ad73-137d3573b3b3",
+  "prevId": "1f128df2-af01-4bd2-a33c-3303c509cd2f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.invite_hints": {
+      "name": "invite_hints",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_hints_invite_id_invites_id_fk": {
+          "name": "invite_hints_invite_id_invites_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "invites",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_hints_ratee_id_profiles_id_fk": {
+          "name": "invite_hints_ratee_id_profiles_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_hints_invite_id_ratee_id_pk": {
+          "name": "invite_hints_invite_id_ratee_id_pk",
+          "columns": [
+            "invite_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by": {
+          "name": "redeemed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_value": {
+          "name": "creator_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_profiles_id_fk": {
+          "name": "invites_created_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_profiles_id_fk": {
+          "name": "invites_redeemed_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "redeemed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_redemption_pair": {
+          "name": "invites_redemption_pair",
+          "value": "(\"invites\".\"redeemed_by\" IS NULL) = (\"invites\".\"redeemed_at\" IS NULL)"
+        },
+        "invites_expires_after_created": {
+          "name": "invites_expires_after_created",
+          "value": "\"invites\".\"expires_at\" > \"invites\".\"created_at\""
+        },
+        "invites_creator_value_range": {
+          "name": "invites_creator_value_range",
+          "value": "\"invites\".\"creator_value\" IS NULL OR (\"invites\".\"creator_value\" BETWEEN 1 AND 4)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profile_programs": {
+      "name": "profile_programs",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_programs_profile_id_profiles_id_fk": {
+          "name": "profile_programs_profile_id_profiles_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_programs_program_id_programs_id_fk": {
+          "name": "profile_programs_program_id_programs_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_programs_profile_id_program_id_pk": {
+          "name": "profile_programs_profile_id_program_id_pk",
+          "columns": [
+            "profile_id",
+            "program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplementary_info": {
+          "name": "supplementary_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by": {
+          "name": "referred_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by_legacy": {
+          "name": "referred_by_legacy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_desire": {
+          "name": "live_desire",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_signed_agreements": {
+          "name": "last_signed_agreements",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_profile": {
+          "name": "last_updated_profile",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reviewed_programs": {
+          "name": "last_reviewed_programs",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_web": {
+          "name": "last_updated_web",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profiles_referred_by_profiles_id_fk": {
+          "name": "profiles_referred_by_profiles_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "referred_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_slug_unique": {
+          "name": "profiles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signups_open": {
+          "name": "signups_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_slug_unique": {
+          "name": "programs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "rater_id": {
+          "name": "rater_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hint": {
+          "name": "is_hint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hinted_by": {
+          "name": "hinted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "relations_rater_id_profiles_id_fk": {
+          "name": "relations_rater_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "rater_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_ratee_id_profiles_id_fk": {
+          "name": "relations_ratee_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_hinted_by_profiles_id_fk": {
+          "name": "relations_hinted_by_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "hinted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "relations_rater_id_ratee_id_pk": {
+          "name": "relations_rater_id_ratee_id_pk",
+          "columns": [
+            "rater_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relations_no_self": {
+          "name": "relations_no_self",
+          "value": "\"relations\".\"rater_id\" != \"relations\".\"ratee_id\""
+        },
+        "relations_value_range": {
+          "name": "relations_value_range",
+          "value": "\"relations\".\"value\" IS NULL OR (\"relations\".\"value\" BETWEEN 1 AND 4)"
+        },
+        "relations_hint_state": {
+          "name": "relations_hint_state",
+          "value": "(NOT \"relations\".\"is_hint\" AND \"relations\".\"value\" IS NOT NULL)\n       OR (\"relations\".\"is_hint\" AND \"relations\".\"value\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1779343350896,
       "tag": "0007_add_profile_hidden",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1779344236894,
+      "tag": "0008_add_programs_archive_signups",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1779344236894,
       "tag": "0008_add_programs_archive_signups",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1779344925149,
+      "tag": "0009_add_profile_programs_left_at",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed-dev.ts
+++ b/scripts/seed-dev.ts
@@ -129,11 +129,16 @@ async function seedProfiles(): Promise<SeedResult> {
 }
 
 async function seedPrograms(): Promise<SeedResult> {
+  // The column default for signups_open is false (closed-by-default for
+  // newly-created programs), but the dev seed represents the live state
+  // of running programs — they should be joinable without admin
+  // intervention. Override here so a fresh seed isn't dead on arrival.
   const values = seedData.programs.map((p) => ({
     id: p.id,
     slug: p.slug,
     name: p.name,
     description: p.description,
+    signupsOpen: true,
   }));
   const result = await db.insert(programs).values(values).onConflictDoNothing().returning({ id: programs.id });
   return { inserted: result.length, skipped: values.length - result.length };

--- a/src/app/admin/programs/[id]/program-detail.tsx
+++ b/src/app/admin/programs/[id]/program-detail.tsx
@@ -63,7 +63,13 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
   const invalidate = () => queryClient.invalidateQueries({ queryKey: programQueryKey(program.id) });
 
   const updateMutation = useMutation({
-    mutationFn: async (vars: { name: string; slug: string; description: string | null }) => {
+    mutationFn: async (vars: {
+      name?: string;
+      slug?: string;
+      description?: string | null;
+      archived?: boolean;
+      signupsOpen?: boolean;
+    }) => {
       const res = await apiClient.api.admin.programs[":id"].$patch({
         param: { id: program.id },
         json: vars,
@@ -231,6 +237,48 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
             {editError}
           </p>
         )}
+      </section>
+
+      <section className="flex flex-col gap-3 rounded border border-border p-3">
+        <h2 className="text-base font-semibold uppercase tracking-wide text-muted-foreground">Visibility</h2>
+        <div className="flex flex-col gap-2 text-sm">
+          <div className="flex items-center justify-between gap-3">
+            <span>
+              <span className="font-medium">Signups</span>{" "}
+              <span className="text-muted-foreground">
+                — {program.signupsOpen ? "members can join from /programs" : "self-serve join is disabled"}
+              </span>
+            </span>
+            <Button
+              type="button"
+              variant="secondary"
+              size="xs"
+              disabled={updateMutation.isPending}
+              onClick={() => updateMutation.mutate({ signupsOpen: !program.signupsOpen })}
+            >
+              {program.signupsOpen ? "Close signups" : "Open signups"}
+            </Button>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <span>
+              <span className="font-medium">Archived</span>{" "}
+              <span className="text-muted-foreground">
+                {program.archivedAt
+                  ? `— hidden from /programs since ${new Date(program.archivedAt).toLocaleDateString()}`
+                  : "— visible to members on /programs"}
+              </span>
+            </span>
+            <Button
+              type="button"
+              variant="secondary"
+              size="xs"
+              disabled={updateMutation.isPending}
+              onClick={() => updateMutation.mutate({ archived: program.archivedAt === null })}
+            >
+              {program.archivedAt ? "Unarchive" : "Archive"}
+            </Button>
+          </div>
+        </div>
       </section>
 
       <section className="flex flex-col gap-3">

--- a/src/app/admin/programs/programs-admin.tsx
+++ b/src/app/admin/programs/programs-admin.tsx
@@ -142,7 +142,19 @@ export function ProgramsAdmin() {
                   className="flex items-center gap-3 rounded border border-border p-3 hover:bg-muted/50"
                 >
                   <span className="flex flex-col">
-                    <span className="text-sm font-semibold">{p.name}</span>
+                    <span className="flex items-center gap-2 text-sm font-semibold">
+                      {p.name}
+                      {p.archivedAt && (
+                        <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                          Archived
+                        </span>
+                      )}
+                      {!p.archivedAt && !p.signupsOpen && (
+                        <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                          Signups closed
+                        </span>
+                      )}
+                    </span>
                     <span className="text-xs text-muted-foreground">
                       {p.memberCount} {p.memberCount === 1 ? "participant" : "participants"}
                     </span>

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,11 +1,24 @@
+import * as Sentry from "@sentry/nextjs";
 import { and, eq, gt, isNull, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 import { createClient } from "@/lib/supabase/server";
 import { db } from "@/server/db";
+import { autoSubscribeNewMember } from "@/server/programs";
 import { upsertProfile } from "@/server/profiles";
 import { materializeInviteRelations } from "@/server/relations";
 import { invites, profiles } from "@/server/schema";
+
+// Best-effort wrapper around the auto-subscribe step. Failures are
+// captured to Sentry and swallowed so a hiccup here never breaks
+// sign-in — the member can join later from /programs.
+const tryAutoSubscribe = async (userId: string): Promise<void> => {
+  try {
+    await autoSubscribeNewMember(userId);
+  } catch (err) {
+    Sentry.captureException(err);
+  }
+};
 
 export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get("code");
@@ -27,10 +40,14 @@ export async function GET(request: NextRequest) {
 
   // Ordinary sign-in — Phase 1 upsert, referredBy stays null.
   if (!invite) {
+    let result: { created: boolean };
     try {
-      await upsertProfile(data.user);
+      result = await upsertProfile(data.user);
     } catch {
       return NextResponse.redirect(new URL("/signin?error=profile_error", request.url));
+    }
+    if (result.created) {
+      await tryAutoSubscribe(data.user.id);
     }
     return NextResponse.redirect(new URL("/", request.url));
   }
@@ -46,10 +63,13 @@ export async function GET(request: NextRequest) {
   const displayName = (data.user.user_metadata?.displayName as string | undefined) ?? null;
 
   const userId = data.user.id;
-  let ok = false;
+  let result: { wasNewProfile: boolean } | null = null;
   try {
-    ok = await db.transaction(async (tx) => {
-      await tx
+    result = await db.transaction(async (tx) => {
+      // `xmax = 0` distinguishes a true insert from an ON CONFLICT
+      // UPDATE so the auto-subscribe step only fires on first sign-in,
+      // not when an existing member redeems a later invite.
+      const inserted = await tx
         .insert(profiles)
         .values({ id: userId, displayName })
         .onConflictDoUpdate({
@@ -57,7 +77,10 @@ export async function GET(request: NextRequest) {
           set: {
             displayName: sql`coalesce(${profiles.displayName}, excluded.display_name)`,
           },
-        });
+        })
+        .returning({ id: profiles.id, created: sql<boolean>`xmax = 0` });
+
+      const wasNewProfile = inserted[0]?.created === true;
 
       const rows = await tx
         .update(invites)
@@ -97,7 +120,7 @@ export async function GET(request: NextRequest) {
         relationValue,
       });
 
-      return true;
+      return { wasNewProfile };
     });
   } catch (err) {
     if (err instanceof InviteInvalid) {
@@ -107,8 +130,15 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL("/signin?error=profile_error", request.url));
   }
 
-  if (!ok) {
+  if (!result) {
     return NextResponse.redirect(new URL("/signin?error=profile_error", request.url));
+  }
+
+  // Auto-subscribe runs outside the redemption transaction: it is
+  // best-effort and a failure here must not roll back the consumed
+  // invite or leave the new member signed out.
+  if (result.wasNewProfile) {
+    await tryAutoSubscribe(userId);
   }
 
   return NextResponse.redirect(new URL("/", request.url));

--- a/src/app/programs/[slug]/page.tsx
+++ b/src/app/programs/[slug]/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { requireUser } from "@/lib/api-server";
+
+import { ProgramSlugDetail } from "./program-slug-detail";
+
+export default async function ProgramDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  await requireUser();
+  const { slug } = await params;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <div className="flex w-full max-w-3xl items-center justify-between">
+        <h1 className="text-2xl font-bold">Program</h1>
+        <Link href="/programs" className="text-base text-muted-foreground hover:text-foreground">
+          ← Programs
+        </Link>
+      </div>
+      <ProgramSlugDetail slug={slug} />
+    </main>
+  );
+}

--- a/src/app/programs/[slug]/program-slug-detail.tsx
+++ b/src/app/programs/[slug]/program-slug-detail.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { UrlObject } from "node:url";
+import Link from "next/link";
+
+import { Avatar } from "@/components/avatar";
+import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api";
+import type { ProgramDetail } from "@/lib/api-types";
+
+const programQueryKey = (slug: string) => ["programs", "by-slug", slug] as const;
+
+const fetchProgram = async (slug: string): Promise<ProgramDetail> => {
+  const res = await apiClient.api.programs["by-slug"][":slug"].$get({ param: { slug } });
+  // 404 is a final answer (archived or unknown), not a transient failure.
+  if (res.status === 404) throw new Error("not_found");
+  if (!res.ok) throw new Error(`programs/by-slug/${slug}: ${res.status}`);
+  const body = await res.json();
+  return body.program;
+};
+
+export function ProgramSlugDetail({ slug }: { slug: string }) {
+  const query = useQuery({
+    queryKey: programQueryKey(slug),
+    queryFn: () => fetchProgram(slug),
+    retry: false,
+  });
+
+  if (query.isPending) {
+    return <p className="w-full max-w-3xl text-sm text-muted-foreground">Loading…</p>;
+  }
+  if (query.isError) {
+    const missing = query.error instanceof Error && query.error.message === "not_found";
+    return (
+      <p role="alert" className="w-full max-w-3xl text-sm text-destructive">
+        {missing ? "Program not found." : "Couldn't load this program."}
+      </p>
+    );
+  }
+
+  return <ProgramBody program={query.data} />;
+}
+
+function ProgramBody({ program }: { program: ProgramDetail }) {
+  const queryClient = useQueryClient();
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: programQueryKey(program.slug) });
+
+  const joinMutation = useMutation({
+    mutationFn: async () => {
+      const res = await apiClient.api.programs[":id"].join.$post({ param: { id: program.id } });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(
+          body.error === "signups_closed"
+            ? "Signups for this program are closed."
+            : body.error === "already_joined"
+              ? "You've already joined this program."
+              : "Failed to join program.",
+        );
+      }
+      return res.json();
+    },
+    onSuccess: invalidate,
+  });
+
+  const leaveMutation = useMutation({
+    mutationFn: async () => {
+      const res = await apiClient.api.programs[":id"].leave.$post({ param: { id: program.id } });
+      if (!res.ok) throw new Error("Failed to leave program.");
+      return res.json();
+    },
+    onSuccess: invalidate,
+  });
+
+  const actionError =
+    joinMutation.error instanceof Error
+      ? joinMutation.error.message
+      : leaveMutation.error instanceof Error
+        ? leaveMutation.error.message
+        : null;
+  const pending = joinMutation.isPending || leaveMutation.isPending;
+
+  return (
+    <div className="flex w-full max-w-3xl flex-col gap-6">
+      <header className="flex flex-col gap-2">
+        <h2 className="text-3xl font-semibold">{program.name}</h2>
+        <p className="text-xs text-muted-foreground">
+          {program.memberCount} {program.memberCount === 1 ? "member" : "members"}
+          {program.joined && program.joinedAt && <> · Joined {formatDate(program.joinedAt)}</>}
+        </p>
+      </header>
+
+      {program.description && (
+        <p className="font-serif text-base text-muted-foreground leading-relaxed">
+          {program.description}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3">
+        {program.joined ? (
+          <Button
+            type="button"
+            variant="primary"
+            disabled={pending}
+            onClick={() => leaveMutation.mutate()}
+          >
+            {leaveMutation.isPending ? "Leaving…" : "Leave program"}
+          </Button>
+        ) : program.signupsOpen ? (
+          <Button type="button" disabled={pending} onClick={() => joinMutation.mutate()}>
+            {joinMutation.isPending ? "Joining…" : "Join program"}
+          </Button>
+        ) : (
+          <Button type="button" disabled>
+            Signups closed
+          </Button>
+        )}
+      </div>
+      {actionError && (
+        <p role="alert" className="text-sm text-destructive">
+          {actionError}
+        </p>
+      )}
+
+      <section className="flex flex-col gap-3">
+        <h3 className="text-base font-semibold uppercase tracking-wide text-muted-foreground">
+          Members ({program.members.length})
+        </h3>
+        {program.members.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No one's joined yet.</p>
+        ) : (
+          <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {program.members.map((m) => {
+              const href: UrlObject = { pathname: `/members/${m.slug ?? m.id}` };
+              return (
+                <li key={m.id}>
+                  <Link
+                    href={href}
+                    className="flex items-center gap-3 rounded border border-border p-2 text-sm hover:bg-muted/50"
+                  >
+                    <Avatar
+                      name={m.displayName}
+                      url={m.avatarUrl}
+                      className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-xs font-semibold text-muted-foreground"
+                    />
+                    <span>{m.displayName ?? "—"}</span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function formatDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+  } catch {
+    return iso;
+  }
+}

--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { UrlObject } from "node:url";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -28,7 +30,14 @@ function ProgramCard({
   return (
     <li className="flex flex-col gap-3 rounded-xl border border-border bg-card p-5">
       <div className="flex flex-col gap-1">
-        <h2 className="text-lg font-semibold">{program.name}</h2>
+        <h2 className="text-lg font-semibold">
+          <Link
+            href={{ pathname: `/programs/${program.slug}` } satisfies UrlObject}
+            className="hover:underline focus-visible:underline"
+          >
+            {program.name}
+          </Link>
+        </h2>
         <p className="text-xs text-muted-foreground">
           {program.memberCount} {program.memberCount === 1 ? "member" : "members"}
           {program.joined && program.joinedAt && <> · Joined {formatDate(program.joinedAt)}</>}

--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -61,9 +61,15 @@ function ProgramCard({
           >
             {pending ? "Leaving…" : "Leave program"}
           </Button>
-        ) : (
+        ) : program.signupsOpen ? (
           <Button type="button" disabled={pending} onClick={() => onJoin(program.id)} className="w-full">
             {pending ? "Joining…" : "Join program"}
+          </Button>
+        ) : (
+          // Self-serve join is gated by signupsOpen — an admin can still
+          // add a member directly, but the button stays out of reach.
+          <Button type="button" disabled className="w-full">
+            Signups closed
           </Button>
         )}
       </div>
@@ -110,7 +116,11 @@ export function ProgramsList() {
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string };
         setActionError(
-          body.error === "already_joined" ? "You've already joined this program." : "Failed to join program.",
+          body.error === "already_joined"
+            ? "You've already joined this program."
+            : body.error === "signups_closed"
+              ? "Signups for this program are closed."
+              : "Failed to join program.",
         );
       }
       reload();

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -19,6 +19,13 @@ export type ProgramsResponse = InferResponseType<(typeof apiClient.api.programs)
 
 export type Program = ProgramsResponse["programs"][number];
 
+export type ProgramDetail = InferResponseType<
+  (typeof apiClient.api.programs)["by-slug"][":slug"]["$get"],
+  200
+>["program"];
+
+export type ProgramDetailMember = ProgramDetail["members"][number];
+
 export type AdminProgram = InferResponseType<
   (typeof apiClient.api.admin.programs)["$get"],
   200

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -418,6 +418,9 @@ const api = new Hono<{ Variables: ApiVariables }>()
       if (result.error === "not_found") {
         return c.json({ error: "not_found" }, 404);
       }
+      if (result.error === "signups_closed") {
+        return c.json({ error: "signups_closed" }, 409);
+      }
       return c.json({ error: "already_joined" }, 409);
     }
     return c.json({ ok: true });

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -30,6 +30,7 @@ import {
   addParticipant,
   createProgram,
   deleteProgram,
+  getProgramBySlug,
   getProgramDetail,
   joinProgram,
   leaveProgram,
@@ -409,6 +410,15 @@ const api = new Hono<{ Variables: ApiVariables }>()
     const user = c.get("user");
     const programsList = await listPrograms(user.id);
     return c.json({ programs: programsList });
+  })
+  // Slug lives under a /by-slug/ prefix so it doesn't collide with the
+  // UUID-keyed /:id/join and /:id/leave routes above.
+  .get("/programs/by-slug/:slug", async (c) => {
+    const user = c.get("user");
+    const slug = c.req.param("slug");
+    const result = await getProgramBySlug(slug, user.id);
+    if ("error" in result) return c.json({ error: "not_found" }, 404);
+    return c.json({ program: result.program });
   })
   .post("/programs/:id/join", async (c) => {
     const user = c.get("user");

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -78,11 +78,22 @@ export const toSlug = (displayName: string): string =>
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "");
 
-export const upsertProfile = async (user: User) => {
+// Returns { created: true } only when a brand-new profile row was
+// inserted. Callers (notably /auth/callback) use this to gate
+// once-per-member side effects like auto-subscribing to the weekly web
+// update — DO NOTHING returns no rows on conflict, so a non-empty
+// RETURNING means "this was a first-time sign-in".
+export const upsertProfile = async (user: User): Promise<{ created: boolean }> => {
   const displayName = (user.user_metadata?.displayName as string | undefined) ?? null;
   const slug = displayName ? toSlug(displayName) : null;
 
-  await db.insert(profiles).values({ id: user.id, displayName, slug }).onConflictDoNothing({ target: profiles.id });
+  const rows = await db
+    .insert(profiles)
+    .values({ id: user.id, displayName, slug })
+    .onConflictDoNothing({ target: profiles.id })
+    .returning({ id: profiles.id });
+
+  return { created: rows.length > 0 };
 };
 
 export type ProfileForSelf = {

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -1,9 +1,45 @@
-import { and, asc, eq, ne, notExists, sql } from "drizzle-orm";
+import * as Sentry from "@sentry/nextjs";
+import { and, asc, eq, inArray, ne, notExists, sql } from "drizzle-orm";
 
 import { isUuid } from "./auth-middleware";
 import { attachAvatarUrls } from "./avatars";
 import { db } from "./db";
 import { profilePrograms, profiles, programs } from "./schema";
+
+// Slugs of programs every new member is enrolled in automatically on
+// first sign-in. The welcome flow's "We added one for you" copy on
+// /welcome/programs points at this list. Mirrors the same constant in
+// scripts/import-members-csv.ts — keep them in sync.
+const AUTO_SUBSCRIBE_SLUGS = ["weekly-web-updates"] as const;
+
+// Best-effort: subscribe a freshly-created member to the auto-subscribe
+// programs. A missing slug is logged to Sentry and skipped rather than
+// failing — sign-in shouldn't break over a misconfigured program list,
+// and operators can patch the database after the fact. Idempotent via
+// onConflictDoNothing, but callers should still gate on "is this a new
+// profile" so re-subscribing won't undo a member's opt-out.
+export const autoSubscribeNewMember = async (userId: string): Promise<void> => {
+  const rows = await db
+    .select({ id: programs.id, slug: programs.slug })
+    .from(programs)
+    .where(inArray(programs.slug, AUTO_SUBSCRIBE_SLUGS as unknown as string[]));
+
+  const found = new Set(rows.map((r) => r.slug));
+  for (const slug of AUTO_SUBSCRIBE_SLUGS) {
+    if (!found.has(slug)) {
+      Sentry.captureException(
+        new Error(`autoSubscribeNewMember: program slug "${slug}" not found in database`),
+      );
+    }
+  }
+
+  if (rows.length === 0) return;
+
+  await db
+    .insert(profilePrograms)
+    .values(rows.map((r) => ({ profileId: userId, programId: r.id })))
+    .onConflictDoNothing();
+};
 
 export type ProgramWithMembership = {
   id: string;

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -60,6 +60,11 @@ export type ProgramWithMembership = {
 // Archived programs are hidden — admins manage them via /admin/programs.
 // signupsOpen is returned so the client can disable the join button on
 // programs that are still listed but not currently accepting joins.
+//
+// "Member" means currently joined (left_at IS NULL). Left memberships
+// stay in the table to preserve the original assigned_at as the stable
+// first-joined date across rejoin cycles, but they don't count toward
+// member counts or the viewer's joined flag.
 export const listPrograms = async (userId: string): Promise<ProgramWithMembership[]> => {
   const rows = await db
     .select({
@@ -71,11 +76,13 @@ export const listPrograms = async (userId: string): Promise<ProgramWithMembershi
       memberCount: sql<number>`(
         SELECT count(*)::int FROM ${profilePrograms}
         WHERE ${profilePrograms.programId} = ${programs.id}
+          AND ${profilePrograms.leftAt} IS NULL
       )`,
       joinedAt: sql<string | null>`(
         SELECT to_json(${profilePrograms.assignedAt}) #>> '{}' FROM ${profilePrograms}
         WHERE ${profilePrograms.programId} = ${programs.id}
           AND ${profilePrograms.profileId} = ${userId}
+          AND ${profilePrograms.leftAt} IS NULL
       )`,
     })
     .from(programs)
@@ -125,11 +132,22 @@ export const joinProgram = async (
   // Self-heal: ensure profile row exists before FK insert
   await ensureProfile(userId);
 
-  // Insert membership — conflict means already joined
+  // Three cases on the composite-PK conflict, all handled atomically:
+  //   - No row yet → INSERT. assignedAt = now() is the stable first-
+  //     joined timestamp from this moment forward.
+  //   - Row exists with leftAt IS NOT NULL → rejoin: clear leftAt,
+  //     leave assignedAt alone so the original join date survives.
+  //   - Row exists with leftAt IS NULL → already a current member;
+  //     the WHERE on DO UPDATE blocks the no-op write, returning() is
+  //     empty, and we surface already_joined.
   const result = await db
     .insert(profilePrograms)
     .values({ profileId: userId, programId })
-    .onConflictDoNothing()
+    .onConflictDoUpdate({
+      target: [profilePrograms.profileId, profilePrograms.programId],
+      set: { leftAt: null },
+      setWhere: sql`${profilePrograms.leftAt} IS NOT NULL`,
+    })
     .returning({ profileId: profilePrograms.profileId });
 
   if (result.length === 0) return { error: "already_joined" };
@@ -143,9 +161,20 @@ export const leaveProgram = async (
 ): Promise<{ ok: true } | { error: "not_found" }> => {
   if (!isUuid(programId)) return { error: "not_found" };
 
+  // Soft delete — flip leftAt instead of removing the row, so a future
+  // rejoin can preserve the original assignedAt. The leftAt IS NULL
+  // predicate makes the call idempotent against double-leaves: a row
+  // already marked left returns no result, surfacing as not_found.
   const result = await db
-    .delete(profilePrograms)
-    .where(and(eq(profilePrograms.profileId, userId), eq(profilePrograms.programId, programId)))
+    .update(profilePrograms)
+    .set({ leftAt: sql`now()` })
+    .where(
+      and(
+        eq(profilePrograms.profileId, userId),
+        eq(profilePrograms.programId, programId),
+        isNull(profilePrograms.leftAt),
+      ),
+    )
     .returning({ profileId: profilePrograms.profileId });
 
   if (result.length === 0) return { error: "not_found" };
@@ -280,7 +309,8 @@ export const parseProgramUpdate = (body: unknown): ProgramUpdate | { error: stri
 // Every program with its member count. Unlike listPrograms this carries
 // no per-user membership — admins manage programs, they don't join them.
 // Archived programs are included here so admins can re-open them; the
-// member-facing listPrograms hides them.
+// member-facing listPrograms hides them. memberCount excludes left
+// rows so admins see the same "currently in" number members do.
 export const listAllProgramsForAdmin = async (): Promise<AdminProgram[]> => {
   return db
     .select({
@@ -294,6 +324,7 @@ export const listAllProgramsForAdmin = async (): Promise<AdminProgram[]> => {
       memberCount: sql<number>`(
         SELECT count(*)::int FROM ${profilePrograms}
         WHERE ${profilePrograms.programId} = ${programs.id}
+          AND ${profilePrograms.leftAt} IS NULL
       )`,
     })
     .from(programs)
@@ -394,7 +425,7 @@ export const getProgramDetail = async (
     })
     .from(profilePrograms)
     .innerJoin(profiles, eq(profiles.id, profilePrograms.profileId))
-    .where(eq(profilePrograms.programId, programId))
+    .where(and(eq(profilePrograms.programId, programId), isNull(profilePrograms.leftAt)))
     .orderBy(asc(profiles.displayName));
 
   const withUrls = await attachAvatarUrls(rows);
@@ -436,21 +467,31 @@ export const addParticipant = async (
   const [profile] = await db.select({ id: profiles.id }).from(profiles).where(eq(profiles.id, profileId));
   if (!profile) return { error: "profile_not_found" };
 
+  // Same three-case upsert as joinProgram: insert / rejoin / already-
+  // a-member. The admin path ignores signupsOpen — admins can add a
+  // participant even to a program with closed signups.
   const result = await db
     .insert(profilePrograms)
     .values({ profileId, programId })
-    .onConflictDoNothing()
+    .onConflictDoUpdate({
+      target: [profilePrograms.profileId, profilePrograms.programId],
+      set: { leftAt: null },
+      setWhere: sql`${profilePrograms.leftAt} IS NOT NULL`,
+    })
     .returning({ profileId: profilePrograms.profileId });
 
   if (result.length === 0) return { error: "already_member" };
   return { ok: true };
 };
 
-// Deletes a program only while it has no participants — the guardrail
-// for clearing out test data and mistakes without touching live ones.
-// The "no participants" check rides on the DELETE as a NOT EXISTS
-// subquery so it's atomic: a join landing between a separate check and
-// the delete can't slip a participant past the FK cascade.
+// Deletes a program only while it has no current participants — the
+// guardrail for clearing out test data and mistakes without touching
+// live ones. The "no participants" check rides on the DELETE as a NOT
+// EXISTS subquery so it's atomic: a join landing between a separate
+// check and the delete can't slip a participant past the FK cascade.
+// Past members (leftAt IS NOT NULL) don't block the delete; the FK
+// cascade still nukes their history rows, which is fine — the program
+// itself is going away.
 export const deleteProgram = async (
   programId: string,
 ): Promise<{ ok: true } | { error: "not_found" | "has_participants" }> => {
@@ -465,7 +506,7 @@ export const deleteProgram = async (
           db
             .select({ one: sql`1` })
             .from(profilePrograms)
-            .where(eq(profilePrograms.programId, programId)),
+            .where(and(eq(profilePrograms.programId, programId), isNull(profilePrograms.leftAt))),
         ),
       ),
     )
@@ -473,7 +514,7 @@ export const deleteProgram = async (
 
   if (deleted.length > 0) return { ok: true };
 
-  // Nothing deleted: the program is either gone or still has
+  // Nothing deleted: the program is either gone or still has current
   // participants. Re-read to tell 404 apart from 409 for the caller.
   const [program] = await db.select({ id: programs.id }).from(programs).where(eq(programs.id, programId));
   return program ? { error: "has_participants" } : { error: "not_found" };
@@ -485,9 +526,18 @@ export const removeParticipant = async (
 ): Promise<{ ok: true } | { error: "not_found" }> => {
   if (!isUuid(programId) || !isUuid(profileId)) return { error: "not_found" };
 
+  // Mirror leaveProgram's soft delete so admin removals also preserve
+  // the original assignedAt for any future rejoin.
   const result = await db
-    .delete(profilePrograms)
-    .where(and(eq(profilePrograms.programId, programId), eq(profilePrograms.profileId, profileId)))
+    .update(profilePrograms)
+    .set({ leftAt: sql`now()` })
+    .where(
+      and(
+        eq(profilePrograms.programId, programId),
+        eq(profilePrograms.profileId, profileId),
+        isNull(profilePrograms.leftAt),
+      ),
+    )
     .returning({ profileId: profilePrograms.profileId });
 
   if (result.length === 0) return { error: "not_found" };

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
-import { and, asc, eq, inArray, ne, notExists, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, ne, notExists, sql } from "drizzle-orm";
 
 import { isUuid } from "./auth-middleware";
 import { attachAvatarUrls } from "./avatars";
@@ -46,6 +46,7 @@ export type ProgramWithMembership = {
   slug: string;
   name: string;
   description: string | null;
+  signupsOpen: boolean;
   memberCount: number;
   joined: boolean;
   joinedAt: string | null;
@@ -55,6 +56,10 @@ export type ProgramWithMembership = {
 // fine for a small number of programs. If the programs table grows
 // significantly, refactor to LEFT JOIN + GROUP BY with a conditional
 // aggregate for the current user's assigned_at.
+//
+// Archived programs are hidden — admins manage them via /admin/programs.
+// signupsOpen is returned so the client can disable the join button on
+// programs that are still listed but not currently accepting joins.
 export const listPrograms = async (userId: string): Promise<ProgramWithMembership[]> => {
   const rows = await db
     .select({
@@ -62,6 +67,7 @@ export const listPrograms = async (userId: string): Promise<ProgramWithMembershi
       slug: programs.slug,
       name: programs.name,
       description: programs.description,
+      signupsOpen: programs.signupsOpen,
       memberCount: sql<number>`(
         SELECT count(*)::int FROM ${profilePrograms}
         WHERE ${profilePrograms.programId} = ${programs.id}
@@ -73,6 +79,7 @@ export const listPrograms = async (userId: string): Promise<ProgramWithMembershi
       )`,
     })
     .from(programs)
+    .where(isNull(programs.archivedAt))
     .orderBy(programs.name);
 
   return rows.map((r) => ({
@@ -96,13 +103,24 @@ const ensureProfile = async (userId: string): Promise<void> => {
 export const joinProgram = async (
   userId: string,
   programId: string,
-): Promise<{ ok: true } | { error: "not_found" | "already_joined" }> => {
+): Promise<{ ok: true } | { error: "not_found" | "already_joined" | "signups_closed" }> => {
   if (!isUuid(programId)) return { error: "not_found" };
 
-  // Verify program exists
-  const [program] = await db.select({ id: programs.id }).from(programs).where(eq(programs.id, programId));
+  // Read archive + signupsOpen alongside the existence check. Archived
+  // programs are surfaced as "not_found" — members shouldn't see them
+  // in their listing, so a join attempt with the id is treated like an
+  // attempt at any other unknown program.
+  const [program] = await db
+    .select({
+      id: programs.id,
+      archivedAt: programs.archivedAt,
+      signupsOpen: programs.signupsOpen,
+    })
+    .from(programs)
+    .where(eq(programs.id, programId));
 
-  if (!program) return { error: "not_found" };
+  if (!program || program.archivedAt !== null) return { error: "not_found" };
+  if (!program.signupsOpen) return { error: "signups_closed" };
 
   // Self-heal: ensure profile row exists before FK insert
   await ensureProfile(userId);
@@ -147,6 +165,8 @@ export type AdminProgram = {
   slug: string;
   name: string;
   description: string | null;
+  archivedAt: string | null;
+  signupsOpen: boolean;
   memberCount: number;
   createdAt: string;
 };
@@ -208,14 +228,23 @@ export const parseProgramCreate = (
 
 // Parses an edit-program body. Every field is optional — only the keys
 // present are updated — but a present `name` or `slug` must be valid.
-export const parseProgramUpdate = (
-  body: unknown,
-): { name?: string; slug?: string; description?: string | null } | { error: string } => {
+// `archived` is a boolean toggle: true stamps archived_at = now(), false
+// clears it. `signupsOpen` flips directly. Both are passed through as
+// their resolved column values so updateProgram doesn't have to know.
+export type ProgramUpdate = {
+  name?: string;
+  slug?: string;
+  description?: string | null;
+  archived?: boolean;
+  signupsOpen?: boolean;
+};
+
+export const parseProgramUpdate = (body: unknown): ProgramUpdate | { error: string } => {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     return { error: "body must be a JSON object" };
   }
   const obj = body as Record<string, unknown>;
-  const result: { name?: string; slug?: string; description?: string | null } = {};
+  const result: ProgramUpdate = {};
 
   if ("name" in obj) {
     const name = trimmedString(obj.name);
@@ -237,11 +266,21 @@ export const parseProgramUpdate = (
     }
     result.description = description || null;
   }
+  if ("archived" in obj) {
+    if (typeof obj.archived !== "boolean") return { error: "archived must be a boolean" };
+    result.archived = obj.archived;
+  }
+  if ("signupsOpen" in obj) {
+    if (typeof obj.signupsOpen !== "boolean") return { error: "signupsOpen must be a boolean" };
+    result.signupsOpen = obj.signupsOpen;
+  }
   return result;
 };
 
 // Every program with its member count. Unlike listPrograms this carries
 // no per-user membership — admins manage programs, they don't join them.
+// Archived programs are included here so admins can re-open them; the
+// member-facing listPrograms hides them.
 export const listAllProgramsForAdmin = async (): Promise<AdminProgram[]> => {
   return db
     .select({
@@ -249,6 +288,8 @@ export const listAllProgramsForAdmin = async (): Promise<AdminProgram[]> => {
       slug: programs.slug,
       name: programs.name,
       description: programs.description,
+      archivedAt: sql<string | null>`to_json(${programs.archivedAt}) #>> '{}'`,
+      signupsOpen: programs.signupsOpen,
       createdAt: sql<string>`to_json(${programs.createdAt}) #>> '{}'`,
       memberCount: sql<number>`(
         SELECT count(*)::int FROM ${profilePrograms}
@@ -278,6 +319,8 @@ export const createProgram = async (input: {
       slug: row.slug,
       name: row.name,
       description: row.description,
+      archivedAt: row.archivedAt ? row.archivedAt.toISOString() : null,
+      signupsOpen: row.signupsOpen,
       memberCount: 0,
       createdAt: row.createdAt.toISOString(),
     },
@@ -286,16 +329,22 @@ export const createProgram = async (input: {
 
 export const updateProgram = async (
   programId: string,
-  input: { name?: string; slug?: string; description?: string | null },
+  input: ProgramUpdate,
 ): Promise<{ ok: true } | { error: "not_found" | "slug_conflict" }> => {
   if (!isUuid(programId)) return { error: "not_found" };
 
   const [program] = await db.select({ id: programs.id }).from(programs).where(eq(programs.id, programId));
   if (!program) return { error: "not_found" };
 
-  const update: { name?: string; slug?: string; description?: string | null } = {};
+  // Drizzle's set() accepts an SQL expression for archived_at when we
+  // want now()/null, so split the type out from the validated input.
+  const update: Record<string, unknown> = {};
   if (input.name !== undefined) update.name = input.name;
   if (input.description !== undefined) update.description = input.description;
+  if (input.archived !== undefined) {
+    update.archivedAt = input.archived ? sql`now()` : null;
+  }
+  if (input.signupsOpen !== undefined) update.signupsOpen = input.signupsOpen;
   if (input.slug !== undefined) {
     // Reject a slug a different program already holds; the row keeping
     // its own slug unchanged is fine.
@@ -327,6 +376,8 @@ export const getProgramDetail = async (
       slug: programs.slug,
       name: programs.name,
       description: programs.description,
+      archivedAt: programs.archivedAt,
+      signupsOpen: programs.signupsOpen,
       createdAt: programs.createdAt,
     })
     .from(programs)
@@ -361,6 +412,8 @@ export const getProgramDetail = async (
       slug: program.slug,
       name: program.name,
       description: program.description,
+      archivedAt: program.archivedAt ? program.archivedAt.toISOString() : null,
+      signupsOpen: program.signupsOpen,
       createdAt: program.createdAt.toISOString(),
       memberCount: participants.length,
       participants,

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -182,6 +182,93 @@ export const leaveProgram = async (
   return { ok: true };
 };
 
+// --- Per-program detail (member-facing) ------------------------------
+//
+// The detail page at /programs/[slug] shows a single program's members
+// alongside the description, with a join/leave button for the viewer.
+// Archived programs return not_found here — the listing already hides
+// them, so a deep link to an archived slug should look like any other
+// missing page.
+
+export type ProgramMember = {
+  id: string;
+  slug: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  joinedAt: string;
+};
+
+export type ProgramDetailForMember = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  signupsOpen: boolean;
+  memberCount: number;
+  joined: boolean;
+  joinedAt: string | null;
+  members: ProgramMember[];
+};
+
+export const getProgramBySlug = async (
+  slug: string,
+  viewerId: string,
+): Promise<{ program: ProgramDetailForMember } | { error: "not_found" }> => {
+  const [program] = await db
+    .select({
+      id: programs.id,
+      slug: programs.slug,
+      name: programs.name,
+      description: programs.description,
+      signupsOpen: programs.signupsOpen,
+      archivedAt: programs.archivedAt,
+    })
+    .from(programs)
+    .where(eq(programs.slug, slug));
+
+  if (!program || program.archivedAt !== null) return { error: "not_found" };
+
+  // Current participants only. Left rows live on for the stable
+  // assignedAt but aren't part of the public roster.
+  const memberRows = await db
+    .select({
+      id: profiles.id,
+      slug: profiles.slug,
+      displayName: profiles.displayName,
+      avatarPath: profiles.avatarPath,
+      assignedAt: profilePrograms.assignedAt,
+    })
+    .from(profilePrograms)
+    .innerJoin(profiles, eq(profiles.id, profilePrograms.profileId))
+    .where(and(eq(profilePrograms.programId, program.id), isNull(profilePrograms.leftAt)))
+    .orderBy(asc(profiles.displayName));
+
+  const withUrls = await attachAvatarUrls(memberRows);
+  const members: ProgramMember[] = withUrls.map((m) => ({
+    id: m.id,
+    slug: m.slug,
+    displayName: m.displayName,
+    avatarUrl: m.avatarUrl,
+    joinedAt: m.assignedAt.toISOString(),
+  }));
+
+  const viewer = members.find((m) => m.id === viewerId) ?? null;
+
+  return {
+    program: {
+      id: program.id,
+      slug: program.slug,
+      name: program.name,
+      description: program.description,
+      signupsOpen: program.signupsOpen,
+      memberCount: members.length,
+      joined: viewer !== null,
+      joinedAt: viewer?.joinedAt ?? null,
+      members,
+    },
+  };
+};
+
 // --- Admin program administration (issue #139) ---------------------
 //
 // The functions above are member-facing: browse, join, leave. Below is

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -107,6 +107,54 @@ const ensureProfile = async (userId: string): Promise<void> => {
   }
 };
 
+// --- Soft-delete primitives -----------------------------------------
+//
+// The four public functions (joinProgram, leaveProgram, addParticipant,
+// removeParticipant) all differ in their gates and error taxonomy, but
+// the actual mutation reduces to one of two state transitions. These
+// helpers own the mutation; the public functions own the policy.
+
+// First-insert or rejoin. Returns true if the row is newly current — an
+// INSERT (first-ever join) or an UPDATE clearing leftAt (rejoin) — and
+// false if a current row already existed (no-op). assignedAt is set on
+// the first insert and never touched on rejoin, so it survives any
+// leave/rejoin cycle as the stable first-joined date. The conditional
+// DO UPDATE setWhere is what gives us the "already a member" signal:
+// when the existing row is already current, Postgres treats the
+// conflict as DO NOTHING and the RETURNING set comes back empty.
+const setMembershipActive = async (profileId: string, programId: string): Promise<boolean> => {
+  const result = await db
+    .insert(profilePrograms)
+    .values({ profileId, programId })
+    .onConflictDoUpdate({
+      target: [profilePrograms.profileId, profilePrograms.programId],
+      set: { leftAt: null },
+      setWhere: sql`${profilePrograms.leftAt} IS NOT NULL`,
+    })
+    .returning({ profileId: profilePrograms.profileId });
+  return result.length > 0;
+};
+
+// Soft-delete the current membership. Returns true if a current row was
+// ended, false if there was nothing to end (already left, or the
+// (profile, program) pair never had a row). The leftAt IS NULL guard
+// makes this idempotent past the first call — callers can treat the
+// false return as "not_found" without a separate read.
+const setMembershipEnded = async (profileId: string, programId: string): Promise<boolean> => {
+  const result = await db
+    .update(profilePrograms)
+    .set({ leftAt: sql`now()` })
+    .where(
+      and(
+        eq(profilePrograms.profileId, profileId),
+        eq(profilePrograms.programId, programId),
+        isNull(profilePrograms.leftAt),
+      ),
+    )
+    .returning({ profileId: profilePrograms.profileId });
+  return result.length > 0;
+};
+
 export const joinProgram = async (
   userId: string,
   programId: string,
@@ -132,27 +180,7 @@ export const joinProgram = async (
   // Self-heal: ensure profile row exists before FK insert
   await ensureProfile(userId);
 
-  // Three cases on the composite-PK conflict, all handled atomically:
-  //   - No row yet → INSERT. assignedAt = now() is the stable first-
-  //     joined timestamp from this moment forward.
-  //   - Row exists with leftAt IS NOT NULL → rejoin: clear leftAt,
-  //     leave assignedAt alone so the original join date survives.
-  //   - Row exists with leftAt IS NULL → already a current member;
-  //     the WHERE on DO UPDATE blocks the no-op write, returning() is
-  //     empty, and we surface already_joined.
-  const result = await db
-    .insert(profilePrograms)
-    .values({ profileId: userId, programId })
-    .onConflictDoUpdate({
-      target: [profilePrograms.profileId, profilePrograms.programId],
-      set: { leftAt: null },
-      setWhere: sql`${profilePrograms.leftAt} IS NOT NULL`,
-    })
-    .returning({ profileId: profilePrograms.profileId });
-
-  if (result.length === 0) return { error: "already_joined" };
-
-  return { ok: true };
+  return (await setMembershipActive(userId, programId)) ? { ok: true } : { error: "already_joined" };
 };
 
 export const leaveProgram = async (
@@ -161,25 +189,7 @@ export const leaveProgram = async (
 ): Promise<{ ok: true } | { error: "not_found" }> => {
   if (!isUuid(programId)) return { error: "not_found" };
 
-  // Soft delete — flip leftAt instead of removing the row, so a future
-  // rejoin can preserve the original assignedAt. The leftAt IS NULL
-  // predicate makes the call idempotent against double-leaves: a row
-  // already marked left returns no result, surfacing as not_found.
-  const result = await db
-    .update(profilePrograms)
-    .set({ leftAt: sql`now()` })
-    .where(
-      and(
-        eq(profilePrograms.profileId, userId),
-        eq(profilePrograms.programId, programId),
-        isNull(profilePrograms.leftAt),
-      ),
-    )
-    .returning({ profileId: profilePrograms.profileId });
-
-  if (result.length === 0) return { error: "not_found" };
-
-  return { ok: true };
+  return (await setMembershipEnded(userId, programId)) ? { ok: true } : { error: "not_found" };
 };
 
 // --- Per-program detail (member-facing) ------------------------------
@@ -554,21 +564,9 @@ export const addParticipant = async (
   const [profile] = await db.select({ id: profiles.id }).from(profiles).where(eq(profiles.id, profileId));
   if (!profile) return { error: "profile_not_found" };
 
-  // Same three-case upsert as joinProgram: insert / rejoin / already-
-  // a-member. The admin path ignores signupsOpen — admins can add a
-  // participant even to a program with closed signups.
-  const result = await db
-    .insert(profilePrograms)
-    .values({ profileId, programId })
-    .onConflictDoUpdate({
-      target: [profilePrograms.profileId, profilePrograms.programId],
-      set: { leftAt: null },
-      setWhere: sql`${profilePrograms.leftAt} IS NOT NULL`,
-    })
-    .returning({ profileId: profilePrograms.profileId });
-
-  if (result.length === 0) return { error: "already_member" };
-  return { ok: true };
+  // The admin path ignores signupsOpen — admins can add a participant
+  // even to a program with closed signups.
+  return (await setMembershipActive(profileId, programId)) ? { ok: true } : { error: "already_member" };
 };
 
 // Deletes a program only while it has no current participants — the
@@ -613,20 +611,5 @@ export const removeParticipant = async (
 ): Promise<{ ok: true } | { error: "not_found" }> => {
   if (!isUuid(programId) || !isUuid(profileId)) return { error: "not_found" };
 
-  // Mirror leaveProgram's soft delete so admin removals also preserve
-  // the original assignedAt for any future rejoin.
-  const result = await db
-    .update(profilePrograms)
-    .set({ leftAt: sql`now()` })
-    .where(
-      and(
-        eq(profilePrograms.programId, programId),
-        eq(profilePrograms.profileId, profileId),
-        isNull(profilePrograms.leftAt),
-      ),
-    )
-    .returning({ profileId: profilePrograms.profileId });
-
-  if (result.length === 0) return { error: "not_found" };
-  return { ok: true };
+  return (await setMembershipEnded(profileId, programId)) ? { ok: true } : { error: "not_found" };
 };

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -79,6 +79,11 @@ export const programs = pgTable("programs", {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 }).enableRLS();
 
+// Soft-delete table: a row's existence records "Alice was ever joined
+// to this program"; leftAt distinguishes "currently joined" (NULL) from
+// "left, history preserved" (timestamp). assignedAt is set once on
+// first insert and never updated, so it survives leave/rejoin cycles
+// as the stable first-joined date.
 export const profilePrograms = pgTable(
   "profile_programs",
   {
@@ -89,6 +94,7 @@ export const profilePrograms = pgTable(
       .notNull()
       .references(() => programs.id, { onDelete: "cascade" }),
     assignedAt: timestamp("assigned_at", { withTimezone: true }).notNull().defaultNow(),
+    leftAt: timestamp("left_at", { withTimezone: true }),
   },
   (table) => [primaryKey({ columns: [table.profileId, table.programId] })],
 ).enableRLS();

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -68,6 +68,14 @@ export const programs = pgTable("programs", {
   slug: text("slug").notNull().unique(),
   name: text("name").notNull(),
   description: text("description"),
+  // Archived programs are hidden from member-facing listings (admins
+  // still see them in /admin/programs). Set the timestamp instead of
+  // a boolean — it's strictly more information.
+  archivedAt: timestamp("archived_at", { withTimezone: true }),
+  // Gates the member-facing self-serve join. Closed by default so a
+  // newly-created cohort or pod doesn't accidentally accept signups
+  // before the admin is ready; admin add-participant is unaffected.
+  signupsOpen: boolean("signups_open").notNull().default(false),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 }).enableRLS();
 

--- a/tests/functional/server/admin-programs.test.ts
+++ b/tests/functional/server/admin-programs.test.ts
@@ -240,6 +240,84 @@ describe("Admin programs API", () => {
       const res = await patch(randomUUID(), { name: "Whatever" });
       expect(res.status).toBe(404);
     });
+
+    it("archives and unarchives via the boolean toggle, stamping archived_at", async () => {
+      const programId = await seedProgram("Archivable Program");
+      authAs(admin);
+
+      let res = await patch(programId, { archived: true });
+      expect(res.status).toBe(200);
+      let [row] = await db
+        .select({ archivedAt: programs.archivedAt })
+        .from(programs)
+        .where(eq(programs.id, programId));
+      expect(row.archivedAt).not.toBeNull();
+
+      res = await patch(programId, { archived: false });
+      expect(res.status).toBe(200);
+      [row] = await db
+        .select({ archivedAt: programs.archivedAt })
+        .from(programs)
+        .where(eq(programs.id, programId));
+      expect(row.archivedAt).toBeNull();
+    });
+
+    it("opens and closes signups via the signupsOpen boolean", async () => {
+      // New programs default to signups closed — flip open, then closed
+      // again to exercise both directions.
+      const programId = await seedProgram("Toggleable Signups Program");
+      authAs(admin);
+
+      let res = await patch(programId, { signupsOpen: true });
+      expect(res.status).toBe(200);
+      let [row] = await db
+        .select({ signupsOpen: programs.signupsOpen })
+        .from(programs)
+        .where(eq(programs.id, programId));
+      expect(row.signupsOpen).toBe(true);
+
+      res = await patch(programId, { signupsOpen: false });
+      expect(res.status).toBe(200);
+      [row] = await db
+        .select({ signupsOpen: programs.signupsOpen })
+        .from(programs)
+        .where(eq(programs.id, programId));
+      expect(row.signupsOpen).toBe(false);
+    });
+
+    it("rejects a non-boolean archived or signupsOpen with 400", async () => {
+      const programId = await seedProgram("Type Strict Program");
+      authAs(admin);
+
+      let res = await patch(programId, { archived: "yes" });
+      expect(res.status).toBe(400);
+      res = await patch(programId, { signupsOpen: 1 });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/admin/programs (archive/signups state)", () => {
+    it("includes archived programs in the admin listing", async () => {
+      const liveId = await seedProgram("Live Program");
+      const archivedId = await seedProgram("Archived Program");
+      await db.update(programs).set({ archivedAt: sql`now()` }).where(eq(programs.id, archivedId));
+
+      authAs(admin);
+      const res = await app.request("/api/admin/programs");
+      const body = (await res.json()) as {
+        programs: Array<{ id: string; archivedAt: string | null; signupsOpen: boolean }>;
+      };
+
+      const live = body.programs.find((p) => p.id === liveId);
+      const archived = body.programs.find((p) => p.id === archivedId);
+      expect(live).toBeDefined();
+      expect(archived).toBeDefined();
+      expect(archived?.archivedAt).not.toBeNull();
+      expect(live?.archivedAt).toBeNull();
+      // New programs are seeded without specifying signups_open, so they
+      // pick up the closed-by-default policy.
+      expect(live?.signupsOpen).toBe(false);
+    });
   });
 
   describe("DELETE /api/admin/programs/:id", () => {

--- a/tests/functional/server/admin-programs.test.ts
+++ b/tests/functional/server/admin-programs.test.ts
@@ -353,6 +353,20 @@ describe("Admin programs API", () => {
       expect(enrolled).toHaveLength(1);
     });
 
+    it("deletes a program whose only members have already left", async () => {
+      // Past memberships shouldn't block deletion — only currently-
+      // joined ones do. The FK cascade cleans up the history rows.
+      const programId = await seedProgram("Vacated Program");
+      await db.insert(profilePrograms).values({ profileId: member, programId, leftAt: new Date() });
+
+      authAs(admin);
+      const res = await del(programId);
+      expect(res.status).toBe(200);
+
+      const rows = await db.select().from(programs).where(eq(programs.id, programId));
+      expect(rows).toHaveLength(0);
+    });
+
     it("returns 404 for a non-existent program", async () => {
       authAs(admin);
       const res = await del(randomUUID());
@@ -423,7 +437,7 @@ describe("Admin programs API", () => {
   });
 
   describe("DELETE /api/admin/programs/:id/participants/:profileId", () => {
-    it("removes a participant", async () => {
+    it("soft-removes a participant by stamping left_at", async () => {
       const programId = await seedProgram("Removable Program");
       await db.insert(profilePrograms).values({ profileId: member, programId });
 
@@ -433,11 +447,47 @@ describe("Admin programs API", () => {
       });
       expect(res.status).toBe(200);
 
+      // The row still exists but is marked left so the original
+      // assignedAt is available for any future re-add.
       const rows = await db
         .select()
         .from(profilePrograms)
         .where(eq(profilePrograms.programId, programId));
-      expect(rows).toHaveLength(0);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].leftAt).not.toBeNull();
+    });
+
+    it("re-adding a previously-left member restores membership and preserves the original assignedAt", async () => {
+      const programId = await seedProgram("Re-Addable Program");
+      await db.insert(profilePrograms).values({ profileId: member, programId });
+
+      const [original] = await db
+        .select()
+        .from(profilePrograms)
+        .where(eq(profilePrograms.programId, programId));
+      const originalAssignedAt = original.assignedAt;
+
+      authAs(admin);
+      // Remove (soft-deletes)
+      let res = await app.request(`/api/admin/programs/${programId}/participants/${member}`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+
+      // Re-add — the existing row's leftAt clears, assignedAt is unchanged.
+      res = await app.request(`/api/admin/programs/${programId}/participants`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ profileId: member }),
+      });
+      expect(res.status).toBe(200);
+
+      const [after] = await db
+        .select()
+        .from(profilePrograms)
+        .where(eq(profilePrograms.programId, programId));
+      expect(after.leftAt).toBeNull();
+      expect(after.assignedAt.getTime()).toBe(originalAssignedAt.getTime());
     });
 
     it("returns 404 when the member is not a participant", async () => {

--- a/tests/functional/server/auth-callback.test.ts
+++ b/tests/functional/server/auth-callback.test.ts
@@ -55,25 +55,25 @@ const deleteAuthUser = async (id: string) => {
   await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
 };
 
-// Same idea as programs.test.ts's helper: use the seed row if present,
-// otherwise insert one. The boolean tells the caller whether to clean
-// it up so we don't trample the seed.
-const ensureWeeklyProgram = async (): Promise<{ id: string; insertedByTest: boolean }> => {
-  const [existing] = await db
-    .select({ id: programs.id })
-    .from(programs)
-    .where(eq(programs.slug, "weekly-web-updates"));
-  if (existing) return { id: existing.id, insertedByTest: false };
-
-  const [row] = await db
+// The auto-subscribe target's slug is fixed in the production code, so
+// concurrent tests would otherwise race on inserting/deleting the same
+// row. Upsert with ON CONFLICT DO NOTHING and never delete — the slug
+// has a unique constraint, so there's only ever one row, and leaving
+// it across tests is harmless.
+const ensureWeeklyProgram = async (): Promise<string> => {
+  await db
     .insert(programs)
     .values({
       slug: "weekly-web-updates",
       name: "Weekly Web Updates",
-      description: "Auto-subscribe target (test-inserted).",
+      description: "Auto-subscribe target (test-managed).",
     })
-    .returning({ id: programs.id });
-  return { id: row.id, insertedByTest: true };
+    .onConflictDoNothing({ target: programs.slug });
+  const [row] = await db
+    .select({ id: programs.id })
+    .from(programs)
+    .where(eq(programs.slug, "weekly-web-updates"));
+  return row.id;
 };
 
 describe("GET /auth/callback", () => {
@@ -102,22 +102,16 @@ describe("GET /auth/callback", () => {
 describe("GET /auth/callback (ordinary sign-in, auto-subscribe to weekly-web-updates)", () => {
   let userId: string;
   let weeklyProgramId: string;
-  let weeklyInsertedByTest: boolean;
 
   beforeEach(async () => {
     mockCreateClient.mockReset();
     userId = randomUUID();
     await insertAuthUser(userId, `${userId}@testfake.local`);
-    const ensured = await ensureWeeklyProgram();
-    weeklyProgramId = ensured.id;
-    weeklyInsertedByTest = ensured.insertedByTest;
+    weeklyProgramId = await ensureWeeklyProgram();
   });
 
   afterEach(async () => {
     await db.delete(profilePrograms).where(eq(profilePrograms.profileId, userId));
-    if (weeklyInsertedByTest) {
-      await db.delete(programs).where(eq(programs.id, weeklyProgramId));
-    }
     await deleteAuthUser(userId);
   });
 
@@ -155,7 +149,6 @@ describe("GET /auth/callback?invite=... (invited sign-in)", () => {
   let inviterId: string;
   let newUserId: string;
   let weeklyProgramId: string;
-  let weeklyInsertedByTest: boolean;
 
   beforeEach(async () => {
     mockCreateClient.mockReset();
@@ -164,16 +157,11 @@ describe("GET /auth/callback?invite=... (invited sign-in)", () => {
     await insertAuthUser(inviterId, `${inviterId}@testfake.local`);
     await db.insert(profiles).values({ id: inviterId, displayName: "Inviter" });
     await insertAuthUser(newUserId, `${newUserId}@testfake.local`);
-    const ensured = await ensureWeeklyProgram();
-    weeklyProgramId = ensured.id;
-    weeklyInsertedByTest = ensured.insertedByTest;
+    weeklyProgramId = await ensureWeeklyProgram();
   });
 
   afterEach(async () => {
     await db.delete(profilePrograms).where(eq(profilePrograms.profileId, newUserId));
-    if (weeklyInsertedByTest) {
-      await db.delete(programs).where(eq(programs.id, weeklyProgramId));
-    }
     await db.delete(invites).where(eq(invites.createdBy, inviterId));
     await deleteAuthUser(newUserId);
     await deleteAuthUser(inviterId);

--- a/tests/functional/server/auth-callback.test.ts
+++ b/tests/functional/server/auth-callback.test.ts
@@ -11,7 +11,7 @@ import { GET } from "@/app/auth/callback/route";
 import { createClient } from "@/lib/supabase/server";
 import { db } from "@/server/db";
 import { createInvite } from "@/server/invites";
-import { invites, profiles } from "@/server/schema";
+import { invites, profilePrograms, profiles, programs } from "@/server/schema";
 
 const mockCreateClient = vi.mocked(createClient);
 
@@ -55,6 +55,27 @@ const deleteAuthUser = async (id: string) => {
   await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
 };
 
+// Same idea as programs.test.ts's helper: use the seed row if present,
+// otherwise insert one. The boolean tells the caller whether to clean
+// it up so we don't trample the seed.
+const ensureWeeklyProgram = async (): Promise<{ id: string; insertedByTest: boolean }> => {
+  const [existing] = await db
+    .select({ id: programs.id })
+    .from(programs)
+    .where(eq(programs.slug, "weekly-web-updates"));
+  if (existing) return { id: existing.id, insertedByTest: false };
+
+  const [row] = await db
+    .insert(programs)
+    .values({
+      slug: "weekly-web-updates",
+      name: "Weekly Web Updates",
+      description: "Auto-subscribe target (test-inserted).",
+    })
+    .returning({ id: programs.id });
+  return { id: row.id, insertedByTest: true };
+};
+
 describe("GET /auth/callback", () => {
   beforeEach(() => {
     mockCreateClient.mockReset();
@@ -78,9 +99,63 @@ describe("GET /auth/callback", () => {
   });
 });
 
+describe("GET /auth/callback (ordinary sign-in, auto-subscribe to weekly-web-updates)", () => {
+  let userId: string;
+  let weeklyProgramId: string;
+  let weeklyInsertedByTest: boolean;
+
+  beforeEach(async () => {
+    mockCreateClient.mockReset();
+    userId = randomUUID();
+    await insertAuthUser(userId, `${userId}@testfake.local`);
+    const ensured = await ensureWeeklyProgram();
+    weeklyProgramId = ensured.id;
+    weeklyInsertedByTest = ensured.insertedByTest;
+  });
+
+  afterEach(async () => {
+    await db.delete(profilePrograms).where(eq(profilePrograms.profileId, userId));
+    if (weeklyInsertedByTest) {
+      await db.delete(programs).where(eq(programs.id, weeklyProgramId));
+    }
+    await deleteAuthUser(userId);
+  });
+
+  it("auto-subscribes the new member to weekly-web-updates", async () => {
+    mockSupabase({ id: userId, email: "newbie@testfake.local" });
+
+    const res = await GET(makeRequest("/auth/callback?code=pkce"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("http://testfake.local/");
+
+    const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, userId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].programId).toBe(weeklyProgramId);
+  });
+
+  it("does not re-subscribe an existing member who has opted out", async () => {
+    // Simulate a member who signed in once (so their profile exists)
+    // and then opted out of the weekly update.
+    await db.insert(profiles).values({ id: userId, displayName: "Returning" });
+
+    mockSupabase({ id: userId, email: "returning@testfake.local" });
+
+    const res = await GET(makeRequest("/auth/callback?code=pkce"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("http://testfake.local/");
+
+    const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, userId));
+    expect(rows).toHaveLength(0);
+  });
+});
+
 describe("GET /auth/callback?invite=... (invited sign-in)", () => {
   let inviterId: string;
   let newUserId: string;
+  let weeklyProgramId: string;
+  let weeklyInsertedByTest: boolean;
 
   beforeEach(async () => {
     mockCreateClient.mockReset();
@@ -89,9 +164,16 @@ describe("GET /auth/callback?invite=... (invited sign-in)", () => {
     await insertAuthUser(inviterId, `${inviterId}@testfake.local`);
     await db.insert(profiles).values({ id: inviterId, displayName: "Inviter" });
     await insertAuthUser(newUserId, `${newUserId}@testfake.local`);
+    const ensured = await ensureWeeklyProgram();
+    weeklyProgramId = ensured.id;
+    weeklyInsertedByTest = ensured.insertedByTest;
   });
 
   afterEach(async () => {
+    await db.delete(profilePrograms).where(eq(profilePrograms.profileId, newUserId));
+    if (weeklyInsertedByTest) {
+      await db.delete(programs).where(eq(programs.id, weeklyProgramId));
+    }
     await db.delete(invites).where(eq(invites.createdBy, inviterId));
     await deleteAuthUser(newUserId);
     await deleteAuthUser(inviterId);
@@ -155,5 +237,23 @@ describe("GET /auth/callback?invite=... (invited sign-in)", () => {
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toBe("http://testfake.local/signin?error=invite_invalid");
     expect(signOut).toHaveBeenCalledOnce();
+  });
+
+  it("auto-subscribes the newly redeemed member to weekly-web-updates", async () => {
+    const r = await createInvite({
+      createdBy: inviterId,
+      note: "invited path auto-subscribe test",
+    });
+    if ("error" in r) throw new Error("seed failed");
+    mockSupabase({ id: newUserId, email: "newbie@testfake.local" });
+
+    const res = await GET(makeRequest(`/auth/callback?code=pkce&invite=${r.code}`));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("http://testfake.local/");
+
+    const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, newUserId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].programId).toBe(weeklyProgramId);
   });
 });

--- a/tests/functional/server/profiles.test.ts
+++ b/tests/functional/server/profiles.test.ts
@@ -51,6 +51,22 @@ describe("upsertProfile", () => {
     expect(rows[0]?.displayName).toBe("Test User");
   });
 
+  it("reports created=true on first call and created=false thereafter", async () => {
+    const user = {
+      id: testUserId,
+      user_metadata: { displayName: "Test User" },
+      app_metadata: {},
+      aud: "authenticated",
+      created_at: "2026-01-01T00:00:00Z",
+    } as User;
+
+    const first = await upsertProfile(user);
+    const second = await upsertProfile(user);
+
+    expect(first).toEqual({ created: true });
+    expect(second).toEqual({ created: false });
+  });
+
   it("stores a null displayName when user_metadata is empty", async () => {
     const user = {
       id: testUserId,

--- a/tests/functional/server/programs.test.ts
+++ b/tests/functional/server/programs.test.ts
@@ -52,6 +52,9 @@ describe("Programs API", () => {
       slug: `test-program-${programId.slice(0, 8)}`,
       name: "Test Program",
       description: "A program for testing.",
+      // Tests exercising the member-facing join path need signups open;
+      // the closed-by-default policy is exercised by a dedicated test.
+      signupsOpen: true,
     });
 
     mockCreateServerClient.mockReturnValue({
@@ -85,6 +88,7 @@ describe("Programs API", () => {
             id: programId,
             name: "Test Program",
             description: "A program for testing.",
+            signupsOpen: true,
             memberCount: 0,
             joined: false,
             joinedAt: null,
@@ -104,6 +108,15 @@ describe("Programs API", () => {
       expect(program.joined).toBe(true);
       expect(program.joinedAt).toBeTruthy();
       expect(program.memberCount).toBe(1);
+    });
+
+    it("hides archived programs from the member listing", async () => {
+      await db.update(programs).set({ archivedAt: sql`now()` }).where(eq(programs.id, programId));
+
+      const res = await app.request("/api/programs");
+      const body = await res.json();
+      const hit = body.programs.find((p: { id: string }) => p.id === programId);
+      expect(hit).toBeUndefined();
     });
   });
 
@@ -144,6 +157,26 @@ describe("Programs API", () => {
       const res = await app.request("/api/programs/not-a-uuid/join", {
         method: "POST",
       });
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: "not_found" });
+    });
+
+    it("returns 409 signups_closed when the program has signups disabled", async () => {
+      await db.update(programs).set({ signupsOpen: false }).where(eq(programs.id, programId));
+
+      const res = await app.request(`/api/programs/${programId}/join`, { method: "POST" });
+      expect(res.status).toBe(409);
+      expect(await res.json()).toEqual({ error: "signups_closed" });
+
+      // No membership row landed.
+      const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, userId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("returns 404 when the program is archived", async () => {
+      await db.update(programs).set({ archivedAt: sql`now()` }).where(eq(programs.id, programId));
+
+      const res = await app.request(`/api/programs/${programId}/join`, { method: "POST" });
       expect(res.status).toBe(404);
       expect(await res.json()).toEqual({ error: "not_found" });
     });

--- a/tests/functional/server/programs.test.ts
+++ b/tests/functional/server/programs.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { User } from "@supabase/supabase-js";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@supabase/ssr", () => ({
@@ -183,7 +183,7 @@ describe("Programs API", () => {
   });
 
   describe("POST /api/programs/:id/leave", () => {
-    it("leaves a program successfully", async () => {
+    it("leaves a program by stamping left_at (soft delete)", async () => {
       await db.insert(profilePrograms).values({ profileId: userId, programId });
 
       const res = await app.request(`/api/programs/${programId}/leave`, {
@@ -192,9 +192,13 @@ describe("Programs API", () => {
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ ok: true });
 
-      // Verify row deleted
-      const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, userId));
-      expect(rows).toHaveLength(0);
+      // Row survives — leftAt stamps the soft delete.
+      const [row] = await db
+        .select()
+        .from(profilePrograms)
+        .where(and(eq(profilePrograms.profileId, userId), eq(profilePrograms.programId, programId)));
+      expect(row).toBeDefined();
+      expect(row.leftAt).not.toBeNull();
     });
 
     it("returns 404 when not a member", async () => {
@@ -203,6 +207,81 @@ describe("Programs API", () => {
       });
       expect(res.status).toBe(404);
       expect(await res.json()).toEqual({ error: "not_found" });
+    });
+
+    it("returns 404 on a double-leave (idempotent past the first)", async () => {
+      await db.insert(profilePrograms).values({ profileId: userId, programId });
+
+      let res = await app.request(`/api/programs/${programId}/leave`, { method: "POST" });
+      expect(res.status).toBe(200);
+
+      res = await app.request(`/api/programs/${programId}/leave`, { method: "POST" });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("join → leave → rejoin preserves the first-joined date", () => {
+    it("keeps the original assigned_at across a leave/rejoin cycle", async () => {
+      // First join
+      let res = await app.request(`/api/programs/${programId}/join`, { method: "POST" });
+      expect(res.status).toBe(200);
+
+      const [firstRow] = await db
+        .select()
+        .from(profilePrograms)
+        .where(and(eq(profilePrograms.profileId, userId), eq(profilePrograms.programId, programId)));
+      const originalAssignedAt = firstRow.assignedAt;
+      expect(originalAssignedAt).toBeInstanceOf(Date);
+      expect(firstRow.leftAt).toBeNull();
+
+      // Leave — soft delete stamps leftAt, row persists with same assignedAt.
+      res = await app.request(`/api/programs/${programId}/leave`, { method: "POST" });
+      expect(res.status).toBe(200);
+
+      const [afterLeave] = await db
+        .select()
+        .from(profilePrograms)
+        .where(and(eq(profilePrograms.profileId, userId), eq(profilePrograms.programId, programId)));
+      expect(afterLeave.leftAt).not.toBeNull();
+      expect(afterLeave.assignedAt.getTime()).toBe(originalAssignedAt.getTime());
+
+      // Rejoin — leftAt clears, assignedAt is unchanged.
+      res = await app.request(`/api/programs/${programId}/join`, { method: "POST" });
+      expect(res.status).toBe(200);
+
+      const [afterRejoin] = await db
+        .select()
+        .from(profilePrograms)
+        .where(and(eq(profilePrograms.profileId, userId), eq(profilePrograms.programId, programId)));
+      expect(afterRejoin.leftAt).toBeNull();
+      expect(afterRejoin.assignedAt.getTime()).toBe(originalAssignedAt.getTime());
+
+      // GET /programs surfaces the original date as joinedAt.
+      const list = await app.request("/api/programs");
+      const body = await list.json();
+      const program = body.programs.find((p: { id: string }) => p.id === programId);
+      expect(program.joined).toBe(true);
+      expect(new Date(program.joinedAt).getTime()).toBe(originalAssignedAt.getTime());
+    });
+
+    it("treats a second join while currently joined as already_joined", async () => {
+      let res = await app.request(`/api/programs/${programId}/join`, { method: "POST" });
+      expect(res.status).toBe(200);
+
+      res = await app.request(`/api/programs/${programId}/join`, { method: "POST" });
+      expect(res.status).toBe(409);
+      expect(await res.json()).toEqual({ error: "already_joined" });
+    });
+
+    it("member count and joined flag ignore left rows", async () => {
+      await db.insert(profilePrograms).values({ profileId: userId, programId, leftAt: new Date() });
+
+      const res = await app.request("/api/programs");
+      const body = await res.json();
+      const program = body.programs.find((p: { id: string }) => p.id === programId);
+      expect(program.memberCount).toBe(0);
+      expect(program.joined).toBe(false);
+      expect(program.joinedAt).toBeNull();
     });
   });
 });

--- a/tests/functional/server/programs.test.ts
+++ b/tests/functional/server/programs.test.ts
@@ -284,35 +284,90 @@ describe("Programs API", () => {
       expect(program.joinedAt).toBeNull();
     });
   });
+
+  describe("GET /api/programs/by-slug/:slug", () => {
+    it("returns program detail keyed by slug with members and viewer's joined flag", async () => {
+      // The viewer is joined; the seed in the outer beforeEach put them
+      // in nothing, so insert a current membership now.
+      await db.insert(profilePrograms).values({ profileId: userId, programId });
+
+      const slug = `test-program-${programId.slice(0, 8)}`;
+      const res = await app.request(`/api/programs/by-slug/${slug}`);
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as {
+        program: {
+          id: string;
+          slug: string;
+          name: string;
+          description: string | null;
+          signupsOpen: boolean;
+          memberCount: number;
+          joined: boolean;
+          joinedAt: string | null;
+          members: Array<{ id: string; displayName: string | null; joinedAt: string }>;
+        };
+      };
+      expect(body.program.id).toBe(programId);
+      expect(body.program.slug).toBe(slug);
+      expect(body.program.signupsOpen).toBe(true);
+      expect(body.program.memberCount).toBe(1);
+      expect(body.program.joined).toBe(true);
+      expect(body.program.joinedAt).toBeTruthy();
+      expect(body.program.members).toHaveLength(1);
+      expect(body.program.members[0].id).toBe(userId);
+    });
+
+    it("excludes members who have left from the members array", async () => {
+      await db
+        .insert(profilePrograms)
+        .values({ profileId: userId, programId, leftAt: new Date() });
+
+      const slug = `test-program-${programId.slice(0, 8)}`;
+      const res = await app.request(`/api/programs/by-slug/${slug}`);
+      const body = await res.json();
+      expect(body.program.members).toHaveLength(0);
+      expect(body.program.memberCount).toBe(0);
+      expect(body.program.joined).toBe(false);
+    });
+
+    it("returns 404 for an archived program", async () => {
+      await db.update(programs).set({ archivedAt: sql`now()` }).where(eq(programs.id, programId));
+
+      const slug = `test-program-${programId.slice(0, 8)}`;
+      const res = await app.request(`/api/programs/by-slug/${slug}`);
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 404 for an unknown slug", async () => {
+      const res = await app.request("/api/programs/by-slug/does-not-exist");
+      expect(res.status).toBe(404);
+    });
+  });
 });
 
-// Look up the auto-subscribe target's id, inserting it if the local
-// schema doesn't already have it from the dev seed. Returns the program
-// id either way. The cleanup half tells the caller whether the row was
-// inserted by this helper (so the test can drop it without trampling
-// seed data).
-const ensureWeeklyProgram = async (): Promise<{ id: string; insertedByTest: boolean }> => {
-  const [existing] = await db
-    .select({ id: programs.id })
-    .from(programs)
-    .where(eq(programs.slug, "weekly-web-updates"));
-  if (existing) return { id: existing.id, insertedByTest: false };
-
-  const [row] = await db
+// Upsert the auto-subscribe target's row and return its id. Never
+// deletes — concurrent tests share the slug (production code hard-
+// codes it), and the unique-slug constraint guarantees a single row.
+const ensureWeeklyProgram = async (): Promise<string> => {
+  await db
     .insert(programs)
     .values({
       slug: "weekly-web-updates",
       name: "Weekly Web Updates",
-      description: "Auto-subscribe target (test-inserted).",
+      description: "Auto-subscribe target (test-managed).",
     })
-    .returning({ id: programs.id });
-  return { id: row.id, insertedByTest: true };
+    .onConflictDoNothing({ target: programs.slug });
+  const [row] = await db
+    .select({ id: programs.id })
+    .from(programs)
+    .where(eq(programs.slug, "weekly-web-updates"));
+  return row.id;
 };
 
 describe("autoSubscribeNewMember", () => {
   let userId: string;
   let weeklyProgramId: string;
-  let weeklyInsertedByTest: boolean;
 
   beforeEach(async () => {
     userId = randomUUID();
@@ -321,16 +376,11 @@ describe("autoSubscribeNewMember", () => {
           VALUES (${userId}::uuid, ${`auto-${userId.slice(0, 8)}@testfake.local`}, false, false)`,
     );
     await db.insert(profiles).values({ id: userId });
-    const ensured = await ensureWeeklyProgram();
-    weeklyProgramId = ensured.id;
-    weeklyInsertedByTest = ensured.insertedByTest;
+    weeklyProgramId = await ensureWeeklyProgram();
   });
 
   afterEach(async () => {
     await db.delete(profilePrograms).where(eq(profilePrograms.profileId, userId));
-    if (weeklyInsertedByTest) {
-      await db.delete(programs).where(eq(programs.id, weeklyProgramId));
-    }
     await db.delete(profiles).where(eq(profiles.id, userId));
     await db.execute(sql`DELETE FROM auth.users WHERE id = ${userId}::uuid`);
   });
@@ -352,23 +402,30 @@ describe("autoSubscribeNewMember", () => {
   });
 
   it("does not throw or re-subscribe when the program is missing — captures to Sentry instead", async () => {
-    // Drop the program so the slug lookup misses. The function should
-    // log to Sentry and return without inserting anything. After the
-    // delete, the afterEach should not try to delete it again.
+    // The slug is shared with other tests running in parallel workers,
+    // so the missingness window has to be tight: delete, exercise the
+    // path, and restore inside the test rather than waiting for the
+    // next beforeEach. The outer await on autoSubscribeNewMember
+    // finishes before any restore concurrency could matter.
     await db.delete(programs).where(eq(programs.id, weeklyProgramId));
-    weeklyInsertedByTest = false;
 
-    const captureMock = vi.mocked(Sentry.captureException);
-    captureMock.mockClear();
+    try {
+      const captureMock = vi.mocked(Sentry.captureException);
+      captureMock.mockClear();
 
-    await expect(autoSubscribeNewMember(userId)).resolves.toBeUndefined();
+      await expect(autoSubscribeNewMember(userId)).resolves.toBeUndefined();
 
-    expect(captureMock).toHaveBeenCalledOnce();
-    const arg = captureMock.mock.calls[0][0];
-    expect(arg).toBeInstanceOf(Error);
-    expect((arg as Error).message).toMatch(/weekly-web-updates/);
+      expect(captureMock).toHaveBeenCalledOnce();
+      const arg = captureMock.mock.calls[0][0];
+      expect(arg).toBeInstanceOf(Error);
+      expect((arg as Error).message).toMatch(/weekly-web-updates/);
 
-    const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, userId));
-    expect(rows).toHaveLength(0);
+      const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, userId));
+      expect(rows).toHaveLength(0);
+    } finally {
+      // Restore so any concurrent test that depends on the slug isn't
+      // stranded by our delete.
+      await ensureWeeklyProgram();
+    }
   });
 });

--- a/tests/functional/server/programs.test.ts
+++ b/tests/functional/server/programs.test.ts
@@ -7,10 +7,19 @@ vi.mock("@supabase/ssr", () => ({
   createServerClient: vi.fn(),
 }));
 
+// ESM module namespaces aren't configurable, so vi.spyOn on the
+// @sentry/nextjs export fails. Mocking the module up front lets the
+// missing-program test assert on calls to captureException.
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+import * as Sentry from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 
 import app from "@/server/api";
 import { db } from "@/server/db";
+import { autoSubscribeNewMember } from "@/server/programs";
 import { profilePrograms, profiles, programs } from "@/server/schema";
 
 const mockCreateServerClient = vi.mocked(createServerClient);
@@ -162,5 +171,92 @@ describe("Programs API", () => {
       expect(res.status).toBe(404);
       expect(await res.json()).toEqual({ error: "not_found" });
     });
+  });
+});
+
+// Look up the auto-subscribe target's id, inserting it if the local
+// schema doesn't already have it from the dev seed. Returns the program
+// id either way. The cleanup half tells the caller whether the row was
+// inserted by this helper (so the test can drop it without trampling
+// seed data).
+const ensureWeeklyProgram = async (): Promise<{ id: string; insertedByTest: boolean }> => {
+  const [existing] = await db
+    .select({ id: programs.id })
+    .from(programs)
+    .where(eq(programs.slug, "weekly-web-updates"));
+  if (existing) return { id: existing.id, insertedByTest: false };
+
+  const [row] = await db
+    .insert(programs)
+    .values({
+      slug: "weekly-web-updates",
+      name: "Weekly Web Updates",
+      description: "Auto-subscribe target (test-inserted).",
+    })
+    .returning({ id: programs.id });
+  return { id: row.id, insertedByTest: true };
+};
+
+describe("autoSubscribeNewMember", () => {
+  let userId: string;
+  let weeklyProgramId: string;
+  let weeklyInsertedByTest: boolean;
+
+  beforeEach(async () => {
+    userId = randomUUID();
+    await db.execute(
+      sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous)
+          VALUES (${userId}::uuid, ${`auto-${userId.slice(0, 8)}@testfake.local`}, false, false)`,
+    );
+    await db.insert(profiles).values({ id: userId });
+    const ensured = await ensureWeeklyProgram();
+    weeklyProgramId = ensured.id;
+    weeklyInsertedByTest = ensured.insertedByTest;
+  });
+
+  afterEach(async () => {
+    await db.delete(profilePrograms).where(eq(profilePrograms.profileId, userId));
+    if (weeklyInsertedByTest) {
+      await db.delete(programs).where(eq(programs.id, weeklyProgramId));
+    }
+    await db.delete(profiles).where(eq(profiles.id, userId));
+    await db.execute(sql`DELETE FROM auth.users WHERE id = ${userId}::uuid`);
+  });
+
+  it("inserts a membership row for the auto-subscribe program", async () => {
+    await autoSubscribeNewMember(userId);
+
+    const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, userId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].programId).toBe(weeklyProgramId);
+  });
+
+  it("is idempotent across repeated calls (no duplicate rows)", async () => {
+    await autoSubscribeNewMember(userId);
+    await autoSubscribeNewMember(userId);
+
+    const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, userId));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("does not throw or re-subscribe when the program is missing — captures to Sentry instead", async () => {
+    // Drop the program so the slug lookup misses. The function should
+    // log to Sentry and return without inserting anything. After the
+    // delete, the afterEach should not try to delete it again.
+    await db.delete(programs).where(eq(programs.id, weeklyProgramId));
+    weeklyInsertedByTest = false;
+
+    const captureMock = vi.mocked(Sentry.captureException);
+    captureMock.mockClear();
+
+    await expect(autoSubscribeNewMember(userId)).resolves.toBeUndefined();
+
+    expect(captureMock).toHaveBeenCalledOnce();
+    const arg = captureMock.mock.calls[0][0];
+    expect(arg).toBeInstanceOf(Error);
+    expect((arg as Error).message).toMatch(/weekly-web-updates/);
+
+    const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, userId));
+    expect(rows).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Bundle of four polish improvements to `/programs` (#226), plus a small cleanup commit on top.

- **Auto-subscribe newsletter** — new members get a `profile_programs` row for `weekly-web-updates` on first sign-in. Gated on "newly inserted profile" so an opt-out sticks across subsequent sign-ins. Best-effort; failures go to Sentry and sign-in continues.
- **`archivedAt` + `signupsOpen`** — `archivedAt` (timestamp) hides a program from the member listing; `signupsOpen` (boolean, closed by default) gates self-serve join. Admin add-participant is unaffected. Admin UI gains a Visibility section with toggles.
- **`leftAt` soft-delete** — `profile_programs` rows now persist across leave/rejoin, so `assignedAt` is the stable first-joined date. Every "currently joined" query filters `leftAt IS NULL`.
- **`/programs/[slug]` detail page** — name, description, members grid, join/leave button respecting `signupsOpen`. Linked from the main list; deliberately not from `/welcome/programs`.
- **Cleanup** — `setMembershipActive` / `setMembershipEnded` private helpers absorb the duplicated upsert/soft-delete bodies; the four public functions (join/leave/add/remove) own only their policy difference.

## Schema expand step required

Two migrations land here:
- `0008_add_programs_archive_signups.sql` — adds `archived_at` and `signups_open` to `programs`, with a backfill `UPDATE programs SET signups_open = true` so existing programs preserve current behavior.
- `0009_add_profile_programs_left_at.sql` — adds nullable `left_at` to `profile_programs`.

Run `npm run prod:db:expand` against prod before merging — previews share prod's DB and skip migrations, so a preview without expand would 500 on missing columns.

## Related issues filed during the work

- **#255** — `/auth/callback` swallows DB failures into a generic `?error=profile_error` redirect with no Sentry breadcrumb. Two specific catches to fix.
- **#256** — decide between aliased named imports (with `noNamespaceImport` Biome rule) vs. namespace imports + a code-style note. Affects the four new `import * as Sentry` lines this PR adds.
- **#257** — switching `drizzle.config.ts` to `migrations.prefix: "timestamp"` hits a `schemaFilter` regression in drizzle-kit v0.31.10. Kept on `index` prefix for now; this PR's renumber-on-rebase was manual.

## Test plan

- [ ] CI: lint + functional tests pass
- [ ] CI: e2e tests pass against the preview deploy
- [ ] Preview: `/programs` — programs you've joined show "Leave program"; closed-signup programs show a disabled "Signups closed" button; archived programs are absent
- [ ] Preview: `/programs/[slug]` for a live program — members grid renders, join/leave works, button disables with the right message on closed-signup programs
- [ ] Preview: `/admin/programs/[id]` — archive a program, confirm it disappears from `/programs` and from any typeaheads; still listed with the "Archived" badge in the admin list
- [ ] Preview: leave then rejoin a program — the listing's "Joined …" date doesn't change
- [ ] Preview: sign in as a brand-new member — confirm a `profile_programs` row for `weekly-web-updates` appears
- [ ] Preview: sign in as an existing member who has opted out — no re-subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)