### PR TITLE
feat: highlight joined program cards with ring

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-24 | Benji | Joined program card ring highlight
+
+Program cards now show a ring highlight when the user has joined, replacing the default border with `ring-3 ring-ring/50` for a clearer visual distinction.
+
 ## 2026-05-24 | Benji | Give Feedback link in sidebar
 
 Added a "Give Feedback" link to the hamburger menu that opens a Google Form in a new tab. Includes a functional test asserting the link's presence, URL, and target attributes.

--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -29,7 +29,7 @@ function ProgramCard({
 
   return (
     <li
-      className={`flex flex-col gap-3 rounded-xl bg-card p-5 ${program.joined ? "ring-3 ring-ring/50" : "border border-border"}`}
+      className={`flex flex-col gap-3 rounded-xl bg-card p-5 ${program.joined ? "border border-transparent ring-3 ring-ring/50" : "border border-border"}`}
     >
       <div className="flex flex-col gap-1">
         <h2 className="text-lg font-semibold">

--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -28,7 +28,9 @@ function ProgramCard({
   const visibleDescription = isLong && !expanded ? `${description.slice(0, DESCRIPTION_LIMIT)}…` : description;
 
   return (
-    <li className="flex flex-col gap-3 rounded-xl border border-border bg-card p-5">
+    <li
+      className={`flex flex-col gap-3 rounded-xl bg-card p-5 ${program.joined ? "ring-3 ring-ring/50" : "border border-border"}`}
+    >
       <div className="flex flex-col gap-1">
         <h2 className="text-lg font-semibold">
           <Link


### PR DESCRIPTION
This pull request updates the visual styling of program cards to provide a clearer indication when a user has joined a program. Instead of the default border, joined program cards now display a ring highlight, making them stand out more distinctly.

**UI Improvements:**

* [`src/app/programs/programs-list.tsx`](diffhunk://#diff-9f109e49a8386d0d1f7ce439540b0ac72dfcf77d04ca43583311d61ea8cd1203L31-R33): Updated the `ProgramCard` component to conditionally apply a `ring-3 ring-ring/50` highlight when `program.joined` is true, replacing the standard border for joined programs.

**Documentation:**

* [`docs/devjournal.md`](diffhunk://#diff-ff2ac01e297e24aacc94397b5b8385968856889110f39873253f5d2657afb7f2R7-R10): Added a new entry describing the joined program card ring highlight change.