### PR TITLE
UX polish: home pages, nav, auth-page copy, and member search

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { AppWordmark } from "@/components/app-wordmark";
 import { getServerUser } from "@/lib/supabase/server-user";
 
 import { ForgotPasswordForm } from "./forgot-password-form";
@@ -17,7 +18,7 @@ export default async function ForgotPasswordPage() {
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
-      <h1 className="text-4xl font-bold">Intentional Society</h1>
+      <AppWordmark asLink />
       <p className="max-w-sm text-center text-base text-muted-foreground">
         Enter your email and we will send you a link to reset your password.
       </p>

--- a/src/app/members/members-list.tsx
+++ b/src/app/members/members-list.tsx
@@ -8,6 +8,7 @@ import { Avatar } from "@/components/avatar";
 import { KeywordChips } from "@/components/keyword-chips";
 import { Input } from "@/components/ui/input";
 import type { MemberSummary } from "@/lib/api-types";
+import { scoreMember } from "@/lib/member-search";
 
 function MemberCard({ member }: { member: MemberSummary }) {
   const href: UrlObject = { pathname: `/members/${member.slug ?? member.id}` };
@@ -34,15 +35,14 @@ function MemberCard({ member }: { member: MemberSummary }) {
 export function MembersList({ members }: { members: MemberSummary[] }) {
   const [query, setQuery] = useState("");
 
+  // Same matcher and threshold as MemberTypeahead (see lib/member-search).
+  // Sort by score so the closest matches lead, like the typeahead does.
   const filtered = query.trim()
-    ? members.filter((m) => {
-        const q = query.toLowerCase();
-        return (
-          m.displayName.toLowerCase().includes(q) ||
-          (m.location?.toLowerCase().includes(q) ?? false) ||
-          m.keywords.some((k) => k.toLowerCase().includes(q))
-        );
-      })
+    ? members
+        .map((m) => ({ m, score: scoreMember(m, query) }))
+        .filter(({ score }) => score > 0)
+        .sort((a, b) => b.score - a.score)
+        .map(({ m }) => m)
     : members;
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { AppWordmark } from "@/components/app-wordmark";
 import { Button } from "@/components/ui/button";
 import { loadMe } from "@/lib/api-server";
 import { welcomeEntryStep } from "@/lib/welcomeEntryStep";
@@ -13,12 +14,23 @@ export const metadata: Metadata = { robots: { index: true, follow: true } };
 function LoggedOutHome() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-8 p-8">
-      <div className="flex flex-col items-center gap-1">
-        <h1 className="text-4xl font-bold">Intentional Society</h1>
-        <p className="font-serif italic text-2xl text-muted-foreground">The IS Web App</p>
-      </div>
-      <p className="max-w-md text-center text-muted-foreground">
-        A community of people practicing relational growth together.
+      <AppWordmark />
+      <p className="w-full max-w-sm text-center text-base text-muted-foreground">
+        This site is for network members. Don&apos;t have an invite?{" "}
+        <a
+          href="https://www.intentionalsociety.org/get-involved#connection-calls"
+          className="underline text-muted-foreground hover:text-foreground"
+        >
+          Join a Connection Call
+        </a>{" "}
+        to introduce yourself! In the meantime,{" "}
+        <a
+          href="https://www.intentionalsociety.org/web"
+          className="underline text-muted-foreground hover:text-foreground"
+        >
+          read more here
+        </a>
+        .
       </p>
 
       <div className="flex w-full max-w-sm flex-col gap-3">
@@ -29,19 +41,6 @@ function LoggedOutHome() {
           Join with an invite code
         </Button>
       </div>
-
-      <p className="max-w-sm text-center text-base text-muted-foreground">
-        Don&apos;t have an invite?{" "}
-        <a
-          href="https://www.intentionalsociety.org/get-involved#connection-calls"
-          className="underline text-muted-foreground hover:text-foreground"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Join a Connection Call
-        </a>{" "}
-        to meet the community and learn more.
-      </p>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -69,16 +69,26 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
   return (
     <main className="flex min-h-screen flex-col items-center gap-8 p-8 pt-12">
       <div className="flex flex-col items-center gap-2">
-        <h1 className="text-3xl font-bold">{greeting}</h1>
-        <p className="font-serif italic text-muted-foreground">What would you like to do?</p>
+        <h1 className="text-4xl font-bold">The IS Web App</h1>
+        <p className="font-serif italic text-muted-foreground">{greeting}. What would you like to do?</p>
+        <p className="mt-2 max-w-md text-center text-base text-muted-foreground">
+          We&apos;re actively building across this app still, but please try everything here — especially setting up
+          your Web connections! Send any feedback to{" "}
+          <a
+            href="mailto:devteam@mail.intentionalsociety.org"
+            className="underline text-muted-foreground hover:text-foreground"
+          >
+            devteam@mail.intentionalsociety.org
+          </a>
+        </p>
       </div>
 
       <div className="grid w-full max-w-lg gap-4 sm:grid-cols-2">
-        <NavCard href="/myweb" title="My web" description="See your connections and relational map." />
-        <NavCard href="/profile" title="My profile" description="View and edit your community profile." />
-        <NavCard href="/members" title="Member directory" description="Browse and connect with other members." />
-        <NavCard href="/programs" title="Programs" description="Explore and join community programs." />
-        <NavCard href="/invites" title="Invite a friend" description="Generate invite codes for new members." />
+        <NavCard href="/programs" title="Programs" description="Explore and join IS Web programs." />
+        <NavCard href="/members" title="Member directory" description="Browse and find other members." />
+        <NavCard href="/myweb" title="My web" description="Build your relational map by adding connections!" />
+        <NavCard href="/profile" title="My profile" description="View and edit your profile information." />
+        <NavCard href="/invites" title="Invite a friend" description="Generate an invite code to bring someone into the network." />
       </div>
     </main>
   );

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -36,7 +36,7 @@ export default async function SigninPage({ searchParams }: SigninPageProps) {
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
       <AppWordmark asLink />
       <p className="max-w-sm text-center text-base text-muted-foreground">
-        Receive a sign-in link by email, or sign in with your password if you have set one.
+        Receive a sign-in link by email, or sign in with your password if you've set one.
       </p>
       {process.env.NODE_ENV === "development" && (
         <p className="max-w-sm rounded border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { AppWordmark } from "@/components/app-wordmark";
 import { getServerUser } from "@/lib/supabase/server-user";
 
 import { SigninForm } from "./signin-form";
@@ -33,14 +34,14 @@ export default async function SigninPage({ searchParams }: SigninPageProps) {
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
-      <h1 className="text-4xl font-bold">Intentional Society</h1>
+      <AppWordmark asLink />
       <p className="max-w-sm text-center text-base text-muted-foreground">
-        Sign in with your password, or leave it blank to receive a magic link by email.
+        Receive a sign-in link by email, or sign in with your password if you have set one.
       </p>
       {process.env.NODE_ENV === "development" && (
         <p className="max-w-sm rounded border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
           <strong>Local dev:</strong> this database is separate from production. Use a seeded email (e.g.{" "}
-          <code>aria.chen@example.com</code>) or run <code>npm run seed:dev</code> first. Magic links arrive at{" "}
+          <code>aria.chen@example.com</code>) or run <code>npm run seed:dev</code> first. Sign-in links arrive at{" "}
           <a href="http://localhost:54324" target="_blank" rel="noopener noreferrer" className="underline">
             Inbucket
           </a>

--- a/src/app/signin/signin-form.tsx
+++ b/src/app/signin/signin-form.tsx
@@ -57,9 +57,9 @@ function SentView({ email, origin }: { email: string; origin: string }) {
           type="button"
           onClick={handleResend}
           disabled={!canResend}
-          className="text-base text-muted-foreground underline disabled:no-underline disabled:opacity-50"
+          className="text-base text-muted-foreground underline cursor-pointer disabled:cursor-default disabled:no-underline disabled:opacity-50"
         >
-          {sending ? "Resending…" : secondsLeft > 0 ? `Resend in ${secondsLeft}s` : "Resend email"}
+          {sending ? "Resending…" : secondsLeft > 0 ? `Resend available in ${secondsLeft}s` : "Resend email"}
         </button>
       )}
     </div>

--- a/src/app/signin/signin-form.tsx
+++ b/src/app/signin/signin-form.tsx
@@ -84,7 +84,7 @@ export function SigninForm() {
         password,
       });
       if (error) {
-        // No fallback to magic link — a failed password means the
+        // No fallback to the email sign-in link — a failed password means the
         // member mistyped it; falling through silently would be
         // confusing. They can clear the field and resubmit.
         setState({ status: "error", message: error.message });
@@ -150,7 +150,7 @@ export function SigninForm() {
         id="password"
         type="password"
         autoComplete="current-password"
-        placeholder="Leave blank to use magic link"
+        placeholder="Leave blank to use a sign-in link"
         value={password}
         onChange={(event) => setPassword(event.target.value)}
         disabled={state.status === "submitting"}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { AppWordmark } from "@/components/app-wordmark";
 import { getServerUser } from "@/lib/supabase/server-user";
 
 import { SignupForm } from "./signup-form";
@@ -24,7 +25,7 @@ export default async function SignupPage({ searchParams }: SignupPageProps) {
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
-      <h1 className="text-4xl font-bold">Intentional Society</h1>
+      <AppWordmark asLink />
       <p className="max-w-sm text-center text-base text-muted-foreground">
         Joining by invite? Enter the code a member shared with you.
       </p>

--- a/src/app/welcome/profile/welcome-form.tsx
+++ b/src/app/welcome/profile/welcome-form.tsx
@@ -48,12 +48,12 @@ export function WelcomeForm({ initial }: { initial: ProfileFormValues }) {
         id="password"
         type="password"
         autoComplete="new-password"
-        placeholder="Leave blank to continue using magic links"
+        placeholder="Leave blank to continue using sign-in links"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
         disabled={disabled}
       />
-      <p className="text-sm text-muted-foreground">You can always sign in with a magic link instead.</p>
+      <p className="text-sm text-muted-foreground">You can always use a sign-in link instead.</p>
 
       <Button type="submit" className="mt-3" disabled={disabled}>
         {disabled ? "Saving…" : "Save"}

--- a/src/components/app-wordmark.tsx
+++ b/src/components/app-wordmark.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+
+// The logged-out app title + tagline, shown on the landing and auth pages.
+// Logged-out pages have no nav header (SiteHeader renders null without a
+// user), so pass `asLink` on pages other than home to turn the title into a
+// link back to the landing page. Only the title links, not the tagline.
+export function AppWordmark({ asLink = false }: { asLink?: boolean }) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      {asLink ? (
+        <Link href="/" className="rounded transition-opacity hover:opacity-80">
+          <h1 className="text-4xl font-bold">The IS Web App</h1>
+        </Link>
+      ) : (
+        <h1 className="text-4xl font-bold">The IS Web App</h1>
+      )}
+      <p className="text-center font-serif italic text-2xl text-muted-foreground">
+        for the living web of <span className="whitespace-nowrap">Intentional Society</span>
+      </p>
+    </div>
+  );
+}

--- a/src/components/member-typeahead.tsx
+++ b/src/components/member-typeahead.tsx
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { apiClient } from "@/lib/api";
 import type { MemberSummary } from "@/lib/api-types";
+import { memberKeywords, memberSearchFilter } from "@/lib/member-search";
 
 const MEMBERS_QUERY_KEY = ["members"] as const;
 
@@ -20,12 +21,6 @@ const fetchMembers = async (): Promise<MemberSummary[]> => {
   const body = await res.json();
   return body.members;
 };
-
-// cmdk filters CommandItems by their `value` prop. Build one search
-// string per member so typing matches display name, location, or any
-// keyword without us needing a custom filter function.
-const searchValue = (m: MemberSummary): string =>
-  [m.displayName ?? "", m.location ?? "", ...(m.keywords ?? [])].join(" ");
 
 export function MemberTypeahead({
   label,
@@ -83,7 +78,7 @@ export function MemberTypeahead({
           }
         />
         <PopoverContent align="start" className="w-(--anchor-width) p-0">
-          <Command>
+          <Command filter={memberSearchFilter}>
             <CommandInput placeholder="Search members…" />
             <CommandList>
               <CommandEmpty>{isPending ? "Loading…" : "No member found."}</CommandEmpty>
@@ -91,7 +86,8 @@ export function MemberTypeahead({
                 {visible.map((m) => (
                   <CommandItem
                     key={m.id}
-                    value={searchValue(m)}
+                    value={m.displayName ?? ""}
+                    keywords={memberKeywords(m)}
                     onSelect={() => {
                       onSelect(m);
                       // Closing on every pick is friendlier than staying

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -35,6 +35,22 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
             <SheetClose
               nativeButton={false}
               render={
+                <Link href="/programs" className="rounded px-2 py-2 hover:bg-muted">
+                  Programs
+                </Link>
+              }
+            />
+            <SheetClose
+              nativeButton={false}
+              render={
+                <Link href="/members" className="rounded px-2 py-2 hover:bg-muted">
+                  Member directory
+                </Link>
+              }
+            />
+            <SheetClose
+              nativeButton={false}
+              render={
                 <Link href="/myweb" className="rounded px-2 py-2 hover:bg-muted">
                   My web
                 </Link>
@@ -43,16 +59,16 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
             <SheetClose
               nativeButton={false}
               render={
-                <Link href="/invites" className="rounded px-2 py-2 hover:bg-muted">
-                  Invite a friend
+                <Link href="/profile" className="rounded px-2 py-2 hover:bg-muted">
+                  My profile
                 </Link>
               }
             />
             <SheetClose
               nativeButton={false}
               render={
-                <Link href="/profile" className="rounded px-2 py-2 hover:bg-muted">
-                  My profile
+                <Link href="/invites" className="rounded px-2 py-2 hover:bg-muted">
+                  Invite a friend
                 </Link>
               }
             />

--- a/src/lib/member-search.ts
+++ b/src/lib/member-search.ts
@@ -1,0 +1,29 @@
+import { defaultFilter } from "cmdk";
+
+import type { MemberSummary } from "@/lib/api-types";
+
+// Single source of truth for member search scoring, shared by the cmdk-based
+// MemberTypeahead and the Member Directory's plain list filter so both surfaces
+// match the same fields with the same behavior.
+
+// Floor applied to cmdk's fuzzy score. Below it, an item is treated as no
+// match. Tune here and both surfaces move together.
+export const MEMBER_SEARCH_THRESHOLD = 0.8;
+
+// Location + interest keywords act as search aliases — matchable, but ranked
+// below the display name (which is the item value).
+export const memberKeywords = (m: MemberSummary): string[] =>
+  [m.location ?? "", ...(m.keywords ?? [])].filter(Boolean);
+
+// cmdk's CommandFilter shape: score value/search/keywords and gate at the
+// threshold. Pass straight to <Command filter={...}>. defaultFilter is
+// commandScore(value, search, keywords), so keywords fold into the score.
+export const memberSearchFilter = (value: string, search: string, keywords?: string[]): number => {
+  const score = defaultFilter(value, search, keywords);
+  return score >= MEMBER_SEARCH_THRESHOLD ? score : 0;
+};
+
+// Score a whole member against a query, for non-cmdk callers like the
+// directory list. Returns 0 when the match doesn't clear the threshold.
+export const scoreMember = (m: MemberSummary, query: string): number =>
+  memberSearchFilter(m.displayName ?? "", query, memberKeywords(m));

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -257,7 +257,17 @@ const api = new Hono<{ Variables: ApiVariables }>()
         ...(parsed.displayName !== undefined ? { slug: parsed.displayName ? toSlug(parsed.displayName) : null } : {}),
         lastUpdatedProfile: sql`now()`,
       };
-      await db.update(profiles).set(update).where(eq(profiles.id, user.id));
+      try {
+        await db.update(profiles).set(update).where(eq(profiles.id, user.id));
+      } catch (err) {
+        // Display name maps to a unique slug; a clash means another member
+        // already uses this name. Surface it instead of a generic 500.
+        const cause = (err as { cause?: { code?: string; constraint_name?: string } }).cause;
+        if (cause?.code === "23505" && cause.constraint_name === "profiles_slug_unique") {
+          return c.json({ error: "That display name is already taken. Please choose a different one." }, 409);
+        }
+        throw err;
+      }
     }
 
     const profile = await getProfileForSelf(user.id);

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 test("unauthenticated visit to / shows logged-out home page", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "Intentional Society" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "The IS Web App" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Join with an invite code" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Join a Connection Call" })).toBeVisible();

--- a/tests/functional/server/api-me.test.ts
+++ b/tests/functional/server/api-me.test.ts
@@ -151,6 +151,28 @@ describe("GET /api/me", () => {
     });
     expect(res.status).toBe(400);
   });
+
+  it("PUT /me returns 409 when the display name's slug is already taken", async () => {
+    // Seed another member who already owns the slug "member-name".
+    const otherId = randomUUID();
+    await db.execute(
+      sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${otherId}::uuid, 'slug-clash@testfake.local', false, false)`,
+    );
+    await db.insert(profiles).values({ id: otherId, displayName: "Member Name", slug: "member-name" });
+
+    try {
+      const res = await putMe({ displayName: "Member Name" });
+      expect(res.status).toBe(409);
+      expect((await res.json()).error).toMatch(/already taken/i);
+
+      // The failed update must leave the caller's own slug untouched.
+      const [row] = await db.select().from(profiles).where(eq(profiles.id, testUserId));
+      expect(row?.slug).not.toBe("member-name");
+    } finally {
+      await db.delete(profiles).where(eq(profiles.id, otherId));
+      await db.execute(sql`DELETE FROM auth.users WHERE id = ${otherId}::uuid`);
+    }
+  });
 });
 
 describe("PUT /api/me/last-updated-web", () => {


### PR DESCRIPTION
A batch of UI polish accumulated on `ux-polish`, plus one backend correctness fix.

## Member search
- Extract a shared matcher (`lib/member-search`) so the member typeahead and the directory search use the same fuzzy scorer with a 0.8 threshold over the same fields. The directory drops its hand-rolled substring filter and now sorts by relevance.

## Navigation
- Add **Programs** and **Member directory** to the nav menu. Order: Home, Programs, Member directory, My web, My profile, Invite a friend, Admin, Sign out.

## Signed-out / auth pages
- Shared `AppWordmark` (title "The IS Web App" + tagline) on the landing and auth pages. The title links back to home from signin/signup/forgot-password, since logged-out pages have no nav header.
- Landing copy reworked; "read more here" points at intentionalsociety.org/web; both links open in the same tab.
- Rename "magic link" → "sign-in link" across the sign-in page/form and the welcome profile form.
- Sign-in page: "you've" contraction, "Resend available in Xs", and `cursor-pointer` on the resend button (Tailwind v4 no longer defaults buttons to a pointer cursor).

## Logged-in home
- Title now matches the brand title; the greeting moves into the line below it. Add an "in active development / send feedback" note. Nav cards reordered to match the menu, with rewritten descriptions.

## Backend fix
- `PUT /me` now catches the duplicate-slug unique violation and returns a **409 with an actionable message** (previously an uncaught 500 surfaced as a generic "Failed to save profile"). Functional test added.

## Testing
- `npm test` locally: functional **235/235**, e2e **25/25** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
