### PR TITLE
feat: add custom 404 page

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-24 | Benji | Custom 404 page
+
+Added a `not-found.tsx` at the app root so unmatched routes show a styled 404 page consistent with the app's aesthetic — serif italic subtitle, centered layout, and a "Go home" button.
+
 ## 2026-05-24 | Benji | Joined program card ring highlight
 
 Program cards now show a ring highlight when the user has joined, replacing the default border with `ring-3 ring-ring/50` for a clearer visual distinction.

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
+      <h1 className="text-6xl font-bold">404</h1>
+      <p className="font-serif italic text-lg text-muted-foreground">This page doesn&apos;t exist — or maybe it wandered off.</p>
+      <Button render={<Link href="/" />}>Go home</Button>
+    </main>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,7 +5,10 @@ import { Button } from "@/components/ui/button";
 export default function NotFound() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
-      <h1 className="text-6xl font-bold">404</h1>
+      <h1 className="text-6xl font-bold">
+        404
+        <span className="sr-only"> Page not found</span>
+      </h1>
       <p className="font-serif italic text-lg text-muted-foreground">This page doesn&apos;t exist — or maybe it wandered off.</p>
       <Button render={<Link href="/" />}>Go home</Button>
     </main>


### PR DESCRIPTION
This pull request introduces a custom 404 page to improve the user experience when navigating to an invalid route. The new page provides a styled, branded error message and an easy way for users to return to the homepage.

Custom 404 page implementation:

* Added a new `not-found.tsx` file at the app root, which displays a centered 404 message with a serif italic subtitle and a "Go home" button that navigates back to the homepage. The design is consistent with the app's overall aesthetic.
* Documented the addition of the custom 404 page in `docs/devjournal.md`, describing the new user experience for unmatched routes.