### PR TITLE
feat: add Give Feedback link to sidebar menu

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-24 | Benji | Give Feedback link in sidebar
+
+Added a "Give Feedback" link to the hamburger menu that opens a Google Form in a new tab. Includes a functional test asserting the link's presence, URL, and target attributes.
+
 ## 2026-05-21 | James | Polish programs (#226)
 
 Four bundled improvements: new members are auto-subscribed to the weekly web update on first sign-in; programs gain `archivedAt` (hidden from members) and `signupsOpen` (gates self-serve join, closed by default); `profile_programs` becomes soft-deleted via `leftAt` so the original `assignedAt` survives leave/rejoin as a stable first-joined date; per-program detail pages live at `/programs/[slug]`.

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -72,6 +72,19 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
                 </Link>
               }
             />
+            <SheetClose
+              nativeButton={false}
+              render={
+                <a
+                  href="https://docs.google.com/forms/d/e/1FAIpQLScXhdSxbQ3LxjiYhqN2fmuyy66SK292rTYEZV3QaHgzn1eVjA/viewform?usp=dialog"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="rounded px-2 py-2 hover:bg-muted"
+                >
+                  Give Feedback
+                </a>
+              }
+            />
             {isAdmin ? (
               <SheetClose
                 nativeButton={false}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -72,19 +72,14 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
                 </Link>
               }
             />
-            <SheetClose
-              nativeButton={false}
-              render={
-                <a
-                  href="https://docs.google.com/forms/d/e/1FAIpQLScXhdSxbQ3LxjiYhqN2fmuyy66SK292rTYEZV3QaHgzn1eVjA/viewform?usp=dialog"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="rounded px-2 py-2 hover:bg-muted"
-                >
-                  Give Feedback
-                </a>
-              }
-            />
+            <a
+              href="https://docs.google.com/forms/d/e/1FAIpQLScXhdSxbQ3LxjiYhqN2fmuyy66SK292rTYEZV3QaHgzn1eVjA/viewform?usp=dialog"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded px-2 py-2 hover:bg-muted"
+            >
+              Give Feedback
+            </a>
             {isAdmin ? (
               <SheetClose
                 nativeButton={false}

--- a/tests/functional/client/site-header.test.tsx
+++ b/tests/functional/client/site-header.test.tsx
@@ -69,4 +69,22 @@ describe("SiteHeader", () => {
     fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
     expect(await screen.findByText("Admin")).toBeVisible();
   });
+
+  it("shows Give Feedback link that opens in a new tab", async () => {
+    render(
+      <AuthProvider initialUser={user}>
+        <SiteHeader displayName={null} isAdmin={false} />
+      </AuthProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
+    const link = await screen.findByText("Give Feedback");
+    expect(link).toBeVisible();
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://docs.google.com/forms/d/e/1FAIpQLScXhdSxbQ3LxjiYhqN2fmuyy66SK292rTYEZV3QaHgzn1eVjA/viewform?usp=dialog",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
 });


### PR DESCRIPTION
This pull request adds a new "Give Feedback" link to the site header, allowing users to easily provide feedback via a Google Form.

User experience improvements:

* Added a `SheetClose` component that renders a "Give Feedback" link in the site header, directing users to a Google Form for feedback. The link opens in a new tab and is styled for better visibility.