### PR TITLE
fix: clarify optional password UX on sign-in and welcome forms

### DIFF
--- a/src/app/signin/signin-form.tsx
+++ b/src/app/signin/signin-form.tsx
@@ -150,11 +150,12 @@ export function SigninForm() {
         id="password"
         type="password"
         autoComplete="current-password"
-        placeholder="Leave blank to use a sign-in link"
+        placeholder="Leave blank to receive a sign-in link by email"
         value={password}
         onChange={(event) => setPassword(event.target.value)}
         disabled={state.status === "submitting"}
       />
+      <p className="text-sm text-muted-foreground">Only needed if you've previously set one.</p>
       <Button type="submit" disabled={state.status === "submitting"}>
         {state.status === "submitting"
           ? password.length > 0

--- a/src/app/welcome/profile/welcome-form.tsx
+++ b/src/app/welcome/profile/welcome-form.tsx
@@ -48,12 +48,14 @@ export function WelcomeForm({ initial }: { initial: ProfileFormValues }) {
         id="password"
         type="password"
         autoComplete="new-password"
-        placeholder="Leave blank to continue using sign-in links"
+        placeholder="Leave blank to skip"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
         disabled={disabled}
       />
-      <p className="text-sm text-muted-foreground">You can always use a sign-in link instead.</p>
+      <p className="text-sm text-muted-foreground">
+        You don't need a password — signing in by email link always works. A password is only useful if you'd prefer to sign in without waiting for an email.
+      </p>
 
       <Button type="submit" className="mt-3" disabled={disabled}>
         {disabled ? "Saving…" : "Save"}


### PR DESCRIPTION
Closes #268
Also resolves #225 (all magic link wording was already replaced in a prior commit — closing here since no further copy changes are needed).

## Summary

- **Sign-in form**: added *"Only needed if you've previously set one."* below the password field — users who've never set a password now have a clear signal to leave it blank
- **Welcome form**: replaced *"You can always use a sign-in link instead."* (which implies password is the default) with an explicit explanation that email sign-in always works and a password is only a convenience for skipping the email step
- **Welcome form**: simplified placeholder from *"Leave blank to continue using sign-in links"* to *"Leave blank to skip"* — shorter and more direct

## Test plan

- [ ] Visit `/signin` — password field shows helper text "Only needed if you've previously set one."
- [ ] Leave password blank and submit — button shows "Send sign-in link", email is sent
- [ ] Fill in password and submit — button shows "Sign in", signs in with password
- [ ] Go through welcome flow — password section shows updated helper text explaining email sign-in always works

🤖 Generated with [Claude Code](https://claude.com/claude-code)