### PR TITLE
fix: add privacy note to emergency contact on profile view page

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -6,12 +6,18 @@ import { Button } from "@/components/ui/button";
 import { requireUser } from "@/lib/api-server";
 import type { Me } from "@/lib/api-types";
 
-function Field({ label, children, note }: { label: string; children: React.ReactNode; note?: string }) {
+function Field({ label, children, badge }: { label: string; children: React.ReactNode; badge?: string }) {
   return (
     <div className="flex flex-col gap-1">
-      <dt className="text-sm uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dt className="flex items-center gap-2 text-sm uppercase tracking-wide text-muted-foreground">
+        {label}
+        {badge && (
+          <span className="rounded-full bg-muted px-2 py-0.5 text-xs normal-case tracking-normal text-muted-foreground">
+            {badge}
+          </span>
+        )}
+      </dt>
       <dd className="font-serif text-base">{children || <span className="text-muted-foreground">—</span>}</dd>
-      {note && <p className="text-xs text-muted-foreground">{note}</p>}
     </div>
   );
 }
@@ -50,7 +56,7 @@ export default async function ProfilePage() {
         <Field label="Location">{profile.location}</Field>
         <Field label="Live desire">{profile.liveDesire}</Field>
         <Field label="Supplementary info">{profile.supplementaryInfo}</Field>
-        <Field label="Emergency contact" note="Only visible to you and admins.">{profile.emergencyContact}</Field>
+        <Field label="Emergency contact" badge="Only visible to you and admins">{profile.emergencyContact}</Field>
       </dl>
 
       <Button render={<Link href="/profile/edit" />}>Edit profile</Button>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -6,11 +6,12 @@ import { Button } from "@/components/ui/button";
 import { requireUser } from "@/lib/api-server";
 import type { Me } from "@/lib/api-types";
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+function Field({ label, children, note }: { label: string; children: React.ReactNode; note?: string }) {
   return (
     <div className="flex flex-col gap-1">
       <dt className="text-sm uppercase tracking-wide text-muted-foreground">{label}</dt>
       <dd className="font-serif text-base">{children || <span className="text-muted-foreground">—</span>}</dd>
+      {note && <p className="text-xs text-muted-foreground">{note}</p>}
     </div>
   );
 }
@@ -49,7 +50,7 @@ export default async function ProfilePage() {
         <Field label="Location">{profile.location}</Field>
         <Field label="Live desire">{profile.liveDesire}</Field>
         <Field label="Supplementary info">{profile.supplementaryInfo}</Field>
-        <Field label="Emergency contact">{profile.emergencyContact}</Field>
+        <Field label="Emergency contact" note="Only visible to you and admins.">{profile.emergencyContact}</Field>
       </dl>
 
       <Button render={<Link href="/profile/edit" />}>Edit profile</Button>


### PR DESCRIPTION
Closes #272

## Summary

- Adds "Only visible to you and admins." below the Emergency contact field on `/profile` (the read-only view page)
- The edit form (`profile-fields.tsx`) already had an equivalent note — this closes the gap on the view side
- Implemented via an optional `note` prop on the local `Field` component, keeping the change minimal

## Test plan

- [ ] Visit `/profile` as any member — Emergency contact field shows the privacy note below the value
- [ ] Visit another member's profile at `/members/[id]` — Emergency contact field is not shown at all (unchanged)
- [ ] Visit `/profile/edit` — existing note on the edit form still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)