### PR TITLE
Buttondown sync: schema, cron, inline resync, bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ test-results/
 .claude/
 .vercel
 
+# agent scratch notes — emergent design decisions, working memory
+.scratch/
+
 # member-import source data — contains member PII, never commit
 scripts/*.csv
 scripts/.import-cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ Requires Docker Desktop. `npm run dev` auto-starts a local Supabase stack (Postg
 - `docs/design-emails.md` — auth email template authoring and prod sync
 - `docs/design-profile-pictures.md` — avatar uploads, storage bucket, signed URLs
 - `docs/design-relations.md` — the relationship web (schema, flows, rationale)
+- `docs/design-buttondown.md` — Buttondown sync (program tag mirror, cron, write policy)
 - `docs/doc-vercel.md` — Vercel dashboard settings
 - `docs/doc-supabase.md` — Supabase dashboard settings (auth URLs, API keys)
 - `docs/doc-resend.md` — Resend transactional email (sending domain, DMARC, alternatives)

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-25 | James | Buttondown sync
+
+Mirrors program memberships into Buttondown subscriber tags via a daily cron plus inline hooks on join/leave/admin-remove, replacing the Apps Script pipeline. Per-program opt-in via `programs.buttondown_tag`; ships in dry-run, then `scripts/buttondown-bootstrap.ts` reconciles the existing audience and `BUTTONDOWN_SYNC_WRITE=1` flips writes on. Design: `docs/design-buttondown.md`. (#280)
+
 ## 2026-05-24 | Benji | Custom 404 page
 
 Added a `not-found.tsx` at the app root so unmatched routes show a styled 404 page consistent with the app's aesthetic — serif italic subtitle, centered layout, and a "Go home" button.
@@ -15,10 +19,6 @@ Program cards now show a ring highlight when the user has joined, replacing the 
 ## 2026-05-24 | Benji | Give Feedback link in sidebar
 
 Added a "Give Feedback" link to the hamburger menu that opens a Google Form in a new tab. Includes a functional test asserting the link's presence, URL, and target attributes.
-
-## 2026-05-23 | James (draft) | Buttondown sync
-
-Mirrors IS Web program memberships into Buttondown subscriber tags via a daily Vercel cron (08:00 UTC) plus an inline best-effort hook on first profile save, replacing the pre-app Google Form + Apps Script pipeline. Per-program opt-in via a new `programs.buttondown_tag` column; the cron loops over our profiles so the larger non-member newsletter audience is structurally untouchable. Write-vs-dry-run gate lives at the Buttondown API client layer (every PATCH/POST short-circuits when called with `write: false`). Admin gets two "Sync now" buttons (dry-run and write) under /admin. Full design: `docs/design-buttondown.md`. Rollout: schema, then `scripts/buttondown-bootstrap.ts` to reconcile the ~46 CSV-imported members (Buttondown is authoritative for the bootstrap moment), then flip `BUTTONDOWN_SYNC_WRITE=1` and disable the Apps Script. Tracking: #261.
 
 ## 2026-05-21 | James | Polish programs (#226)
 

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -16,6 +16,10 @@ Program cards now show a ring highlight when the user has joined, replacing the 
 
 Added a "Give Feedback" link to the hamburger menu that opens a Google Form in a new tab. Includes a functional test asserting the link's presence, URL, and target attributes.
 
+## 2026-05-23 | James (draft) | Buttondown sync
+
+Mirrors IS Web program memberships into Buttondown subscriber tags via a daily Vercel cron (08:00 UTC) plus an inline best-effort hook on first profile save, replacing the pre-app Google Form + Apps Script pipeline. Per-program opt-in via a new `programs.buttondown_tag` column; the cron loops over our profiles so the larger non-member newsletter audience is structurally untouchable. Write-vs-dry-run gate lives at the Buttondown API client layer (every PATCH/POST short-circuits when called with `write: false`). Admin gets two "Sync now" buttons (dry-run and write) under /admin. Full design: `docs/design-buttondown.md`. Rollout: schema, then `scripts/buttondown-bootstrap.ts` to reconcile the ~46 CSV-imported members (Buttondown is authoritative for the bootstrap moment), then flip `BUTTONDOWN_SYNC_WRITE=1` and disable the Apps Script. Tracking: #261.
+
 ## 2026-05-21 | James | Polish programs (#226)
 
 Four bundled improvements: new members are auto-subscribed to the weekly web update on first sign-in; programs gain `archivedAt` (hidden from members) and `signupsOpen` (gates self-serve join, closed by default); `profile_programs` becomes soft-deleted via `leftAt` so the original `assignedAt` survives leave/rejoin as a stable first-joined date; per-program detail pages live at `/programs/[slug]`.

--- a/docs/doc-axiom.md
+++ b/docs/doc-axiom.md
@@ -42,5 +42,8 @@ The sync emits two message families: `"buttondown sync"` (structured events with
   `["vercel"] | where message == "buttondown http" and fields.status == 429`
 - **Dry-run vs write traffic split:**
   `["vercel"] | where message == "buttondown sync" and fields.action == "summary" | summarize count() by fields.write`
+- **Lock retry budget — how often does retry save us?**
+  `["vercel"] | where message == "buttondown sync" and fields.action == "lock-acquired" | summarize count() by fields.attempts`
+  Distribution of `attempts` across runs. `1` means no contention; `>1` means a retry succeeded. Pair with `skipped-lock-held` count (retries exhausted) to size the budget.
 
 Sentry surfaces the page-worthy events: `buttondown.sync_profile_error` (one per failing profile, tagged with `errorKind`), `buttondown.sync_lock_held` (cron overlap), and `buttondown.unsubscribed_member` (member-with-active-program who unsubscribed). Each Sentry issue's `runId` tag links back to the Axiom query above.

--- a/docs/doc-axiom.md
+++ b/docs/doc-axiom.md
@@ -25,3 +25,22 @@ Every API request is logged by Hono middleware in `src/server/api.ts` with:
 ## Environment Variables
 
 No Axiom-specific env vars are needed in the app. The Vercel Log Drain integration handles authentication automatically. `next-axiom` reads the Vercel-provided `NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT` at build time.
+
+## Buttondown sync — canonical queries
+
+The sync emits two message families: `"buttondown sync"` (structured events with a `fields.action`) and `"buttondown http"` (one per outbound Buttondown API call). Every event carries `fields.runId`, which for cron runs is `cron:<iso-timestamp>`, for admin runs is `admin:<profileId>:(dry-run|write)`, and for inline first-save is `first-save:<profileId>`.
+
+- **Cron summary trend (run duration, counts):**
+  `["vercel"] | where ['service.name'] == "is-app" | where message == "buttondown sync" and fields.action == "summary" | summarize avg(fields.durationMs), sum(fields.errors), sum(fields.tagsUpdated) by bin_auto(_time)`
+- **Per-profile errors by kind:**
+  `["vercel"] | where message == "buttondown sync" and fields.action == "error" | summarize count() by fields.errorKind, bin_auto(_time)`
+- **Unsubscribe alerts (operator follow-up queue):**
+  `["vercel"] | where message == "buttondown sync" and fields.action == "unsubscribe-alert"`
+- **Buttondown HTTP health (status distribution, p95 latency):**
+  `["vercel"] | where message == "buttondown http" | summarize count(), avg(fields.durationMs), percentile(fields.durationMs, 95) by fields.status, fields.path`
+- **Rate-limit hits:**
+  `["vercel"] | where message == "buttondown http" and fields.status == 429`
+- **Dry-run vs write traffic split:**
+  `["vercel"] | where message == "buttondown sync" and fields.action == "summary" | summarize count() by fields.write`
+
+Sentry surfaces the page-worthy events: `buttondown.sync_profile_error` (one per failing profile, tagged with `errorKind`), `buttondown.sync_lock_held` (cron overlap), and `buttondown.unsubscribed_member` (member-with-active-program who unsubscribed). Each Sentry issue's `runId` tag links back to the Axiom query above.

--- a/drizzle/0010_add_buttondown_sync.sql
+++ b/drizzle/0010_add_buttondown_sync.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "sync_locks" (
+	"name" text PRIMARY KEY NOT NULL,
+	"locked_until" timestamp with time zone NOT NULL,
+	"acquired_by" text NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "sync_locks" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "buttondown_subscriber_id" text;--> statement-breakpoint
+ALTER TABLE "programs" ADD COLUMN "buttondown_tag" text;

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,684 @@
+{
+  "id": "2cee0e17-387c-4319-87d8-205ba2cde329",
+  "prevId": "94eb3abb-3699-4c0a-ad73-137d3573b3b3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.invite_hints": {
+      "name": "invite_hints",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_hints_invite_id_invites_id_fk": {
+          "name": "invite_hints_invite_id_invites_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "invites",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_hints_ratee_id_profiles_id_fk": {
+          "name": "invite_hints_ratee_id_profiles_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_hints_invite_id_ratee_id_pk": {
+          "name": "invite_hints_invite_id_ratee_id_pk",
+          "columns": [
+            "invite_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by": {
+          "name": "redeemed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_value": {
+          "name": "creator_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_profiles_id_fk": {
+          "name": "invites_created_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_profiles_id_fk": {
+          "name": "invites_redeemed_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "redeemed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_redemption_pair": {
+          "name": "invites_redemption_pair",
+          "value": "(\"invites\".\"redeemed_by\" IS NULL) = (\"invites\".\"redeemed_at\" IS NULL)"
+        },
+        "invites_expires_after_created": {
+          "name": "invites_expires_after_created",
+          "value": "\"invites\".\"expires_at\" > \"invites\".\"created_at\""
+        },
+        "invites_creator_value_range": {
+          "name": "invites_creator_value_range",
+          "value": "\"invites\".\"creator_value\" IS NULL OR (\"invites\".\"creator_value\" BETWEEN 1 AND 4)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profile_programs": {
+      "name": "profile_programs",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_programs_profile_id_profiles_id_fk": {
+          "name": "profile_programs_profile_id_profiles_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_programs_program_id_programs_id_fk": {
+          "name": "profile_programs_program_id_programs_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_programs_profile_id_program_id_pk": {
+          "name": "profile_programs_profile_id_program_id_pk",
+          "columns": [
+            "profile_id",
+            "program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplementary_info": {
+          "name": "supplementary_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by": {
+          "name": "referred_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by_legacy": {
+          "name": "referred_by_legacy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_desire": {
+          "name": "live_desire",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_signed_agreements": {
+          "name": "last_signed_agreements",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_profile": {
+          "name": "last_updated_profile",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reviewed_programs": {
+          "name": "last_reviewed_programs",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_web": {
+          "name": "last_updated_web",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttondown_subscriber_id": {
+          "name": "buttondown_subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profiles_referred_by_profiles_id_fk": {
+          "name": "profiles_referred_by_profiles_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "referred_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_slug_unique": {
+          "name": "profiles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signups_open": {
+          "name": "signups_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "buttondown_tag": {
+          "name": "buttondown_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_slug_unique": {
+          "name": "programs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "rater_id": {
+          "name": "rater_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hint": {
+          "name": "is_hint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hinted_by": {
+          "name": "hinted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "relations_rater_id_profiles_id_fk": {
+          "name": "relations_rater_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "rater_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_ratee_id_profiles_id_fk": {
+          "name": "relations_ratee_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_hinted_by_profiles_id_fk": {
+          "name": "relations_hinted_by_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "hinted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "relations_rater_id_ratee_id_pk": {
+          "name": "relations_rater_id_ratee_id_pk",
+          "columns": [
+            "rater_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relations_no_self": {
+          "name": "relations_no_self",
+          "value": "\"relations\".\"rater_id\" != \"relations\".\"ratee_id\""
+        },
+        "relations_value_range": {
+          "name": "relations_value_range",
+          "value": "\"relations\".\"value\" IS NULL OR (\"relations\".\"value\" BETWEEN 1 AND 4)"
+        },
+        "relations_hint_state": {
+          "name": "relations_hint_state",
+          "value": "(NOT \"relations\".\"is_hint\" AND \"relations\".\"value\" IS NOT NULL)\n       OR (\"relations\".\"is_hint\" AND \"relations\".\"value\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.sync_locks": {
+      "name": "sync_locks",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_by": {
+          "name": "acquired_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1779344925149,
       "tag": "0009_add_profile_programs_left_at",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1779519730089,
+      "tag": "0010_add_buttondown_sync",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/buttondown-bootstrap.ts
+++ b/scripts/buttondown-bootstrap.ts
@@ -22,21 +22,20 @@
  *     npx tsx scripts/buttondown-bootstrap.ts --write
  *
  * ENV (from .env.local in dev, .env.prod via --prod in production):
- *   BUTTONDOWN_API_KEY   required to talk to Buttondown
- *   DATABASE_URL         the app DB
+ *   BUTTONDOWN_API_KEY                              required to talk to Buttondown
+ *   DATABASE_URL                                    the app DB
+ *   NEXT_PUBLIC_SUPABASE_URL                        loaded via transitive imports
+ *   NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY    loaded via transitive imports
+ *
+ * Note on the dynamic imports inside main(): src/server modules
+ * transitively pull src/lib/supabase/env.ts, which throws at module
+ * load if Supabase env vars are unset. Loading dotenv first and
+ * dynamic-importing the app modules afterward keeps the import-time
+ * env check happening AFTER .env.* is in place.
  */
 
 import { createInterface } from "node:readline/promises";
 import { config } from "dotenv";
-
-import { createButtondownClient } from "../src/server/buttondown";
-import {
-  applyBootstrapForMember,
-  loadBootstrapMembers,
-  loadJoinedTaggedPrograms,
-  loadManagedUniverse,
-} from "../src/server/buttondown-bootstrap";
-import { buildSubscriberLookup } from "../src/server/buttondown-sync";
 
 const argv = process.argv.slice(2);
 const useProd = argv.includes("--prod");
@@ -63,6 +62,18 @@ async function main() {
   }
 
   await confirmIfWrite();
+
+  // Dynamic imports: see header note. Static imports would evaluate
+  // src/lib/supabase/env.ts before config() loaded .env, throwing
+  // before this script could even check its own env precondition.
+  const { createButtondownClient } = await import("../src/server/buttondown");
+  const {
+    applyBootstrapForMember,
+    loadBootstrapMembers,
+    loadJoinedTaggedPrograms,
+    loadManagedUniverse,
+  } = await import("../src/server/buttondown-bootstrap");
+  const { buildSubscriberLookup } = await import("../src/server/buttondown-sync");
 
   const client = createButtondownClient({
     apiKey: process.env.BUTTONDOWN_API_KEY,

--- a/scripts/buttondown-bootstrap.ts
+++ b/scripts/buttondown-bootstrap.ts
@@ -36,17 +36,11 @@ import {
   loadJoinedTaggedPrograms,
   loadManagedUniverse,
 } from "../src/server/buttondown-bootstrap";
+import { buildSubscriberLookup } from "../src/server/buttondown-sync";
 
 const argv = process.argv.slice(2);
 const useProd = argv.includes("--prod");
 const write = argv.includes("--write");
-
-config({ path: useProd ? ".env.prod" : ".env.local" });
-
-if (!process.env.BUTTONDOWN_API_KEY) {
-  console.error("BUTTONDOWN_API_KEY is not set in the loaded env file.");
-  process.exit(1);
-}
 
 const confirmIfWrite = async (): Promise<void> => {
   if (!write) return;
@@ -60,69 +54,88 @@ const confirmIfWrite = async (): Promise<void> => {
   }
 };
 
-await confirmIfWrite();
+async function main() {
+  config({ path: useProd ? ".env.prod" : ".env.local" });
 
-const client = createButtondownClient({
-  apiKey: process.env.BUTTONDOWN_API_KEY,
-  write,
-});
-
-console.log(`# Buttondown bootstrap — ${write ? "WRITE" : "dry-run"} mode (${useProd ? "prod" : "local"})`);
-
-const [members, byProfile, managedUniverse] = await Promise.all([
-  loadBootstrapMembers(),
-  loadJoinedTaggedPrograms(),
-  loadManagedUniverse(),
-]);
-
-console.log(`# ${members.length} saved profiles; managed tag universe: [${[...managedUniverse].join(", ")}]\n`);
-
-const counts = {
-  reconciled: 0,
-  skippedMissingEmail: 0,
-  skippedMissingSubscriber: 0,
-  skippedUnsubscribed: 0,
-  errors: 0,
-};
-
-for (const member of members) {
-  const label = `${member.displayName ?? "(no name)"} <${member.email ?? "(no email)"}>`;
-  try {
-    const joined = byProfile.get(member.profileId) ?? [];
-    const { plan, applied } = await applyBootstrapForMember(member, joined, managedUniverse, { client, write });
-
-    switch (plan.kind) {
-      case "skip-missing-email":
-        counts.skippedMissingEmail++;
-        console.log(`SKIP missing-email   ${label}`);
-        break;
-      case "skip-missing-subscriber":
-        counts.skippedMissingSubscriber++;
-        console.log(`SKIP missing-sub     ${label}  (tried: ${plan.tried.join(", ")})`);
-        break;
-      case "skip-unsubscribed":
-        counts.skippedUnsubscribed++;
-        console.log(`SKIP unsubscribed    ${label}  (subscriber ${plan.subscriberId})`);
-        break;
-      case "reconcile": {
-        counts.reconciled++;
-        const leaveSummary =
-          plan.programsToLeave.length === 0
-            ? "no app-side leaves"
-            : `leaveProgram: ${plan.programsToLeave.map((p) => p.programSlug).join(", ")}`;
-        console.log(
-          `${applied ? "APPLY" : "PLAN "} reconcile        ${label}  (${leaveSummary}; final tags: [${plan.finalTags.join(", ")}])`,
-        );
-        break;
-      }
-    }
-  } catch (err) {
-    counts.errors++;
-    console.log(`ERROR                ${label}  ${err instanceof Error ? err.message : String(err)}`);
+  if (!process.env.BUTTONDOWN_API_KEY) {
+    console.error("BUTTONDOWN_API_KEY is not set in the loaded env file.");
+    process.exit(1);
   }
+
+  await confirmIfWrite();
+
+  const client = createButtondownClient({
+    apiKey: process.env.BUTTONDOWN_API_KEY,
+    write,
+  });
+
+  console.log(`# Buttondown bootstrap — ${write ? "WRITE" : "dry-run"} mode (${useProd ? "prod" : "local"})`);
+
+  const [members, byProfile, managedUniverse] = await Promise.all([
+    loadBootstrapMembers(),
+    loadJoinedTaggedPrograms(),
+    loadManagedUniverse(),
+  ]);
+
+  // Preload the audience once via listSubscribers and index it. The
+  // bootstrap is a broad run (every member), so the same per-member
+  // lookup the cron uses applies here — turning N×(1-2) GETs into
+  // ceil(N_subscribers/100) paginated calls.
+  console.log(`# Preloading Buttondown audience…`);
+  const lookup = await buildSubscriberLookup(client, undefined);
+
+  console.log(`# ${members.length} saved profiles; managed tag universe: [${[...managedUniverse].join(", ")}]\n`);
+
+  const counts = {
+    reconciled: 0,
+    skippedMissingEmail: 0,
+    skippedMissingSubscriber: 0,
+    skippedUnsubscribed: 0,
+    errors: 0,
+  };
+
+  for (const member of members) {
+    const label = `${member.displayName ?? "(no name)"} <${member.email ?? "(no email)"}>`;
+    try {
+      const joined = byProfile.get(member.profileId) ?? [];
+      const { plan, applied } = await applyBootstrapForMember(member, joined, managedUniverse, { client, lookup, write });
+
+      switch (plan.kind) {
+        case "skip-missing-email":
+          counts.skippedMissingEmail++;
+          console.log(`SKIP missing-email   ${label}`);
+          break;
+        case "skip-missing-subscriber":
+          counts.skippedMissingSubscriber++;
+          console.log(`SKIP missing-sub     ${label}  (tried: ${plan.tried.join(", ")})`);
+          break;
+        case "skip-unsubscribed":
+          counts.skippedUnsubscribed++;
+          console.log(`SKIP unsubscribed    ${label}  (subscriber ${plan.subscriberId})`);
+          break;
+        case "reconcile": {
+          counts.reconciled++;
+          const leaveSummary =
+            plan.programsToLeave.length === 0
+              ? "no app-side leaves"
+              : `leaveProgram: ${plan.programsToLeave.map((p) => p.programSlug).join(", ")}`;
+          console.log(
+            `${applied ? "APPLY" : "PLAN "} reconcile        ${label}  (${leaveSummary}; final tags: [${plan.finalTags.join(", ")}])`,
+          );
+          break;
+        }
+      }
+    } catch (err) {
+      counts.errors++;
+      console.log(`ERROR                ${label}  ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  console.log(`\n# Summary: ${JSON.stringify(counts)}`);
+  console.log(write ? "# Wrote changes." : "# Dry-run only — no changes made. Re-run with --write to apply.");
 }
 
-console.log(`\n# Summary: ${JSON.stringify(counts)}`);
-console.log(write ? "# Wrote changes." : "# Dry-run only — no changes made. Re-run with --write to apply.");
-
-process.exit(0);
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/buttondown-bootstrap.ts
+++ b/scripts/buttondown-bootstrap.ts
@@ -1,0 +1,128 @@
+/**
+ * One-shot bootstrap reconciliation for the Buttondown sync rollout.
+ *
+ * See docs/design-buttondown.md → "Initial bootstrap reconciliation"
+ * for the full design. Briefly:
+ *
+ *   - The CSV importer parked ~46 members in profile_programs based on
+ *     Google Form data, but Buttondown's tag state has moved on since
+ *     and is the more authoritative record for "is this person still
+ *     opted in to this program."
+ *   - This script walks every saved profile, reads its Buttondown
+ *     subscriber, and reconciles the APP side to match (calling
+ *     leaveProgram where Buttondown disagrees). It then issues a
+ *     single full-overwrite PATCH per active subscriber to lock in
+ *     the canonical tag set, clearing legacy tags like `active`.
+ *
+ * USAGE
+ *   Dry run (default — no writes anywhere):
+ *     npx tsx scripts/buttondown-bootstrap.ts
+ *
+ *   Apply for real (mutates the app DB and writes to Buttondown):
+ *     npx tsx scripts/buttondown-bootstrap.ts --write
+ *
+ * ENV (from .env.local in dev, .env.prod via --prod in production):
+ *   BUTTONDOWN_API_KEY   required to talk to Buttondown
+ *   DATABASE_URL         the app DB
+ */
+
+import { createInterface } from "node:readline/promises";
+import { config } from "dotenv";
+
+import { createButtondownClient } from "../src/server/buttondown";
+import {
+  applyBootstrapForMember,
+  loadBootstrapMembers,
+  loadJoinedTaggedPrograms,
+  loadManagedUniverse,
+} from "../src/server/buttondown-bootstrap";
+
+const argv = process.argv.slice(2);
+const useProd = argv.includes("--prod");
+const write = argv.includes("--write");
+
+config({ path: useProd ? ".env.prod" : ".env.local" });
+
+if (!process.env.BUTTONDOWN_API_KEY) {
+  console.error("BUTTONDOWN_API_KEY is not set in the loaded env file.");
+  process.exit(1);
+}
+
+const confirmIfWrite = async (): Promise<void> => {
+  if (!write) return;
+  const target = useProd ? "PRODUCTION" : "local";
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await rl.question(`About to mutate ${target} state (app DB + Buttondown). Type "yes" to continue: `);
+  rl.close();
+  if (answer.trim().toLowerCase() !== "yes") {
+    console.error("Aborted.");
+    process.exit(1);
+  }
+};
+
+await confirmIfWrite();
+
+const client = createButtondownClient({
+  apiKey: process.env.BUTTONDOWN_API_KEY,
+  write,
+});
+
+console.log(`# Buttondown bootstrap — ${write ? "WRITE" : "dry-run"} mode (${useProd ? "prod" : "local"})`);
+
+const [members, byProfile, managedUniverse] = await Promise.all([
+  loadBootstrapMembers(),
+  loadJoinedTaggedPrograms(),
+  loadManagedUniverse(),
+]);
+
+console.log(`# ${members.length} saved profiles; managed tag universe: [${[...managedUniverse].join(", ")}]\n`);
+
+const counts = {
+  reconciled: 0,
+  skippedMissingEmail: 0,
+  skippedMissingSubscriber: 0,
+  skippedUnsubscribed: 0,
+  errors: 0,
+};
+
+for (const member of members) {
+  const label = `${member.displayName ?? "(no name)"} <${member.email ?? "(no email)"}>`;
+  try {
+    const joined = byProfile.get(member.profileId) ?? [];
+    const { plan, applied } = await applyBootstrapForMember(member, joined, managedUniverse, { client, write });
+
+    switch (plan.kind) {
+      case "skip-missing-email":
+        counts.skippedMissingEmail++;
+        console.log(`SKIP missing-email   ${label}`);
+        break;
+      case "skip-missing-subscriber":
+        counts.skippedMissingSubscriber++;
+        console.log(`SKIP missing-sub     ${label}  (tried: ${plan.tried.join(", ")})`);
+        break;
+      case "skip-unsubscribed":
+        counts.skippedUnsubscribed++;
+        console.log(`SKIP unsubscribed    ${label}  (subscriber ${plan.subscriberId})`);
+        break;
+      case "reconcile": {
+        counts.reconciled++;
+        const leaveSummary =
+          plan.programsToLeave.length === 0
+            ? "no app-side leaves"
+            : `leaveProgram: ${plan.programsToLeave.map((p) => p.programSlug).join(", ")}`;
+        console.log(
+          `${applied ? "APPLY" : "PLAN "} reconcile        ${label}  (${leaveSummary}; final tags: [${plan.finalTags.join(", ")}])`,
+        );
+        break;
+      }
+    }
+  } catch (err) {
+    counts.errors++;
+    console.log(`ERROR                ${label}  ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+console.log(`\n# Summary: ${JSON.stringify(counts)}`);
+console.log(write ? "# Wrote changes." : "# Dry-run only — no changes made. Re-run with --write to apply.");
+
+process.exit(0);

--- a/src/app/admin/buttondown-sync-buttons.tsx
+++ b/src/app/admin/buttondown-sync-buttons.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api";
+
+// Two admin-triggered Buttondown sync actions:
+//
+// - Dry run fires immediately; safe to press any time. Logs a diff
+//   without writing. Useful during rollout and as a "what would the
+//   cron do right now" check after rollout.
+//
+// - Write opens a confirm step. Only the confirm click triggers the
+//   real run. Design discussion in docs/design-buttondown.md →
+//   "Endpoint shape".
+//
+// The result panel is intentionally minimal — the canonical record is
+// in Axiom (filter by message == "buttondown sync"). What's shown
+// here is just enough to confirm the call landed.
+
+type RunResult =
+  | { status: "ok"; summary: Record<string, unknown> }
+  | { status: "skipped"; reason: string };
+
+export function ButtondownSyncButtons() {
+  const [pending, setPending] = useState<null | "dry-run" | "write">(null);
+  const [result, setResult] = useState<RunResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmingWrite, setConfirmingWrite] = useState(false);
+
+  const runDryRun = async () => {
+    setError(null);
+    setResult(null);
+    setPending("dry-run");
+    try {
+      const res = await apiClient.api.admin["buttondown-sync"]["dry-run"].$post();
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      setResult((await res.json()) as RunResult);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "request failed");
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const runWrite = async () => {
+    setError(null);
+    setResult(null);
+    setPending("write");
+    setConfirmingWrite(false);
+    try {
+      const res = await apiClient.api.admin["buttondown-sync"].write.$post();
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      setResult((await res.json()) as RunResult);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "request failed");
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button type="button" variant="secondary" size="sm" disabled={pending !== null} onClick={runDryRun}>
+          {pending === "dry-run" ? "Running…" : "Sync Buttondown (dry run)"}
+        </Button>
+
+        {confirmingWrite ? (
+          <>
+            <Button type="button" variant="destructive" size="sm" disabled={pending !== null} onClick={runWrite}>
+              {pending === "write" ? "Running…" : "Yes, write to Buttondown"}
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              disabled={pending !== null}
+              onClick={() => setConfirmingWrite(false)}
+            >
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            disabled={pending !== null}
+            onClick={() => {
+              setError(null);
+              setResult(null);
+              setConfirmingWrite(true);
+            }}
+          >
+            Sync Buttondown (write)
+          </Button>
+        )}
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Both runs log a structured diff to Axiom (filter <code>message == "buttondown sync"</code>). Write actually
+        applies the diff; dry-run skips every PATCH/POST.
+      </p>
+
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          Sync failed: {error}
+        </p>
+      )}
+
+      {result && (
+        <pre className="rounded border border-border bg-muted/50 p-3 text-xs">{JSON.stringify(result, null, 2)}</pre>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -5,6 +5,7 @@ import { requireUser, serverApiClient } from "@/lib/api-server";
 
 import { AdminHidden } from "./admin-hidden";
 import { AdminHints } from "./admin-hints";
+import { ButtondownSyncButtons } from "./buttondown-sync-buttons";
 
 export default async function AdminPage() {
   const me = await requireUser();
@@ -53,6 +54,11 @@ export default async function AdminPage() {
       <section className="flex w-full max-w-xl flex-col gap-2">
         <h2 className="text-lg font-semibold">Hidden accounts</h2>
         <AdminHidden />
+      </section>
+
+      <section className="flex w-full max-w-xl flex-col gap-2">
+        <h2 className="text-lg font-semibold">Buttondown sync</h2>
+        <ButtondownSyncButtons />
       </section>
     </main>
   );

--- a/src/app/admin/programs/[id]/program-detail.tsx
+++ b/src/app/admin/programs/[id]/program-detail.tsx
@@ -55,6 +55,7 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
   const [name, setName] = useState(program.name);
   const [slug, setSlug] = useState(program.slug);
   const [description, setDescription] = useState(program.description ?? "");
+  const [buttondownTag, setButtondownTag] = useState(program.buttondownTag ?? "");
   const [editError, setEditError] = useState<string | null>(null);
   const [participantError, setParticipantError] = useState<string | null>(null);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
@@ -69,6 +70,7 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
       description?: string | null;
       archived?: boolean;
       signupsOpen?: boolean;
+      buttondownTag?: string | null;
     }) => {
       const res = await apiClient.api.admin.programs[":id"].$patch({
         param: { id: program.id },
@@ -167,10 +169,12 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
 
   const trimmedName = name.trim();
   const trimmedSlug = slug.trim();
+  const trimmedButtondownTag = buttondownTag.trim();
   const dirty =
     trimmedName !== program.name ||
     trimmedSlug !== program.slug ||
-    description.trim() !== (program.description ?? "");
+    description.trim() !== (program.description ?? "") ||
+    trimmedButtondownTag !== (program.buttondownTag ?? "");
 
   const save = () => {
     if (!trimmedName) {
@@ -185,6 +189,7 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
       name: trimmedName,
       slug: trimmedSlug,
       description: description.trim() || null,
+      buttondownTag: trimmedButtondownTag || null,
     });
   };
 
@@ -222,6 +227,20 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
             onChange={(e) => setDescription(e.target.value)}
             disabled={updateMutation.isPending}
           />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-buttondown-tag">Buttondown tag</Label>
+          <Input
+            id="program-buttondown-tag"
+            value={buttondownTag}
+            onChange={(e) => setButtondownTag(e.target.value)}
+            disabled={updateMutation.isPending}
+            placeholder="(leave blank to opt out of Buttondown sync)"
+          />
+          <p className="text-xs text-muted-foreground">
+            When set, members joining this program get tagged with this exact string in Buttondown. Leave blank to opt
+            out entirely.
+          </p>
         </div>
         <Button
           type="button"

--- a/src/app/admin/programs/programs-admin.tsx
+++ b/src/app/admin/programs/programs-admin.tsx
@@ -154,6 +154,11 @@ export function ProgramsAdmin() {
                           Signups closed
                         </span>
                       )}
+                      {p.buttondownTag && (
+                        <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                          Buttondown:Linked
+                        </span>
+                      )}
                     </span>
                     <span className="text-xs text-muted-foreground">
                       {p.memberCount} {p.memberCount === 1 ? "participant" : "participants"}

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -8,6 +8,7 @@ import { isRelationValue } from "@/lib/relation-value";
 import { getAppSettings } from "./app-settings";
 import { type ApiVariables, isAdmin, isUuid, requireAdmin, requireAuth } from "./auth-middleware";
 import { clearAvatar, encodeAvatar, MAX_AVATAR_UPLOAD_BYTES, replaceAvatar } from "./avatars";
+import { runButtondownSyncForServer } from "./buttondown-runner";
 import { db } from "./db";
 import { checkInvite, createInvite, getInvitesForCreator, revokeInvite, validateNote } from "./invites";
 import {
@@ -170,7 +171,28 @@ const adminRoutes = new Hono<{ Variables: ApiVariables }>()
       if ("error" in result) return c.json({ error: result.error }, 404);
       return c.json({ ok: true });
     },
-  );
+  )
+  // Two admin-triggered Buttondown sync routes. The dry-run button
+  // fires immediately and is safe to press anytime; the write button
+  // is wrapped in a confirm step on the UI side. Both call the same
+  // shared runner, distinguished only by `write` and by the
+  // `acquired_by` string recorded on the lock.
+  .post("/buttondown-sync/dry-run", async (c) => {
+    const user = c.get("user");
+    const result = await runButtondownSyncForServer({
+      acquiredBy: `admin:${user.id}:dry-run`,
+      write: false,
+    });
+    return c.json(result);
+  })
+  .post("/buttondown-sync/write", async (c) => {
+    const user = c.get("user");
+    const result = await runButtondownSyncForServer({
+      acquiredBy: `admin:${user.id}:write`,
+      write: true,
+    });
+    return c.json(result);
+  });
 
 const api = new Hono<{ Variables: ApiVariables }>()
   .basePath("/api")
@@ -585,6 +607,24 @@ api.post("/_test/reset", async (c) => {
     return c.json({ error: "not_found" }, 404);
   }
   const result = await resetE2EUsers();
+  return c.json(result);
+});
+
+// Vercel cron entrypoint. Vercel attaches `Authorization: Bearer
+// $CRON_SECRET` when invoking scheduled crons; we reject anything
+// else with 401. The write toggle is BUTTONDOWN_SYNC_WRITE=1 — the
+// design's "Prod-only by construction" lock #4. Unset (the default)
+// means dry-run; set means writes go through.
+api.post("/cron/buttondown-sync", async (c) => {
+  const provided = c.req.header("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || provided !== `Bearer ${cronSecret}`) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+  const result = await runButtondownSyncForServer({
+    acquiredBy: `cron:${new Date().toISOString()}`,
+    write: process.env.BUTTONDOWN_SYNC_WRITE === "1",
+  });
   return c.json(result);
 });
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -643,6 +643,15 @@ api.post("/cron/buttondown-sync", async (c) => {
     acquiredBy: `cron:${new Date().toISOString()}`,
     write: process.env.BUTTONDOWN_SYNC_WRITE === "1",
   });
+  // Surface per-profile errors to Vercel's cron health view by
+  // returning 500 when any profile failed. Vercel doesn't retry
+  // failed crons, so this is signal-only: the cron dashboard lights
+  // up and the existing Sentry capture in the runner pages someone.
+  // Skipped runs (api-key-missing, lock-held) stay 200 since they
+  // aren't failures from the cron's point of view.
+  if (result.status === "ok" && result.summary.errors > 0) {
+    return c.json(result, 500);
+  }
   return c.json(result);
 });
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -8,7 +8,11 @@ import { isRelationValue } from "@/lib/relation-value";
 import { getAppSettings } from "./app-settings";
 import { type ApiVariables, isAdmin, isUuid, requireAdmin, requireAuth } from "./auth-middleware";
 import { clearAvatar, encodeAvatar, MAX_AVATAR_UPLOAD_BYTES, replaceAvatar } from "./avatars";
-import { runButtondownSyncForServer, runFirstProfileSaveForServer } from "./buttondown-runner";
+import {
+  runButtondownSyncForServer,
+  runFirstProfileSaveForServer,
+  runProfileResyncForServer,
+} from "./buttondown-runner";
 import { db } from "./db";
 import { checkInvite, createInvite, getInvitesForCreator, revokeInvite, validateNote } from "./invites";
 import {
@@ -139,8 +143,17 @@ const adminRoutes = new Hono<{ Variables: ApiVariables }>()
     },
   )
   .delete("/programs/:id/participants/:profileId", async (c) => {
-    const result = await removeParticipant(c.req.param("id"), c.req.param("profileId"));
+    const targetProfileId = c.req.param("profileId");
+    const result = await removeParticipant(c.req.param("id"), targetProfileId);
     if ("error" in result) return c.json({ error: result.error }, 404);
+    // Best-effort inline resync so the removed program's tag drops
+    // off the subscriber within this request instead of waiting for
+    // the next cron. The cron is the safety net.
+    await runProfileResyncForServer({
+      profileId: targetProfileId,
+      reason: "admin-remove-participant",
+      write: process.env.BUTTONDOWN_SYNC_WRITE === "1",
+    });
     return c.json({ ok: true });
   })
   .get("/profiles/hidden", async (c) => {
@@ -484,6 +497,12 @@ const api = new Hono<{ Variables: ApiVariables }>()
       }
       return c.json({ error: "already_joined" }, 409);
     }
+    // Best-effort inline resync; the cron is the safety net.
+    await runProfileResyncForServer({
+      profileId: user.id,
+      reason: "join-program",
+      write: process.env.BUTTONDOWN_SYNC_WRITE === "1",
+    });
     return c.json({ ok: true });
   })
   .post("/programs/:id/leave", async (c) => {
@@ -493,6 +512,11 @@ const api = new Hono<{ Variables: ApiVariables }>()
     if ("error" in result) {
       return c.json({ error: "not_found" }, 404);
     }
+    await runProfileResyncForServer({
+      profileId: user.id,
+      reason: "leave-program",
+      write: process.env.BUTTONDOWN_SYNC_WRITE === "1",
+    });
     return c.json({ ok: true });
   })
   .get("/relations/candidates", async (c) => {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -8,7 +8,7 @@ import { isRelationValue } from "@/lib/relation-value";
 import { getAppSettings } from "./app-settings";
 import { type ApiVariables, isAdmin, isUuid, requireAdmin, requireAuth } from "./auth-middleware";
 import { clearAvatar, encodeAvatar, MAX_AVATAR_UPLOAD_BYTES, replaceAvatar } from "./avatars";
-import { runButtondownSyncForServer } from "./buttondown-runner";
+import { runButtondownSyncForServer, runFirstProfileSaveForServer } from "./buttondown-runner";
 import { db } from "./db";
 import { checkInvite, createInvite, getInvitesForCreator, revokeInvite, validateNote } from "./invites";
 import {
@@ -273,6 +273,12 @@ const api = new Hono<{ Variables: ApiVariables }>()
       await upsertProfile(user);
     }
 
+    // Inline first-profile-save detection: lastUpdatedProfile being
+    // null right now (and a real update about to run) is "first
+    // save", which fires the Buttondown inline hook below. See
+    // docs/design-buttondown.md → "Inline hook on first profile save".
+    const isFirstSave = !existing?.lastUpdatedProfile && Object.keys(parsed).length > 0;
+
     if (Object.keys(parsed).length > 0) {
       const update = {
         ...parsed,
@@ -290,6 +296,18 @@ const api = new Hono<{ Variables: ApiVariables }>()
         }
         throw err;
       }
+    }
+
+    // Best-effort Buttondown inline hook. Failures inside the hook
+    // are swallowed by the runner, so even a Buttondown outage
+    // doesn't disturb the PUT /me response. The cron picks up any
+    // miss. Soft-skips on BUTTONDOWN_API_KEY missing (dev / preview).
+    if (isFirstSave && user.email) {
+      await runFirstProfileSaveForServer({
+        profileId: user.id,
+        email: user.email,
+        write: process.env.BUTTONDOWN_SYNC_WRITE === "1",
+      });
     }
 
     const profile = await getProfileForSelf(user.id);

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -195,6 +195,10 @@ const adminRoutes = new Hono<{ Variables: ApiVariables }>()
     const result = await runButtondownSyncForServer({
       acquiredBy: `admin:${user.id}:dry-run`,
       write: false,
+      // Admin clicked once; absorb brief contention rather than
+      // surfacing a "skipped" surprise. Same budget as inline resync.
+      lockRetries: 2,
+      lockRetryDelayMs: 500,
     });
     return c.json(result);
   })
@@ -203,6 +207,8 @@ const adminRoutes = new Hono<{ Variables: ApiVariables }>()
     const result = await runButtondownSyncForServer({
       acquiredBy: `admin:${user.id}:write`,
       write: true,
+      lockRetries: 2,
+      lockRetryDelayMs: 500,
     });
     return c.json(result);
   });
@@ -666,6 +672,14 @@ api.post("/cron/buttondown-sync", async (c) => {
   const result = await runButtondownSyncForServer({
     acquiredBy: `cron:${new Date().toISOString()}`,
     write: process.env.BUTTONDOWN_SYNC_WRITE === "1",
+    // Inline resyncs hold the lock for ~1s each. A daily cron can
+    // realistically collide with one. Skipping costs 24h of drift, so
+    // wait up to 10s for the lock — well under Vercel's 300s function
+    // timeout and far longer than any inline run. If contention
+    // persists past 10s, the prior cron is genuinely stuck and the
+    // existing Sentry warning surfaces it.
+    lockRetries: 20,
+    lockRetryDelayMs: 500,
   });
   // Surface per-profile errors to Vercel's cron health view by
   // returning 500 when any profile failed. Vercel doesn't retry

--- a/src/server/auth-middleware.ts
+++ b/src/server/auth-middleware.ts
@@ -51,6 +51,10 @@ export const PUBLIC_PATHS: readonly (string | RegExp)[] = [
   // CI-only test-reset endpoint. Gated by a shared-secret header — the
   // CI token is the auth here, not a Supabase session.
   "/api/_test/reset",
+  // Vercel cron endpoint. Gated by the CRON_SECRET bearer check that
+  // Vercel attaches when invoking scheduled crons; no Supabase
+  // session is present.
+  "/api/cron/buttondown-sync",
 ];
 
 const isPublicPath = (path: string): boolean =>

--- a/src/server/buttondown-bootstrap.ts
+++ b/src/server/buttondown-bootstrap.ts
@@ -1,0 +1,244 @@
+// One-shot bootstrap reconciliation for the cutover from the Apps
+// Script flow to the app-driven Buttondown sync.
+//
+// See docs/design-buttondown.md → "Initial bootstrap reconciliation".
+// The key difference from the daily reconciler: at the bootstrap
+// moment, Buttondown is authoritative for tag state. If the app says
+// Alice is currently in `weekly-updates` but Buttondown's subscriber
+// lacks that tag, the app side gets corrected (leaveProgram), not
+// Buttondown. Then we do a single full-overwrite PATCH to clear any
+// legacy tags (e.g. the pre-cutover `active` marker) and lock in the
+// canonical state.
+//
+// This module is invoked by `scripts/buttondown-bootstrap.ts`, never
+// by request paths. The script is the only intended caller.
+
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+
+import { type ButtondownClient, type ButtondownSubscriber, isDryRunOutcome } from "./buttondown";
+import { db } from "./db";
+import { authUsers, profilePrograms, profiles, programs } from "./schema";
+import { leaveProgram } from "./programs";
+
+export type BootstrapMemberRecord = {
+  profileId: string;
+  displayName: string | null;
+  email: string | null;
+  buttondownSubscriberId: string | null;
+};
+
+export type ProgramByTag = {
+  programId: string;
+  programSlug: string;
+  buttondownTag: string;
+};
+
+export type BootstrapPlan =
+  | { kind: "skip-missing-email" }
+  | { kind: "skip-missing-subscriber"; tried: string[] }
+  | { kind: "skip-unsubscribed"; subscriberId: string }
+  | {
+      kind: "reconcile";
+      subscriberId: string;
+      programsToLeave: { programId: string; programSlug: string }[];
+      finalTags: string[];
+    };
+
+// Pure decision function. Given the member's app-side state, the set
+// of tag-bearing programs they're currently joined to, and what
+// Buttondown shows, decide what to do. No I/O.
+export const planBootstrap = (params: {
+  subscriber: ButtondownSubscriber | null;
+  appJoinedTaggedPrograms: ProgramByTag[];
+  managedUniverse: Set<string>;
+}): BootstrapPlan => {
+  const { subscriber, appJoinedTaggedPrograms, managedUniverse } = params;
+
+  if (!subscriber) {
+    return {
+      kind: "skip-missing-subscriber",
+      tried: [],
+    };
+  }
+  if (subscriber.type === "unsubscribed") {
+    return { kind: "skip-unsubscribed", subscriberId: subscriber.id };
+  }
+
+  // Buttondown's view of the managed-tag intersection — the source of
+  // truth for what programs the member is "really" in for this
+  // bootstrap moment.
+  const buttondownManagedTags = new Set(subscriber.tags.filter((t) => managedUniverse.has(t)));
+
+  // For each app-side joined-tagged program, decide whether Buttondown
+  // confirms the membership. If not, plan a leaveProgram.
+  const programsToLeave: { programId: string; programSlug: string }[] = [];
+  for (const p of appJoinedTaggedPrograms) {
+    if (!buttondownManagedTags.has(p.buttondownTag)) {
+      programsToLeave.push({ programId: p.programId, programSlug: p.programSlug });
+    }
+  }
+
+  // After app-side reconcile, the final managed tag set on the
+  // subscriber is exactly what Buttondown already says it is for the
+  // managed universe (since Buttondown is authoritative). We pair that
+  // with the standing markers: keep `isweb-member` if already there,
+  // otherwise add it; same for `returning` (this member predated us).
+  const finalTags = [
+    ...buttondownManagedTags,
+    "isweb-member",
+    "returning",
+  ];
+  // Dedupe in case isweb-member or returning is already in the
+  // managed intersection somehow (shouldn't happen — those are
+  // standing markers, not managed — but cheap defensive uniquing).
+  const seen = new Set<string>();
+  const uniqueFinalTags = finalTags.filter((t) => {
+    if (seen.has(t)) return false;
+    seen.add(t);
+    return true;
+  });
+
+  return {
+    kind: "reconcile",
+    subscriberId: subscriber.id,
+    programsToLeave,
+    finalTags: uniqueFinalTags,
+  };
+};
+
+// Load all profiles with a saved profile (lastUpdatedProfile non-null),
+// paired with their auth.users email.
+export const loadBootstrapMembers = async (): Promise<BootstrapMemberRecord[]> => {
+  return db
+    .select({
+      profileId: profiles.id,
+      displayName: profiles.displayName,
+      email: authUsers.email,
+      buttondownSubscriberId: profiles.buttondownSubscriberId,
+    })
+    .from(profiles)
+    .innerJoin(authUsers, eq(authUsers.id, profiles.id))
+    .where(isNotNull(profiles.lastUpdatedProfile));
+};
+
+// Load the current (leftAt IS NULL) memberships for non-archived
+// programs with a buttondownTag — same shape the daily reconciler
+// uses, indexed by profile id for the bootstrap loop.
+export const loadJoinedTaggedPrograms = async (): Promise<Map<string, ProgramByTag[]>> => {
+  const rows = await db
+    .select({
+      profileId: profilePrograms.profileId,
+      programId: profilePrograms.programId,
+      programSlug: programs.slug,
+      buttondownTag: programs.buttondownTag,
+    })
+    .from(profilePrograms)
+    .innerJoin(programs, eq(programs.id, profilePrograms.programId))
+    .where(
+      and(
+        isNull(profilePrograms.leftAt),
+        isNull(programs.archivedAt),
+        isNotNull(programs.buttondownTag),
+      ),
+    );
+
+  const grouped = new Map<string, ProgramByTag[]>();
+  for (const r of rows) {
+    if (!r.buttondownTag) continue;
+    const arr = grouped.get(r.profileId) ?? [];
+    arr.push({
+      programId: r.programId,
+      programSlug: r.programSlug,
+      buttondownTag: r.buttondownTag,
+    });
+    grouped.set(r.profileId, arr);
+  }
+  return grouped;
+};
+
+export const loadManagedUniverse = async (): Promise<Set<string>> => {
+  const rows = await db
+    .select({ buttondownTag: programs.buttondownTag })
+    .from(programs)
+    .where(isNotNull(programs.buttondownTag));
+  const out = new Set<string>();
+  for (const r of rows) {
+    if (r.buttondownTag) out.add(r.buttondownTag);
+  }
+  return out;
+};
+
+// Orchestrates one member's bootstrap: looks up Buttondown, decides,
+// applies. Honors the client's `write` flag for Buttondown writes and
+// the `write` arg for app-side mutations.
+export type ApplyBootstrapDeps = {
+  client: ButtondownClient;
+  write: boolean;
+};
+
+export const applyBootstrapForMember = async (
+  member: BootstrapMemberRecord,
+  appJoinedTaggedPrograms: ProgramByTag[],
+  managedUniverse: Set<string>,
+  deps: ApplyBootstrapDeps,
+): Promise<{ plan: BootstrapPlan; applied: boolean }> => {
+  if (!member.email) {
+    return { plan: { kind: "skip-missing-email" }, applied: false };
+  }
+
+  // id-first lookup is stable across email changes; fall back to email.
+  let subscriber: ButtondownSubscriber | null = null;
+  const tried: string[] = [];
+  if (member.buttondownSubscriberId) {
+    tried.push(`id:${member.buttondownSubscriberId}`);
+    subscriber = await deps.client.getSubscriber(member.buttondownSubscriberId);
+  }
+  if (!subscriber) {
+    tried.push(`email:${member.email}`);
+    subscriber = await deps.client.getSubscriber(member.email);
+  }
+
+  const plan = planBootstrap({
+    subscriber,
+    appJoinedTaggedPrograms,
+    managedUniverse,
+  });
+
+  if (plan.kind === "skip-missing-subscriber") {
+    plan.tried = tried;
+  }
+
+  if (!deps.write) {
+    return { plan, applied: false };
+  }
+  if (plan.kind !== "reconcile") {
+    return { plan, applied: false };
+  }
+
+  // Apply app-side leaves first so the next sync (or another
+  // bootstrap run) sees consistent app state.
+  for (const p of plan.programsToLeave) {
+    await leaveProgram(member.profileId, p.programId);
+  }
+
+  // Persist the subscriber id if we discovered it via email lookup.
+  if (member.buttondownSubscriberId !== plan.subscriberId) {
+    await db
+      .update(profiles)
+      .set({ buttondownSubscriberId: plan.subscriberId })
+      .where(eq(profiles.id, member.profileId));
+  }
+
+  // Single full-overwrite PATCH locks in the canonical state. The
+  // client's write flag still applies — passing write=true on the
+  // bootstrap client means this actually goes out; write=false would
+  // make this a Buttondown-side dry run while the DB updates above
+  // still ran (because the script controls those separately via its
+  // own --write flag, which sets both).
+  const patchResult = await deps.client.updateSubscriber(plan.subscriberId, { tags: plan.finalTags });
+  // isDryRunOutcome is fine to consult; we don't actually need to
+  // branch on it since the client's gate already handled the choice.
+  void isDryRunOutcome(patchResult);
+
+  return { plan, applied: true };
+};

--- a/src/server/buttondown-bootstrap.ts
+++ b/src/server/buttondown-bootstrap.ts
@@ -16,6 +16,7 @@
 import { and, eq, isNotNull, isNull } from "drizzle-orm";
 
 import { type ButtondownClient, type ButtondownSubscriber, isDryRunOutcome } from "./buttondown";
+import { type SubscriberLookup } from "./buttondown-sync";
 import { db } from "./db";
 import { authUsers, profilePrograms, profiles, programs } from "./schema";
 import { leaveProgram } from "./programs";
@@ -170,9 +171,13 @@ export const loadManagedUniverse = async (): Promise<Set<string>> => {
 
 // Orchestrates one member's bootstrap: looks up Buttondown, decides,
 // applies. Honors the client's `write` flag for Buttondown writes and
-// the `write` arg for app-side mutations.
+// the `write` arg for app-side mutations. Subscriber resolution goes
+// through a shared `lookup` so the script can preload the audience
+// once via listSubscribers (one paginated call) instead of doing
+// 1-2 GETs per member.
 export type ApplyBootstrapDeps = {
   client: ButtondownClient;
+  lookup: SubscriberLookup;
   write: boolean;
 };
 
@@ -186,17 +191,7 @@ export const applyBootstrapForMember = async (
     return { plan: { kind: "skip-missing-email" }, applied: false };
   }
 
-  // id-first lookup is stable across email changes; fall back to email.
-  let subscriber: ButtondownSubscriber | null = null;
-  const tried: string[] = [];
-  if (member.buttondownSubscriberId) {
-    tried.push(`id:${member.buttondownSubscriberId}`);
-    subscriber = await deps.client.getSubscriber(member.buttondownSubscriberId);
-  }
-  if (!subscriber) {
-    tried.push(`email:${member.email}`);
-    subscriber = await deps.client.getSubscriber(member.email);
-  }
+  const subscriber = await deps.lookup(member);
 
   const plan = planBootstrap({
     subscriber,
@@ -205,6 +200,12 @@ export const applyBootstrapForMember = async (
   });
 
   if (plan.kind === "skip-missing-subscriber") {
+    // Reconstruct the lookup attempts for operator debugging — the
+    // lookup tries id-first then email when both are present, so
+    // surface both whenever they were known.
+    const tried: string[] = [];
+    if (member.buttondownSubscriberId) tried.push(`id:${member.buttondownSubscriberId}`);
+    tried.push(`email:${member.email}`);
     plan.tried = tried;
   }
 

--- a/src/server/buttondown-runner.ts
+++ b/src/server/buttondown-runner.ts
@@ -38,18 +38,28 @@ export type RunResult =
 const isSyncLogEvent = (event: SyncLogEvent): event is SyncLogEvent => event !== undefined;
 
 export const runButtondownSyncForServer = async (options: RunButtondownSyncOptions): Promise<RunResult> => {
+  const runId = options.acquiredBy;
+
   // Lock #2 from the design doc's "Prod-only by construction" — the
   // sync is a no-op in any environment without the API key. This is
   // the only gate the inline first-save path will share with this
   // path, so it's intentionally a soft skip rather than an error.
   if (!process.env.BUTTONDOWN_API_KEY) {
-    log.warn("buttondown sync", { action: "skipped-api-key-missing", acquiredBy: options.acquiredBy });
+    log.warn("buttondown sync", { action: "skipped-api-key-missing", acquiredBy: runId });
     return { status: "skipped", reason: "api_key_missing" };
   }
 
-  const got = await acquireLock(LOCK_NAME, options.acquiredBy);
+  const got = await acquireLock(LOCK_NAME, runId);
   if (!got) {
-    log.warn("buttondown sync", { action: "skipped-lock-held", acquiredBy: options.acquiredBy });
+    log.warn("buttondown sync", { action: "skipped-lock-held", acquiredBy: runId });
+    // A held lock means the previous invocation is still running past
+    // the cron interval — that's a real signal, not just noise. Send
+    // it to Sentry so it pages; the fingerprint stays stable so an
+    // operator sees one issue per ongoing overlap, not one per cron.
+    Sentry.captureMessage("buttondown.sync_lock_held", {
+      level: "warning",
+      tags: { feature: "buttondown-sync", action: "skipped-lock-held", acquiredBy: runId },
+    });
     return { status: "skipped", reason: "lock_held" };
   }
 
@@ -57,11 +67,14 @@ export const runButtondownSyncForServer = async (options: RunButtondownSyncOptio
     const client = createButtondownClient({
       apiKey: process.env.BUTTONDOWN_API_KEY,
       write: options.write,
+      logger: (event) => {
+        log.info("buttondown http", { ...event, runId });
+      },
     });
 
     const summary = await runButtondownSync({
       client,
-      runId: options.acquiredBy,
+      runId,
       write: options.write,
       log: (event) => {
         if (isSyncLogEvent(event)) {
@@ -69,6 +82,21 @@ export const runButtondownSyncForServer = async (options: RunButtondownSyncOptio
           // "buttondown sync" message; downstream Axiom queries filter
           // on that and split on fields.action.
           log.info("buttondown sync", event as unknown as Record<string, unknown>);
+        }
+        // Per-profile errors are signal worth paging on. The sync
+        // core keeps going (so one bad profile doesn't kill the run)
+        // and we re-raise here as a Sentry exception so the alert
+        // story doesn't depend on parsing Axiom logs.
+        if (event.action === "error") {
+          Sentry.captureException(new Error("buttondown.sync_profile_error"), {
+            tags: {
+              feature: "buttondown-sync",
+              action: "sync-error",
+              runId,
+              errorKind: event.errorKind,
+            },
+            extra: { profileId: event.profileId, message: event.message },
+          });
         }
       },
       raiseUnsubscribeAlert: (alert: UnsubscribeAlert) => {
@@ -82,14 +110,14 @@ export const runButtondownSyncForServer = async (options: RunButtondownSyncOptio
             programSlugsHeld: alert.programSlugsHeld,
             buttondownTagsOnSubscriber: alert.buttondownTagsOnSubscriber,
           },
-          tags: { feature: "buttondown-sync" },
+          tags: { feature: "buttondown-sync", runId, acquiredBy: runId },
         });
       },
     });
 
     return { status: "ok", summary };
   } finally {
-    await releaseLock(LOCK_NAME, options.acquiredBy);
+    await releaseLock(LOCK_NAME, runId);
   }
 };
 
@@ -105,10 +133,14 @@ export const runFirstProfileSaveForServer = async (params: {
   write: boolean;
 }): Promise<void> => {
   if (!process.env.BUTTONDOWN_API_KEY) return;
+  const runId = `first-save:${params.profileId}`;
   try {
     const client = createButtondownClient({
       apiKey: process.env.BUTTONDOWN_API_KEY,
       write: params.write,
+      logger: (event) => {
+        log.info("buttondown http", { ...event, runId, path_kind: "first-profile-save" });
+      },
     });
     await runFirstProfileSaveSync({
       profileId: params.profileId,
@@ -122,23 +154,25 @@ export const runFirstProfileSaveForServer = async (params: {
             programSlugsHeld: alert.programSlugsHeld,
             buttondownTagsOnSubscriber: alert.buttondownTagsOnSubscriber,
           },
-          tags: { feature: "buttondown-sync", path: "first-profile-save" },
+          tags: { feature: "buttondown-sync", path: "first-profile-save", runId },
         });
       },
     });
     log.info("buttondown sync", {
       action: "first-profile-save-applied",
       profileId: params.profileId,
+      runId,
       write: params.write,
     });
   } catch (err) {
     log.warn("buttondown sync", {
       action: "first-profile-save-failed",
       profileId: params.profileId,
+      runId,
       message: err instanceof Error ? err.message : String(err),
     });
     Sentry.captureException(err, {
-      tags: { feature: "buttondown-sync", path: "first-profile-save" },
+      tags: { feature: "buttondown-sync", path: "first-profile-save", runId },
       extra: { profileId: params.profileId },
     });
   }

--- a/src/server/buttondown-runner.ts
+++ b/src/server/buttondown-runner.ts
@@ -24,11 +24,16 @@ const LOCK_NAME = "buttondown";
 export type RunButtondownSyncOptions = {
   // Identifier for this run, recorded on the lock and in every log
   // event. Cron uses "cron:<iso-timestamp>"; admin uses
-  // "admin:<profileId>:<dry-run|write>".
+  // "admin:<profileId>:<dry-run|write>"; per-profile resync uses
+  // "resync:<reason>:<profileId>".
   acquiredBy: string;
   // Whether this run is allowed to write. The client itself enforces
   // the gate; the runner threads it through and uses it in logs.
   write: boolean;
+  // Narrow the reconciler to a specific set of profiles. Used by the
+  // per-profile resync paths so an inline hook doesn't walk the whole
+  // audience. Omit for the daily broad sweep.
+  scopeProfileIds?: string[];
 };
 
 export type RunResult =
@@ -76,6 +81,7 @@ export const runButtondownSyncForServer = async (options: RunButtondownSyncOptio
       client,
       runId,
       write: options.write,
+      scopeProfileIds: options.scopeProfileIds,
       log: (event) => {
         if (isSyncLogEvent(event)) {
           // Project each structured event into next-axiom with the
@@ -173,6 +179,56 @@ export const runFirstProfileSaveForServer = async (params: {
     });
     Sentry.captureException(err, {
       tags: { feature: "buttondown-sync", path: "first-profile-save", runId },
+      extra: { profileId: params.profileId },
+    });
+  }
+};
+
+/**
+ * Reasons an inline per-profile resync fires. Each shows up as a
+ * Sentry tag and an Axiom field, so we can ask "how often does a
+ * program-join trigger a resync that ends in an error?" without
+ * parsing log strings.
+ */
+export type ProfileResyncReason = "join-program" | "leave-program" | "admin-remove-participant";
+
+/**
+ * Best-effort inline resync for a single profile. Called from the
+ * program join / leave / admin-remove handlers so a tag change shows
+ * up in Buttondown within the request instead of after the next
+ * cron. Delegates to the broad runner with a single-profile scope —
+ * inheriting its lock, Sentry alerting, HTTP telemetry, and
+ * dry-run-vs-write gate. Swallows top-level errors so the user's
+ * action isn't blocked; the cron catches up on anything missed.
+ */
+export const runProfileResyncForServer = async (params: {
+  profileId: string;
+  reason: ProfileResyncReason;
+  write: boolean;
+}): Promise<void> => {
+  if (!process.env.BUTTONDOWN_API_KEY) return;
+  try {
+    const result = await runButtondownSyncForServer({
+      acquiredBy: `resync:${params.reason}:${params.profileId}`,
+      write: params.write,
+      scopeProfileIds: [params.profileId],
+    });
+    log.info("buttondown sync", {
+      action: "profile-resync-applied",
+      profileId: params.profileId,
+      reason: params.reason,
+      status: result.status,
+      ...(result.status === "skipped" ? { skipReason: result.reason } : {}),
+    });
+  } catch (err) {
+    log.warn("buttondown sync", {
+      action: "profile-resync-failed",
+      profileId: params.profileId,
+      reason: params.reason,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    Sentry.captureException(err, {
+      tags: { feature: "buttondown-sync", path: "profile-resync", reason: params.reason },
       extra: { profileId: params.profileId },
     });
   }

--- a/src/server/buttondown-runner.ts
+++ b/src/server/buttondown-runner.ts
@@ -1,0 +1,88 @@
+// Shared runner that wires the Buttondown sync core to production
+// concerns: env-keyed real client, the concurrency lock, structured
+// logging, and Sentry alerting for unsubscribed members.
+//
+// Two entry points share this runner: the cron endpoint (one fixed
+// `acquiredBy` per scheduled run) and the admin "Sync now" buttons
+// (one per click, identified by the admin's profile id).
+
+import * as Sentry from "@sentry/nextjs";
+import { log } from "next-axiom";
+
+import { createButtondownClient } from "./buttondown";
+import { runButtondownSync, type SyncLogEvent, type SyncRunSummary, type UnsubscribeAlert } from "./buttondown-sync";
+import { acquireLock, releaseLock } from "./sync-locks";
+
+const LOCK_NAME = "buttondown";
+
+export type RunButtondownSyncOptions = {
+  // Identifier for this run, recorded on the lock and in every log
+  // event. Cron uses "cron:<iso-timestamp>"; admin uses
+  // "admin:<profileId>:<dry-run|write>".
+  acquiredBy: string;
+  // Whether this run is allowed to write. The client itself enforces
+  // the gate; the runner threads it through and uses it in logs.
+  write: boolean;
+};
+
+export type RunResult =
+  | { status: "ok"; summary: SyncRunSummary }
+  | { status: "skipped"; reason: "api_key_missing" | "lock_held" };
+
+const isSyncLogEvent = (event: SyncLogEvent): event is SyncLogEvent => event !== undefined;
+
+export const runButtondownSyncForServer = async (options: RunButtondownSyncOptions): Promise<RunResult> => {
+  // Lock #2 from the design doc's "Prod-only by construction" — the
+  // sync is a no-op in any environment without the API key. This is
+  // the only gate the inline first-save path will share with this
+  // path, so it's intentionally a soft skip rather than an error.
+  if (!process.env.BUTTONDOWN_API_KEY) {
+    log.warn("buttondown sync", { action: "skipped-api-key-missing", acquiredBy: options.acquiredBy });
+    return { status: "skipped", reason: "api_key_missing" };
+  }
+
+  const got = await acquireLock(LOCK_NAME, options.acquiredBy);
+  if (!got) {
+    log.warn("buttondown sync", { action: "skipped-lock-held", acquiredBy: options.acquiredBy });
+    return { status: "skipped", reason: "lock_held" };
+  }
+
+  try {
+    const client = createButtondownClient({
+      apiKey: process.env.BUTTONDOWN_API_KEY,
+      write: options.write,
+    });
+
+    const summary = await runButtondownSync({
+      client,
+      runId: options.acquiredBy,
+      write: options.write,
+      log: (event) => {
+        if (isSyncLogEvent(event)) {
+          // Project each structured event into next-axiom with the
+          // "buttondown sync" message; downstream Axiom queries filter
+          // on that and split on fields.action.
+          log.info("buttondown sync", event as unknown as Record<string, unknown>);
+        }
+      },
+      raiseUnsubscribeAlert: (alert: UnsubscribeAlert) => {
+        // Captured as an exception so Sentry's email-on-error alerting
+        // fires; the fingerprint stays stable across runs so an admin
+        // sees one issue per affected member rather than per cron.
+        Sentry.captureException(new Error("buttondown.unsubscribed_member"), {
+          extra: {
+            profileId: alert.profileId,
+            email: alert.email,
+            programSlugsHeld: alert.programSlugsHeld,
+            buttondownTagsOnSubscriber: alert.buttondownTagsOnSubscriber,
+          },
+          tags: { feature: "buttondown-sync" },
+        });
+      },
+    });
+
+    return { status: "ok", summary };
+  } finally {
+    await releaseLock(LOCK_NAME, options.acquiredBy);
+  }
+};

--- a/src/server/buttondown-runner.ts
+++ b/src/server/buttondown-runner.ts
@@ -10,7 +10,13 @@ import * as Sentry from "@sentry/nextjs";
 import { log } from "next-axiom";
 
 import { createButtondownClient } from "./buttondown";
-import { runButtondownSync, type SyncLogEvent, type SyncRunSummary, type UnsubscribeAlert } from "./buttondown-sync";
+import {
+  runButtondownSync,
+  runFirstProfileSaveSync,
+  type SyncLogEvent,
+  type SyncRunSummary,
+  type UnsubscribeAlert,
+} from "./buttondown-sync";
 import { acquireLock, releaseLock } from "./sync-locks";
 
 const LOCK_NAME = "buttondown";
@@ -84,5 +90,56 @@ export const runButtondownSyncForServer = async (options: RunButtondownSyncOptio
     return { status: "ok", summary };
   } finally {
     await releaseLock(LOCK_NAME, options.acquiredBy);
+  }
+};
+
+/**
+ * Best-effort inline hook called from PUT /me on the first save.
+ * Swallows all failures: profile-save UX is the priority and the
+ * cron is the safety net for whatever this misses. Soft-skips when
+ * BUTTONDOWN_API_KEY isn't set (dev / preview).
+ */
+export const runFirstProfileSaveForServer = async (params: {
+  profileId: string;
+  email: string;
+  write: boolean;
+}): Promise<void> => {
+  if (!process.env.BUTTONDOWN_API_KEY) return;
+  try {
+    const client = createButtondownClient({
+      apiKey: process.env.BUTTONDOWN_API_KEY,
+      write: params.write,
+    });
+    await runFirstProfileSaveSync({
+      profileId: params.profileId,
+      email: params.email,
+      client,
+      raiseUnsubscribeAlert: (alert: UnsubscribeAlert) => {
+        Sentry.captureException(new Error("buttondown.unsubscribed_member"), {
+          extra: {
+            profileId: alert.profileId,
+            email: alert.email,
+            programSlugsHeld: alert.programSlugsHeld,
+            buttondownTagsOnSubscriber: alert.buttondownTagsOnSubscriber,
+          },
+          tags: { feature: "buttondown-sync", path: "first-profile-save" },
+        });
+      },
+    });
+    log.info("buttondown sync", {
+      action: "first-profile-save-applied",
+      profileId: params.profileId,
+      write: params.write,
+    });
+  } catch (err) {
+    log.warn("buttondown sync", {
+      action: "first-profile-save-failed",
+      profileId: params.profileId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    Sentry.captureException(err, {
+      tags: { feature: "buttondown-sync", path: "first-profile-save" },
+      extra: { profileId: params.profileId },
+    });
   }
 };

--- a/src/server/buttondown-runner.ts
+++ b/src/server/buttondown-runner.ts
@@ -34,6 +34,12 @@ export type RunButtondownSyncOptions = {
   // per-profile resync paths so an inline hook doesn't walk the whole
   // audience. Omit for the daily broad sweep.
   scopeProfileIds?: string[];
+  // If the lock is held by another run on the first try, sleep this
+  // long and retry — once per retry. Inline resyncs use this to hide
+  // brief contention (the typical run is sub-second); the cron and
+  // admin buttons leave it 0 so a held lock surfaces immediately.
+  lockRetries?: number;
+  lockRetryDelayMs?: number;
 };
 
 export type RunResult =
@@ -54,19 +60,46 @@ export const runButtondownSyncForServer = async (options: RunButtondownSyncOptio
     return { status: "skipped", reason: "api_key_missing" };
   }
 
-  const got = await acquireLock(LOCK_NAME, runId);
+  // Track attempts and total wait so Axiom can answer "how often
+  // does retry save us?" Per-attempt outcome stays implicit — only
+  // the final ack (lock-acquired) or final fail (skipped-lock-held)
+  // is logged, both carrying the same attempts/waitedMs fields.
+  const lockRetries = options.lockRetries ?? 0;
+  const lockRetryDelayMs = options.lockRetryDelayMs ?? 0;
+  let attempts = 1;
+  let waitedMs = 0;
+  let got = await acquireLock(LOCK_NAME, runId);
+  while (!got && attempts <= lockRetries) {
+    await new Promise((resolve) => setTimeout(resolve, lockRetryDelayMs));
+    waitedMs += lockRetryDelayMs;
+    attempts++;
+    got = await acquireLock(LOCK_NAME, runId);
+  }
   if (!got) {
-    log.warn("buttondown sync", { action: "skipped-lock-held", acquiredBy: runId });
-    // A held lock means the previous invocation is still running past
-    // the cron interval — that's a real signal, not just noise. Send
-    // it to Sentry so it pages; the fingerprint stays stable so an
-    // operator sees one issue per ongoing overlap, not one per cron.
+    log.warn("buttondown sync", {
+      action: "skipped-lock-held",
+      acquiredBy: runId,
+      attempts,
+      waitedMs,
+    });
+    // A held lock that survives every retry means the previous
+    // invocation is still running well past its expected window —
+    // that's a real signal, not just noise. Send it to Sentry so it
+    // pages; the fingerprint stays stable so an operator sees one
+    // issue per ongoing overlap, not one per cron.
     Sentry.captureMessage("buttondown.sync_lock_held", {
       level: "warning",
       tags: { feature: "buttondown-sync", action: "skipped-lock-held", acquiredBy: runId },
+      extra: { attempts, waitedMs },
     });
     return { status: "skipped", reason: "lock_held" };
   }
+  log.info("buttondown sync", {
+    action: "lock-acquired",
+    acquiredBy: runId,
+    attempts,
+    waitedMs,
+  });
 
   try {
     const client = createButtondownClient({
@@ -212,6 +245,12 @@ export const runProfileResyncForServer = async (params: {
       acquiredBy: `resync:${params.reason}:${params.profileId}`,
       write: params.write,
       scopeProfileIds: [params.profileId],
+      // Inline resync is user-triggered, so brief contention with the
+      // cron or another inline action should be hidden, not paged.
+      // Two retries at 500ms each = up to 1s wait — covers the typical
+      // sub-second inline run and the long tail (~P90).
+      lockRetries: 2,
+      lockRetryDelayMs: 500,
     });
     log.info("buttondown sync", {
       action: "profile-resync-applied",

--- a/src/server/buttondown-sync.ts
+++ b/src/server/buttondown-sync.ts
@@ -1,0 +1,378 @@
+// Buttondown sync — the daily cron's core reconciliation logic.
+//
+// See docs/design-buttondown.md, particularly the "Daily reconciler"
+// and "Write policy" sections.
+//
+// This function is the diff-only path: it brings each app member's
+// Buttondown subscriber tags into agreement with the program
+// memberships in our database, leaving all non-managed tags (human
+// edits, the `isweb-member` / `new` / `returning` markers) alone.
+//
+// The authoritative full-overwrite path that runs at first profile
+// save lives in a separate function — see `runFirstProfileSaveSync`.
+// Both share the underlying client; only this function is what the
+// cron and the admin "Sync now" buttons drive.
+
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+
+import {
+  type ButtondownClient,
+  type ButtondownSubscriber,
+  isDryRunOutcome,
+  type UpdateSubscriberInput,
+} from "./buttondown";
+import { db } from "./db";
+import { authUsers, profilePrograms, profiles, programs } from "./schema";
+
+/** Structured event the sync emits to the caller's logger. */
+export type SyncLogEvent =
+  | { action: "summary"; runId: string } & Omit<SyncRunSummary, "runId" | "write">
+  | { action: "subscriber-created"; runId: string; profileId: string; subscriberId: string | null; dryRun: boolean }
+  | {
+      action: "tags-updated";
+      runId: string;
+      profileId: string;
+      subscriberId: string;
+      added: string[];
+      removed: string[];
+      dryRun: boolean;
+    }
+  | { action: "email-updated"; runId: string; profileId: string; subscriberId: string; from: string; to: string; dryRun: boolean }
+  | { action: "unsubscribe-alert"; runId: string; profileId: string; email: string; programSlugsHeld: string[] }
+  | { action: "skipped-missing-email"; runId: string; profileId: string }
+  | { action: "skipped-already-current"; runId: string; profileId: string; subscriberId: string }
+  | { action: "error"; runId: string; profileId: string; message: string };
+
+export type SyncLogger = (event: SyncLogEvent) => void;
+
+export type UnsubscribeAlert = {
+  profileId: string;
+  email: string;
+  programSlugsHeld: string[];
+  buttondownTagsOnSubscriber: string[];
+};
+
+export type SyncRunSummary = {
+  runId: string;
+  write: boolean;
+  scanned: number;
+  created: number;
+  tagsUpdated: number;
+  emailUpdated: number;
+  unchanged: number;
+  unsubscribeAlerts: number;
+  missingProfileEmail: number;
+  errors: number;
+};
+
+export type SyncDeps = {
+  client: ButtondownClient;
+  runId: string;
+  // Whether this run was invoked with write intent. The client itself
+  // enforces the gate; we just thread it through to the summary and
+  // logs for observability.
+  write: boolean;
+  log?: SyncLogger;
+  raiseUnsubscribeAlert?: (alert: UnsubscribeAlert) => void;
+};
+
+type ProfileRow = {
+  profileId: string;
+  email: string | null;
+  buttondownSubscriberId: string | null;
+};
+
+type ProfileMembership = {
+  profileId: string;
+  programSlug: string;
+  buttondownTag: string;
+};
+
+// Compute the set of every Buttondown tag that any program has marked
+// as "managed" — used to decide which tags on a subscriber the sync
+// has authority over.
+const buildManagedUniverse = async (): Promise<Set<string>> => {
+  const tagged = await db
+    .select({ buttondownTag: programs.buttondownTag })
+    .from(programs)
+    .where(isNotNull(programs.buttondownTag));
+  const out = new Set<string>();
+  for (const t of tagged) {
+    if (t.buttondownTag) out.add(t.buttondownTag);
+  }
+  return out;
+};
+
+// Load the current (leftAt IS NULL) memberships for non-archived
+// programs that have a buttondownTag set, joined with the program so
+// we have the tag string at hand. The result is what feeds the
+// per-profile "desired tags" map.
+const loadCurrentTaggedMemberships = async (): Promise<ProfileMembership[]> => {
+  return db
+    .select({
+      profileId: profilePrograms.profileId,
+      programSlug: programs.slug,
+      buttondownTag: programs.buttondownTag,
+    })
+    .from(profilePrograms)
+    .innerJoin(programs, eq(programs.id, profilePrograms.programId))
+    .where(
+      and(
+        isNull(profilePrograms.leftAt),
+        isNull(programs.archivedAt),
+        isNotNull(programs.buttondownTag),
+      ),
+    )
+    .then((rows) =>
+      rows
+        .filter((r): r is { profileId: string; programSlug: string; buttondownTag: string } => r.buttondownTag !== null),
+    );
+};
+
+// All profiles with a saved profile (lastUpdatedProfile non-null) and
+// the email from auth.users. Members whose profile was created but
+// who haven't saved are out of scope.
+const loadEligibleProfiles = async (): Promise<ProfileRow[]> => {
+  return db
+    .select({
+      profileId: profiles.id,
+      email: authUsers.email,
+      buttondownSubscriberId: profiles.buttondownSubscriberId,
+    })
+    .from(profiles)
+    .innerJoin(authUsers, eq(authUsers.id, profiles.id))
+    .where(isNotNull(profiles.lastUpdatedProfile));
+};
+
+// Compute (final tag set, removed-from-managed, added-to-managed)
+// from the subscriber's current tags and the per-profile desired set.
+// Non-managed tags (human edits, standing markers) are preserved.
+const reconcileTags = (
+  currentTags: string[],
+  desired: string[],
+  managedUniverse: Set<string>,
+): { finalTags: string[]; added: string[]; removed: string[]; changed: boolean } => {
+  const desiredSet = new Set(desired);
+  const current = new Set(currentTags);
+
+  // Preserve every existing tag that is either outside our authority
+  // or in the desired set; drop the rest. Then add anything in
+  // `desired` that isn't already there.
+  const final = new Set<string>();
+  for (const t of currentTags) {
+    if (!managedUniverse.has(t) || desiredSet.has(t)) final.add(t);
+  }
+  for (const t of desired) final.add(t);
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  for (const t of final) {
+    if (!current.has(t)) added.push(t);
+  }
+  for (const t of currentTags) {
+    if (!final.has(t)) removed.push(t);
+  }
+
+  return {
+    finalTags: [...final],
+    added,
+    removed,
+    changed: added.length > 0 || removed.length > 0,
+  };
+};
+
+const recordSubscriberId = async (profileId: string, subscriberId: string): Promise<void> => {
+  await db
+    .update(profiles)
+    .set({ buttondownSubscriberId: subscriberId })
+    .where(eq(profiles.id, profileId));
+};
+
+export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary> => {
+  const { client, runId, write } = deps;
+  const log: SyncLogger = deps.log ?? (() => {});
+  const raise = deps.raiseUnsubscribeAlert ?? (() => {});
+
+  const summary: SyncRunSummary = {
+    runId,
+    write,
+    scanned: 0,
+    created: 0,
+    tagsUpdated: 0,
+    emailUpdated: 0,
+    unchanged: 0,
+    unsubscribeAlerts: 0,
+    missingProfileEmail: 0,
+    errors: 0,
+  };
+
+  const [managedUniverse, profileRows, memberships] = await Promise.all([
+    buildManagedUniverse(),
+    loadEligibleProfiles(),
+    loadCurrentTaggedMemberships(),
+  ]);
+
+  // Group memberships by profile so each iteration is one lookup.
+  const desiredByProfile = new Map<string, { tags: string[]; slugs: string[] }>();
+  for (const m of memberships) {
+    const entry = desiredByProfile.get(m.profileId) ?? { tags: [], slugs: [] };
+    if (!entry.tags.includes(m.buttondownTag)) entry.tags.push(m.buttondownTag);
+    if (!entry.slugs.includes(m.programSlug)) entry.slugs.push(m.programSlug);
+    desiredByProfile.set(m.profileId, entry);
+  }
+
+  for (const profile of profileRows) {
+    summary.scanned++;
+    try {
+      await syncOneProfile({
+        profile,
+        desired: desiredByProfile.get(profile.profileId) ?? { tags: [], slugs: [] },
+        managedUniverse,
+        client,
+        runId,
+        log,
+        raise,
+        summary,
+      });
+    } catch (err) {
+      summary.errors++;
+      log({
+        action: "error",
+        runId,
+        profileId: profile.profileId,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  log({ action: "summary", runId, ...summaryWithoutMeta(summary) });
+  return summary;
+};
+
+const summaryWithoutMeta = (s: SyncRunSummary) => {
+  const { runId: _r, write: _w, ...rest } = s;
+  return rest;
+};
+
+type SyncOneProfileArgs = {
+  profile: ProfileRow;
+  desired: { tags: string[]; slugs: string[] };
+  managedUniverse: Set<string>;
+  client: ButtondownClient;
+  runId: string;
+  log: SyncLogger;
+  raise: (alert: UnsubscribeAlert) => void;
+  summary: SyncRunSummary;
+};
+
+const syncOneProfile = async (args: SyncOneProfileArgs): Promise<void> => {
+  const { profile, desired, managedUniverse, client, runId, log, raise, summary } = args;
+  const profileId = profile.profileId;
+
+  if (!profile.email) {
+    summary.missingProfileEmail++;
+    log({ action: "skipped-missing-email", runId, profileId });
+    return;
+  }
+  const email = profile.email;
+
+  // Prefer id-based lookup (stable across email changes). Fall back to
+  // email for profiles we haven't seen before.
+  let subscriber: ButtondownSubscriber | null = null;
+  if (profile.buttondownSubscriberId) {
+    subscriber = await client.getSubscriber(profile.buttondownSubscriberId);
+  }
+  if (!subscriber) {
+    subscriber = await client.getSubscriber(email);
+  }
+
+  if (!subscriber) {
+    // Catch-up create: this is the path that runs when the inline
+    // first-save hook failed (or hasn't shipped yet). Tag with the
+    // managed set + isweb-member + new.
+    const result = await client.createSubscriber({
+      email_address: email,
+      tags: [...desired.tags, "isweb-member", "new"],
+    });
+    summary.created++;
+    const subscriberId = isDryRunOutcome(result) ? null : result.id;
+    if (subscriberId !== null) await recordSubscriberId(profileId, subscriberId);
+    log({
+      action: "subscriber-created",
+      runId,
+      profileId,
+      subscriberId,
+      dryRun: isDryRunOutcome(result),
+    });
+    return;
+  }
+
+  // Subscriber exists — record id if we didn't have it. Always safe;
+  // the column is just a lookup hint.
+  if (profile.buttondownSubscriberId !== subscriber.id) {
+    await recordSubscriberId(profileId, subscriber.id);
+  }
+
+  if (subscriber.type === "unsubscribed") {
+    summary.unsubscribeAlerts++;
+    raise({
+      profileId,
+      email,
+      programSlugsHeld: desired.slugs,
+      buttondownTagsOnSubscriber: subscriber.tags,
+    });
+    log({
+      action: "unsubscribe-alert",
+      runId,
+      profileId,
+      email,
+      programSlugsHeld: desired.slugs,
+    });
+    return;
+  }
+
+  const { finalTags, added, removed, changed } = reconcileTags(
+    subscriber.tags,
+    desired.tags,
+    managedUniverse,
+  );
+  const emailMismatch = subscriber.email_address.toLowerCase() !== email.toLowerCase();
+
+  if (!changed && !emailMismatch) {
+    summary.unchanged++;
+    log({ action: "skipped-already-current", runId, profileId, subscriberId: subscriber.id });
+    return;
+  }
+
+  const patch: UpdateSubscriberInput = {};
+  if (changed) patch.tags = finalTags;
+  if (emailMismatch) patch.email_address = email;
+
+  const result = await client.updateSubscriber(subscriber.id, patch);
+  const dryRun = isDryRunOutcome(result);
+
+  if (changed) {
+    summary.tagsUpdated++;
+    log({
+      action: "tags-updated",
+      runId,
+      profileId,
+      subscriberId: subscriber.id,
+      added,
+      removed,
+      dryRun,
+    });
+  }
+  if (emailMismatch) {
+    summary.emailUpdated++;
+    log({
+      action: "email-updated",
+      runId,
+      profileId,
+      subscriberId: subscriber.id,
+      from: subscriber.email_address,
+      to: email,
+      dryRun,
+    });
+  }
+};

--- a/src/server/buttondown-sync.ts
+++ b/src/server/buttondown-sync.ts
@@ -17,6 +17,7 @@ import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm";
 
 import {
   type ButtondownClient,
+  ButtondownApiError,
   type ButtondownSubscriber,
   isDryRunOutcome,
   type UpdateSubscriberInput,
@@ -118,6 +119,25 @@ export const runFirstProfileSaveSync = async (params: {
   });
 };
 
+/**
+ * Coarse category for a thrown error, attached to `error` events so
+ * Axiom alerts can split "Buttondown is having a bad day" (server)
+ * from "our key is wrong" (auth) from "we're hammering the API"
+ * (rate-limit). Anything we can't classify falls into `other` —
+ * downstream alerts should still react to that bucket.
+ */
+export type SyncErrorKind = "auth" | "rate-limit" | "not-found" | "server" | "other";
+
+export const classifyError = (err: unknown): SyncErrorKind => {
+  if (err instanceof ButtondownApiError) {
+    if (err.status === 401 || err.status === 403) return "auth";
+    if (err.status === 429) return "rate-limit";
+    if (err.status === 404) return "not-found";
+    if (err.status >= 500) return "server";
+  }
+  return "other";
+};
+
 /** Structured event the sync emits to the caller's logger. */
 export type SyncLogEvent =
   | { action: "summary"; runId: string } & Omit<SyncRunSummary, "runId" | "write">
@@ -135,7 +155,7 @@ export type SyncLogEvent =
   | { action: "unsubscribe-alert"; runId: string; profileId: string; email: string; programSlugsHeld: string[] }
   | { action: "skipped-missing-email"; runId: string; profileId: string }
   | { action: "skipped-already-current"; runId: string; profileId: string; subscriberId: string }
-  | { action: "error"; runId: string; profileId: string; message: string };
+  | { action: "error"; runId: string; profileId: string; message: string; errorKind: SyncErrorKind };
 
 export type SyncLogger = (event: SyncLogEvent) => void;
 
@@ -157,6 +177,9 @@ export type SyncRunSummary = {
   unsubscribeAlerts: number;
   missingProfileEmail: number;
   errors: number;
+  // Wall-clock duration of the run, from entry to summary emission.
+  // Use for the "is this cron getting slower?" trend in Axiom.
+  durationMs: number;
 };
 
 export type SyncDeps = {
@@ -306,6 +329,7 @@ export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary>
   const { client, runId, write } = deps;
   const log: SyncLogger = deps.log ?? (() => {});
   const raise = deps.raiseUnsubscribeAlert ?? (() => {});
+  const startedAt = Date.now();
 
   const summary: SyncRunSummary = {
     runId,
@@ -318,6 +342,7 @@ export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary>
     unsubscribeAlerts: 0,
     missingProfileEmail: 0,
     errors: 0,
+    durationMs: 0,
   };
 
   const [managedUniverse, profileRows, memberships] = await Promise.all([
@@ -355,10 +380,12 @@ export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary>
         runId,
         profileId: profile.profileId,
         message: err instanceof Error ? err.message : String(err),
+        errorKind: classifyError(err),
       });
     }
   }
 
+  summary.durationMs = Date.now() - startedAt;
   log({ action: "summary", runId, ...summaryWithoutMeta(summary) });
   return summary;
 };

--- a/src/server/buttondown-sync.ts
+++ b/src/server/buttondown-sync.ts
@@ -325,6 +325,57 @@ const recordSubscriberId = async (profileId: string, subscriberId: string): Prom
     .where(eq(profiles.id, profileId));
 };
 
+/**
+ * Resolves a profile's Buttondown subscriber. Two strategies share
+ * the signature so syncOneProfile is agnostic to which is in play:
+ *
+ *  - Broad reconciler (cron, admin "Sync now"): one listSubscribers
+ *    call up front, indexed in memory; per-profile lookups are
+ *    free. Cheaper than O(N) per-profile GETs against an audience
+ *    that is mostly already correct.
+ *  - Per-profile resync (inline join/leave hooks): one or two
+ *    getSubscriber calls. Fetching the whole audience to act on a
+ *    single row would be the wrong trade.
+ *
+ * Selected by the presence of `deps.scopeProfileIds`.
+ */
+export type SubscriberLookup = (profile: ProfileRow) => Promise<ButtondownSubscriber | null>;
+
+// Exported for unit testing. The runner shouldn't call this
+// directly — runButtondownSync wires it up internally.
+export const buildSubscriberLookup = async (
+  client: ButtondownClient,
+  scope: string[] | undefined,
+): Promise<SubscriberLookup> => {
+  if (scope) {
+    return async (profile) => {
+      if (!profile.email) return null;
+      let sub: ButtondownSubscriber | null = null;
+      if (profile.buttondownSubscriberId) {
+        sub = await client.getSubscriber(profile.buttondownSubscriberId);
+      }
+      if (!sub) sub = await client.getSubscriber(profile.email);
+      return sub;
+    };
+  }
+
+  const all = await client.listSubscribers();
+  const byId = new Map<string, ButtondownSubscriber>();
+  const byEmail = new Map<string, ButtondownSubscriber>();
+  for (const sub of all) {
+    byId.set(sub.id, sub);
+    byEmail.set(sub.email_address.toLowerCase(), sub);
+  }
+  return async (profile) => {
+    if (profile.buttondownSubscriberId) {
+      const found = byId.get(profile.buttondownSubscriberId);
+      if (found) return found;
+    }
+    if (!profile.email) return null;
+    return byEmail.get(profile.email.toLowerCase()) ?? null;
+  };
+};
+
 export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary> => {
   const { client, runId, write } = deps;
   const log: SyncLogger = deps.log ?? (() => {});
@@ -360,6 +411,27 @@ export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary>
     desiredByProfile.set(m.profileId, entry);
   }
 
+  // Build the subscriber lookup before the per-profile loop. If the
+  // broad-path listSubscribers fails we can't trust any "subscriber
+  // missing" decision (mass-creating would be catastrophic), so bail
+  // out with an explicit fatal error rather than continuing.
+  let lookup: SubscriberLookup;
+  try {
+    lookup = await buildSubscriberLookup(client, deps.scopeProfileIds);
+  } catch (err) {
+    summary.errors++;
+    summary.durationMs = Date.now() - startedAt;
+    log({
+      action: "error",
+      runId,
+      profileId: "(audience-preload)",
+      message: err instanceof Error ? err.message : String(err),
+      errorKind: classifyError(err),
+    });
+    log({ action: "summary", runId, ...summaryWithoutMeta(summary) });
+    return summary;
+  }
+
   for (const profile of profileRows) {
     summary.scanned++;
     try {
@@ -367,6 +439,7 @@ export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary>
         profile,
         desired: desiredByProfile.get(profile.profileId) ?? { tags: [], slugs: [] },
         managedUniverse,
+        lookup,
         client,
         runId,
         log,
@@ -399,6 +472,7 @@ type SyncOneProfileArgs = {
   profile: ProfileRow;
   desired: { tags: string[]; slugs: string[] };
   managedUniverse: Set<string>;
+  lookup: SubscriberLookup;
   client: ButtondownClient;
   runId: string;
   log: SyncLogger;
@@ -407,7 +481,7 @@ type SyncOneProfileArgs = {
 };
 
 const syncOneProfile = async (args: SyncOneProfileArgs): Promise<void> => {
-  const { profile, desired, managedUniverse, client, runId, log, raise, summary } = args;
+  const { profile, desired, managedUniverse, lookup, client, runId, log, raise, summary } = args;
   const profileId = profile.profileId;
 
   if (!profile.email) {
@@ -417,15 +491,11 @@ const syncOneProfile = async (args: SyncOneProfileArgs): Promise<void> => {
   }
   const email = profile.email;
 
-  // Prefer id-based lookup (stable across email changes). Fall back to
-  // email for profiles we haven't seen before.
-  let subscriber: ButtondownSubscriber | null = null;
-  if (profile.buttondownSubscriberId) {
-    subscriber = await client.getSubscriber(profile.buttondownSubscriberId);
-  }
-  if (!subscriber) {
-    subscriber = await client.getSubscriber(email);
-  }
+  // Prefer id-based lookup (stable across email changes); falls back
+  // to email for profiles we haven't seen before. In the broad path
+  // both indexes are pre-built in memory; in the scoped path each
+  // miss is a real getSubscriber call.
+  const subscriber = await lookup(profile);
 
   if (!subscriber) {
     // Catch-up create: this is the path that runs when the inline

--- a/src/server/buttondown-sync.ts
+++ b/src/server/buttondown-sync.ts
@@ -329,19 +329,27 @@ const recordSubscriberId = async (profileId: string, subscriberId: string): Prom
  * Resolves a profile's Buttondown subscriber. Two strategies share
  * the signature so syncOneProfile is agnostic to which is in play:
  *
- *  - Broad reconciler (cron, admin "Sync now"): one listSubscribers
- *    call up front, indexed in memory; per-profile lookups are
- *    free. Cheaper than O(N) per-profile GETs against an audience
- *    that is mostly already correct.
+ *  - Broad reconciler (cron, admin "Sync now", bootstrap script):
+ *    one listSubscribers call up front, indexed in memory; per-
+ *    profile lookups are free. Cheaper than O(N) per-profile GETs
+ *    against an audience that is mostly already correct.
  *  - Per-profile resync (inline join/leave hooks): one or two
  *    getSubscriber calls. Fetching the whole audience to act on a
  *    single row would be the wrong trade.
  *
- * Selected by the presence of `deps.scopeProfileIds`.
+ * Selected by the presence of `deps.scopeProfileIds`. The lookup
+ * accepts the minimum shape used by both syncOneProfile's ProfileRow
+ * and the bootstrap script's member record.
  */
-export type SubscriberLookup = (profile: ProfileRow) => Promise<ButtondownSubscriber | null>;
+export type SubscriberLookupInput = {
+  email: string | null;
+  buttondownSubscriberId: string | null;
+};
 
-// Exported for unit testing. The runner shouldn't call this
+export type SubscriberLookup = (profile: SubscriberLookupInput) => Promise<ButtondownSubscriber | null>;
+
+// Exported for unit testing AND for reuse by the bootstrap script,
+// which is a broad-path run. The runner shouldn't call this
 // directly — runButtondownSync wires it up internally.
 export const buildSubscriberLookup = async (
   client: ButtondownClient,

--- a/src/server/buttondown-sync.ts
+++ b/src/server/buttondown-sync.ts
@@ -24,6 +24,100 @@ import {
 import { db } from "./db";
 import { authUsers, profilePrograms, profiles, programs } from "./schema";
 
+/**
+ * Inline first-profile-save hook. Called from PUT /me when the
+ * profile was being saved for the first time (lastUpdatedProfile was
+ * NULL before the save). The "one moment" of full-overwrite tag
+ * writes — see docs/design-buttondown.md → "Write policy".
+ *
+ * Behavior per the design:
+ *   - Missing subscriber → POST create with [...program_tags, "isweb-member", "new"].
+ *   - Unsubscribed → don't write; raise alert.
+ *   - Active with `isweb-member` already → no-op (the app has
+ *     authoritatively touched this subscriber on a previous run and
+ *     overwriting now risks clobbering tags humans set since).
+ *   - Active without `isweb-member` → full-overwrite PATCH with
+ *     [...program_tags, "isweb-member", "returning"]. Clears any
+ *     legacy markers like `active`.
+ *
+ * Best-effort: callers swallow failures so the profile save itself
+ * succeeds. The daily cron picks up any miss.
+ */
+export const runFirstProfileSaveSync = async (params: {
+  profileId: string;
+  email: string;
+  client: ButtondownClient;
+  raiseUnsubscribeAlert?: (alert: UnsubscribeAlert) => void;
+}): Promise<void> => {
+  const { profileId, email, client } = params;
+
+  // This profile's current tagged-program memberships — same shape
+  // the daily reconciler computes but for one profile only.
+  const memberships = await db
+    .select({ buttondownTag: programs.buttondownTag, slug: programs.slug })
+    .from(profilePrograms)
+    .innerJoin(programs, eq(programs.id, profilePrograms.programId))
+    .where(
+      and(
+        eq(profilePrograms.profileId, profileId),
+        isNull(profilePrograms.leftAt),
+        isNull(programs.archivedAt),
+        isNotNull(programs.buttondownTag),
+      ),
+    );
+
+  const desiredTags: string[] = [];
+  const slugs: string[] = [];
+  for (const m of memberships) {
+    if (m.buttondownTag && !desiredTags.includes(m.buttondownTag)) desiredTags.push(m.buttondownTag);
+    if (!slugs.includes(m.slug)) slugs.push(m.slug);
+  }
+
+  const subscriber = await client.getSubscriber(email);
+
+  if (!subscriber) {
+    const result = await client.createSubscriber({
+      email_address: email,
+      tags: [...desiredTags, "isweb-member", "new"],
+    });
+    if (!isDryRunOutcome(result)) {
+      await db
+        .update(profiles)
+        .set({ buttondownSubscriberId: result.id })
+        .where(eq(profiles.id, profileId));
+    }
+    return;
+  }
+
+  // Record the discovered id immediately — every "found subscriber"
+  // branch below benefits from future runs using id-based lookup,
+  // even the no-op "already has isweb-member" case.
+  await db
+    .update(profiles)
+    .set({ buttondownSubscriberId: subscriber.id })
+    .where(eq(profiles.id, profileId));
+
+  if (subscriber.type === "unsubscribed") {
+    params.raiseUnsubscribeAlert?.({
+      profileId,
+      email,
+      programSlugsHeld: slugs,
+      buttondownTagsOnSubscriber: subscriber.tags,
+    });
+    return;
+  }
+
+  if (subscriber.tags.includes("isweb-member")) {
+    // Already authoritatively touched by the app on a previous run;
+    // don't clobber tags humans have added since.
+    return;
+  }
+
+  await client.updateSubscriber(subscriber.id, {
+    tags: [...desiredTags, "isweb-member", "returning"],
+  });
+};
+
 /** Structured event the sync emits to the caller's logger. */
 export type SyncLogEvent =
   | { action: "summary"; runId: string } & Omit<SyncRunSummary, "runId" | "write">

--- a/src/server/buttondown-sync.ts
+++ b/src/server/buttondown-sync.ts
@@ -13,7 +13,7 @@
 // Both share the underlying client; only this function is what the
 // cron and the admin "Sync now" buttons drive.
 
-import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm";
 
 import {
   type ButtondownClient,
@@ -166,6 +166,10 @@ export type SyncDeps = {
   // enforces the gate; we just thread it through to the summary and
   // logs for observability.
   write: boolean;
+  // Restrict the reconciler to a specific set of profile ids. Omit
+  // for the daily broad sweep; pass for per-member resync paths and
+  // for tests that must not touch profiles from other workers.
+  scopeProfileIds?: string[];
   log?: SyncLogger;
   raiseUnsubscribeAlert?: (alert: UnsubscribeAlert) => void;
 };
@@ -201,7 +205,23 @@ const buildManagedUniverse = async (): Promise<Set<string>> => {
 // programs that have a buttondownTag set, joined with the program so
 // we have the tag string at hand. The result is what feeds the
 // per-profile "desired tags" map.
-const loadCurrentTaggedMemberships = async (): Promise<ProfileMembership[]> => {
+//
+// `scopeProfileIds`, when provided, narrows the query to that subset.
+// Used by per-member resync paths (future admin "sync this member"
+// button) and by tests, so the broad reconciler doesn't act outside
+// its caller's intended blast radius.
+const loadCurrentTaggedMemberships = async (
+  scopeProfileIds?: string[],
+): Promise<ProfileMembership[]> => {
+  const conditions = [
+    isNull(profilePrograms.leftAt),
+    isNull(programs.archivedAt),
+    isNotNull(programs.buttondownTag),
+  ];
+  if (scopeProfileIds) {
+    if (scopeProfileIds.length === 0) return [];
+    conditions.push(inArray(profilePrograms.profileId, scopeProfileIds));
+  }
   return db
     .select({
       profileId: profilePrograms.profileId,
@@ -210,13 +230,7 @@ const loadCurrentTaggedMemberships = async (): Promise<ProfileMembership[]> => {
     })
     .from(profilePrograms)
     .innerJoin(programs, eq(programs.id, profilePrograms.programId))
-    .where(
-      and(
-        isNull(profilePrograms.leftAt),
-        isNull(programs.archivedAt),
-        isNotNull(programs.buttondownTag),
-      ),
-    )
+    .where(and(...conditions))
     .then((rows) =>
       rows
         .filter((r): r is { profileId: string; programSlug: string; buttondownTag: string } => r.buttondownTag !== null),
@@ -225,8 +239,14 @@ const loadCurrentTaggedMemberships = async (): Promise<ProfileMembership[]> => {
 
 // All profiles with a saved profile (lastUpdatedProfile non-null) and
 // the email from auth.users. Members whose profile was created but
-// who haven't saved are out of scope.
-const loadEligibleProfiles = async (): Promise<ProfileRow[]> => {
+// who haven't saved are out of scope. `scopeProfileIds` narrows the
+// scan; see loadCurrentTaggedMemberships.
+const loadEligibleProfiles = async (scopeProfileIds?: string[]): Promise<ProfileRow[]> => {
+  const conditions = [isNotNull(profiles.lastUpdatedProfile)];
+  if (scopeProfileIds) {
+    if (scopeProfileIds.length === 0) return [];
+    conditions.push(inArray(profiles.id, scopeProfileIds));
+  }
   return db
     .select({
       profileId: profiles.id,
@@ -235,7 +255,7 @@ const loadEligibleProfiles = async (): Promise<ProfileRow[]> => {
     })
     .from(profiles)
     .innerJoin(authUsers, eq(authUsers.id, profiles.id))
-    .where(isNotNull(profiles.lastUpdatedProfile));
+    .where(and(...conditions));
 };
 
 // Compute (final tag set, removed-from-managed, added-to-managed)
@@ -302,8 +322,8 @@ export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary>
 
   const [managedUniverse, profileRows, memberships] = await Promise.all([
     buildManagedUniverse(),
-    loadEligibleProfiles(),
-    loadCurrentTaggedMemberships(),
+    loadEligibleProfiles(deps.scopeProfileIds),
+    loadCurrentTaggedMemberships(deps.scopeProfileIds),
   ]);
 
   // Group memberships by profile so each iteration is one lookup.

--- a/src/server/buttondown.ts
+++ b/src/server/buttondown.ts
@@ -161,18 +161,64 @@ export interface ButtondownClient {
   deleteSubscriber(id: string): Promise<undefined | DryRunOutcome<"delete">>;
 }
 
+/**
+ * One log line per HTTP call. Emitted from the client whenever a
+ * `logger` is provided in the config — that gives the runner a place
+ * to forward this into Axiom without coupling the client to next-axiom.
+ * `path` is the path portion only (no query string, no host), so an
+ * Axiom panel can group by it.
+ */
+export type ButtondownHttpLogEvent = {
+  method: string;
+  path: string;
+  status: number;
+  durationMs: number;
+  // Present on 429s when Buttondown returns the standard hint.
+  retryAfter?: string;
+};
+
 export type ButtondownClientConfig = {
   apiKey: string;
   write: boolean;
   // Override fetch for testing; defaults to the global fetch.
   fetcher?: typeof fetch;
+  // Optional per-request telemetry sink. Constructed by the runner
+  // for prod paths; tests typically leave it unset.
+  logger?: (event: ButtondownHttpLogEvent) => void;
 };
 
 export const createButtondownClient = (config: ButtondownClientConfig): ButtondownClient => {
-  const fetcher = config.fetcher ?? fetch;
+  const rawFetcher = config.fetcher ?? fetch;
   // Per https://docs.buttondown.com/api-introduction the auth scheme is
   // literally the word "Token", not "Bearer".
   const authHeader = `Token ${config.apiKey}`;
+  const logger = config.logger;
+
+  // Wrap every outbound call with timing + status logging. The base
+  // URL is constant, so logging the path alone is enough to group by
+  // endpoint in Axiom. `next` URLs from pagination are absolute, so
+  // we strip the base before logging when we can.
+  const fetcher: typeof fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
+    const path = url.startsWith(BUTTONDOWN_BASE_URL) ? url.slice(BUTTONDOWN_BASE_URL.length) : url;
+    const start = Date.now();
+    const res = await rawFetcher(input, init);
+    if (logger) {
+      const event: ButtondownHttpLogEvent = {
+        method,
+        path,
+        status: res.status,
+        durationMs: Date.now() - start,
+      };
+      if (res.status === 429) {
+        const retryAfter = res.headers.get("retry-after");
+        if (retryAfter !== null) event.retryAfter = retryAfter;
+      }
+      logger(event);
+    }
+    return res;
+  };
 
   const request = async (method: string, path: string, body?: unknown): Promise<Response> => {
     return fetcher(`${BUTTONDOWN_BASE_URL}${path}`, {

--- a/src/server/buttondown.ts
+++ b/src/server/buttondown.ts
@@ -212,7 +212,9 @@ export const createButtondownClient = (config: ButtondownClientConfig): Buttondo
     }
     const path = url.slice(BUTTONDOWN_BASE_URL.length);
     const start = Date.now();
-    const res = await rawFetcher(input, init);
+    // Pass the validated `url` (not the original `input`) so the host
+    // check above also acts as a taint sanitizer for static analysis.
+    const res = await rawFetcher(url, init);
     if (logger) {
       const event: ButtondownHttpLogEvent = {
         method,

--- a/src/server/buttondown.ts
+++ b/src/server/buttondown.ts
@@ -201,7 +201,14 @@ export const createButtondownClient = (config: ButtondownClientConfig): Buttondo
   const fetcher: typeof fetch = async (input, init) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     const method = init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET");
-    const path = url.startsWith(BUTTONDOWN_BASE_URL) ? url.slice(BUTTONDOWN_BASE_URL.length) : url;
+    // Defense-in-depth: pagination follows `next` URLs returned by
+    // Buttondown's response body. Refuse to forward our Authorization
+    // header to anything outside Buttondown's API in case that field
+    // ever points elsewhere.
+    if (!url.startsWith(BUTTONDOWN_BASE_URL)) {
+      throw new ButtondownApiError(0, `Refusing to fetch URL outside Buttondown: ${url}`);
+    }
+    const path = url.slice(BUTTONDOWN_BASE_URL.length);
     const start = Date.now();
     const res = await rawFetcher(input, init);
     if (logger) {

--- a/src/server/buttondown.ts
+++ b/src/server/buttondown.ts
@@ -204,8 +204,10 @@ export const createButtondownClient = (config: ButtondownClientConfig): Buttondo
     // Defense-in-depth: pagination follows `next` URLs returned by
     // Buttondown's response body. Refuse to forward our Authorization
     // header to anything outside Buttondown's API in case that field
-    // ever points elsewhere.
-    if (!url.startsWith(BUTTONDOWN_BASE_URL)) {
+    // ever points elsewhere. Trailing slash anchors the hostname
+    // boundary so a lookalike host (api.buttondown.com.evil.com)
+    // can't match.
+    if (!url.startsWith(`${BUTTONDOWN_BASE_URL}/`)) {
       throw new ButtondownApiError(0, `Refusing to fetch URL outside Buttondown: ${url}`);
     }
     const path = url.slice(BUTTONDOWN_BASE_URL.length);

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -293,6 +293,7 @@ export type AdminProgram = {
   description: string | null;
   archivedAt: string | null;
   signupsOpen: boolean;
+  buttondownTag: string | null;
   memberCount: number;
   createdAt: string;
 };
@@ -310,6 +311,9 @@ export type ProgramDetail = AdminProgram & { participants: ProgramParticipant[] 
 const MAX_PROGRAM_NAME = 120;
 const MAX_PROGRAM_SLUG = 80;
 const MAX_PROGRAM_DESCRIPTION = 2000;
+// Buttondown tag names are short by convention; the cap is well above
+// anything Buttondown surfaces in its UI and keeps the column index-friendly.
+const MAX_BUTTONDOWN_TAG = 100;
 
 // Slugs are chosen by the admin, independently of the display name.
 // Enforce a URL-safe shape: lowercase alphanumerics in hyphen-separated
@@ -329,9 +333,12 @@ const validateSlug = (slug: string): { slug: string } | { error: string } => {
 
 // Parses a create-program body. Name and slug are both required and
 // chosen independently; description is optional, null when blank.
+// buttondownTag is also optional; blank is normalized to null.
 export const parseProgramCreate = (
   body: unknown,
-): { name: string; slug: string; description: string | null } | { error: string } => {
+):
+  | { name: string; slug: string; description: string | null; buttondownTag: string | null }
+  | { error: string } => {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     return { error: "body must be a JSON object" };
   }
@@ -349,7 +356,17 @@ export const parseProgramCreate = (
   if (description && description.length > MAX_PROGRAM_DESCRIPTION) {
     return { error: "description is too long" };
   }
-  return { name, slug, description: description || null };
+
+  const buttondownTag = trimmedString(obj.buttondownTag);
+  if (buttondownTag && buttondownTag.length > MAX_BUTTONDOWN_TAG) {
+    return { error: "buttondownTag is too long" };
+  }
+  return {
+    name,
+    slug,
+    description: description || null,
+    buttondownTag: buttondownTag || null,
+  };
 };
 
 // Parses an edit-program body. Every field is optional — only the keys
@@ -363,6 +380,10 @@ export type ProgramUpdate = {
   description?: string | null;
   archived?: boolean;
   signupsOpen?: boolean;
+  // null = opt this program out of Buttondown sync. Non-empty string =
+  // the exact Buttondown tag to manage. Empty/blank from the client is
+  // normalized to null in the parser.
+  buttondownTag?: string | null;
 };
 
 export const parseProgramUpdate = (body: unknown): ProgramUpdate | { error: string } => {
@@ -400,6 +421,18 @@ export const parseProgramUpdate = (body: unknown): ProgramUpdate | { error: stri
     if (typeof obj.signupsOpen !== "boolean") return { error: "signupsOpen must be a boolean" };
     result.signupsOpen = obj.signupsOpen;
   }
+  if ("buttondownTag" in obj) {
+    // Accept null or a trimmable string; everything else is a 400.
+    // Blank / whitespace-only normalizes to null (the "unset" state).
+    if (obj.buttondownTag === null) {
+      result.buttondownTag = null;
+    } else {
+      const tag = trimmedString(obj.buttondownTag);
+      if (tag === null) return { error: "buttondownTag must be a string or null" };
+      if (tag.length > MAX_BUTTONDOWN_TAG) return { error: "buttondownTag is too long" };
+      result.buttondownTag = tag || null;
+    }
+  }
   return result;
 };
 
@@ -417,6 +450,7 @@ export const listAllProgramsForAdmin = async (): Promise<AdminProgram[]> => {
       description: programs.description,
       archivedAt: sql<string | null>`to_json(${programs.archivedAt}) #>> '{}'`,
       signupsOpen: programs.signupsOpen,
+      buttondownTag: programs.buttondownTag,
       createdAt: sql<string>`to_json(${programs.createdAt}) #>> '{}'`,
       memberCount: sql<number>`(
         SELECT count(*)::int FROM ${profilePrograms}
@@ -432,13 +466,19 @@ export const createProgram = async (input: {
   name: string;
   slug: string;
   description: string | null;
+  buttondownTag: string | null;
 }): Promise<{ program: AdminProgram } | { error: "slug_conflict" }> => {
   const [existing] = await db.select({ id: programs.id }).from(programs).where(eq(programs.slug, input.slug));
   if (existing) return { error: "slug_conflict" };
 
   const [row] = await db
     .insert(programs)
-    .values({ slug: input.slug, name: input.name, description: input.description })
+    .values({
+      slug: input.slug,
+      name: input.name,
+      description: input.description,
+      buttondownTag: input.buttondownTag,
+    })
     .returning();
 
   return {
@@ -449,6 +489,7 @@ export const createProgram = async (input: {
       description: row.description,
       archivedAt: row.archivedAt ? row.archivedAt.toISOString() : null,
       signupsOpen: row.signupsOpen,
+      buttondownTag: row.buttondownTag,
       memberCount: 0,
       createdAt: row.createdAt.toISOString(),
     },
@@ -473,6 +514,7 @@ export const updateProgram = async (
     update.archivedAt = input.archived ? sql`now()` : null;
   }
   if (input.signupsOpen !== undefined) update.signupsOpen = input.signupsOpen;
+  if (input.buttondownTag !== undefined) update.buttondownTag = input.buttondownTag;
   if (input.slug !== undefined) {
     // Reject a slug a different program already holds; the row keeping
     // its own slug unchanged is fine.
@@ -506,6 +548,7 @@ export const getProgramDetail = async (
       description: programs.description,
       archivedAt: programs.archivedAt,
       signupsOpen: programs.signupsOpen,
+      buttondownTag: programs.buttondownTag,
       createdAt: programs.createdAt,
     })
     .from(programs)
@@ -542,6 +585,7 @@ export const getProgramDetail = async (
       description: program.description,
       archivedAt: program.archivedAt ? program.archivedAt.toISOString() : null,
       signupsOpen: program.signupsOpen,
+      buttondownTag: program.buttondownTag,
       createdAt: program.createdAt.toISOString(),
       memberCount: participants.length,
       participants,

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -56,6 +56,11 @@ export const profiles = pgTable("profiles", {
   lastUpdatedProfile: timestamp("last_updated_profile", { withTimezone: true }),
   lastReviewedPrograms: timestamp("last_reviewed_programs", { withTimezone: true }),
   lastUpdatedWeb: timestamp("last_updated_web", { withTimezone: true }),
+  // Buttondown subscriber id — populated lazily by the sync the first
+  // time it encounters this profile. Lookups by id are stable across
+  // member email changes; the cron PATCHes the subscriber's email when
+  // it sees a mismatch. See docs/design-buttondown.md.
+  buttondownSubscriberId: text("buttondown_subscriber_id"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true })
     .notNull()
@@ -76,7 +81,23 @@ export const programs = pgTable("programs", {
   // newly-created cohort or pod doesn't accidentally accept signups
   // before the admin is ready; admin add-participant is unaffected.
   signupsOpen: boolean("signups_open").notNull().default(false),
+  // Buttondown tag name for this program. NULL means "do not sync this
+  // program to Buttondown at all" — the per-program opt-in mechanism.
+  // The value is the exact tag string Buttondown stores; admins set it
+  // to match whatever tag the newsletter already uses for this program.
+  // See docs/design-buttondown.md.
+  buttondownTag: text("buttondown_tag"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+}).enableRLS();
+
+// Lease-based concurrency lock for sync jobs (currently just Buttondown).
+// One row per actively held lock; the row is deleted on release, so the
+// table is empty when nothing is running. Acquire via INSERT ... ON
+// CONFLICT DO UPDATE WHERE expired (see docs/design-buttondown.md).
+export const syncLocks = pgTable("sync_locks", {
+  name: text("name").primaryKey(),
+  lockedUntil: timestamp("locked_until", { withTimezone: true }).notNull(),
+  acquiredBy: text("acquired_by").notNull(),
 }).enableRLS();
 
 // Soft-delete table: a row's existence records "Alice was ever joined

--- a/src/server/sync-locks.ts
+++ b/src/server/sync-locks.ts
@@ -1,0 +1,68 @@
+// Lease-based concurrency lock for sync jobs.
+//
+// See the "Concurrency lock" section of docs/design-buttondown.md.
+// One row in `sync_locks` per actively held lock; the row is deleted
+// on release so the table is empty when nothing is running. The lease
+// bounds the worst case where a process dies without releasing — the
+// next attempt after `lockedUntil` passes takes over.
+//
+// We use a lease table rather than PostgreSQL session-level advisory
+// locks because Supabase's transaction pooler doesn't preserve session
+// identity across pool members (see docs/strategy-db-transactions.md).
+
+import { and, eq, sql } from "drizzle-orm";
+
+import { db } from "./db";
+import { syncLocks } from "./schema";
+
+const DEFAULT_LEASE_MS = 10 * 60 * 1000;
+
+/**
+ * Try to acquire the named lock for the caller. Returns true if the
+ * caller now holds it, false if it's held by someone else and still
+ * within the lease. Idempotent: re-acquiring an expired lock from the
+ * same `acquiredBy` is fine; re-acquiring a still-valid lock from any
+ * caller returns false.
+ */
+export const acquireLock = async (
+  name: string,
+  acquiredBy: string,
+  leaseMs: number = DEFAULT_LEASE_MS,
+): Promise<boolean> => {
+  const result = await db
+    .insert(syncLocks)
+    .values({
+      name,
+      acquiredBy,
+      // Postgres `now() + interval '$leaseMs milliseconds'` style; we
+      // build it as a typed-driver-side computed timestamp so the
+      // lease is anchored in DB clock time, not Node clock time.
+      lockedUntil: sql`now() + (${leaseMs}::bigint / 1000.0) * interval '1 second'`,
+    })
+    .onConflictDoUpdate({
+      target: syncLocks.name,
+      set: {
+        acquiredBy: sql`excluded.acquired_by`,
+        lockedUntil: sql`excluded.locked_until`,
+      },
+      // Only steal an existing lock if it has expired. The setWhere
+      // matters: if the existing row's lockedUntil is still in the
+      // future, the conflict resolves to DO NOTHING and RETURNING
+      // comes back empty.
+      setWhere: sql`${syncLocks.lockedUntil} < now()`,
+    })
+    .returning({ name: syncLocks.name });
+
+  return result.length > 0;
+};
+
+/**
+ * Release the named lock if held by the caller. Deletes the row.
+ * Safe to call when no lock exists or when the lock is held by
+ * someone else — only rows matching both `name` and `acquiredBy` are
+ * removed, so a stale process waking up after its lease expired
+ * can't accidentally delete a fresher run's lock.
+ */
+export const releaseLock = async (name: string, acquiredBy: string): Promise<void> => {
+  await db.delete(syncLocks).where(and(eq(syncLocks.name, name), eq(syncLocks.acquiredBy, acquiredBy)));
+};

--- a/tests/functional/server/admin-programs.test.ts
+++ b/tests/functional/server/admin-programs.test.ts
@@ -294,6 +294,50 @@ describe("Admin programs API", () => {
       res = await patch(programId, { signupsOpen: 1 });
       expect(res.status).toBe(400);
     });
+
+    it("sets buttondownTag from a non-empty string and back to null via null", async () => {
+      const programId = await seedProgram("Buttondown Tag Program");
+      authAs(admin);
+
+      let res = await patch(programId, { buttondownTag: "weekly-updates" });
+      expect(res.status).toBe(200);
+      let [row] = await db
+        .select({ buttondownTag: programs.buttondownTag })
+        .from(programs)
+        .where(eq(programs.id, programId));
+      expect(row.buttondownTag).toBe("weekly-updates");
+
+      res = await patch(programId, { buttondownTag: null });
+      expect(res.status).toBe(200);
+      [row] = await db
+        .select({ buttondownTag: programs.buttondownTag })
+        .from(programs)
+        .where(eq(programs.id, programId));
+      expect(row.buttondownTag).toBeNull();
+    });
+
+    it("normalizes an empty buttondownTag string to null (the 'unset' state)", async () => {
+      const programId = await seedProgram("Buttondown Tag Blank Program");
+      // Seed with a non-null value so we can observe the clear.
+      await db.update(programs).set({ buttondownTag: "old-tag" }).where(eq(programs.id, programId));
+
+      authAs(admin);
+      const res = await patch(programId, { buttondownTag: "   " });
+      expect(res.status).toBe(200);
+      const [row] = await db
+        .select({ buttondownTag: programs.buttondownTag })
+        .from(programs)
+        .where(eq(programs.id, programId));
+      expect(row.buttondownTag).toBeNull();
+    });
+
+    it("rejects a non-string non-null buttondownTag with 400", async () => {
+      const programId = await seedProgram("Buttondown Tag Type Strict Program");
+      authAs(admin);
+
+      const res = await patch(programId, { buttondownTag: 42 });
+      expect(res.status).toBe(400);
+    });
   });
 
   describe("GET /api/admin/programs (archive/signups state)", () => {

--- a/tests/functional/server/auth-middleware.test.ts
+++ b/tests/functional/server/auth-middleware.test.ts
@@ -72,7 +72,12 @@ describe("API auth middleware", () => {
     // Regression guard: if a new route needs to bypass auth, it should
     // be added here intentionally — and that change will be visible in
     // this test's diff.
-    expect(PUBLIC_PATHS).toEqual(["/api/health", /^\/api\/invites\/[^/]+\/check$/, "/api/_test/reset"]);
+    expect(PUBLIC_PATHS).toEqual([
+      "/api/health",
+      /^\/api\/invites\/[^/]+\/check$/,
+      "/api/_test/reset",
+      "/api/cron/buttondown-sync",
+    ]);
   });
 
   it("allows /api/invites/:code/check without a session", async () => {

--- a/tests/functional/server/avatar.test.ts
+++ b/tests/functional/server/avatar.test.ts
@@ -18,10 +18,12 @@ import { profiles } from "@/server/schema";
 
 const mockCreateServerClient = vi.mocked(createServerClient);
 
+const TEST_EMAIL = "avatar-test@testfake.local";
+
 const makeUser = (id: string): User =>
   ({
     id,
-    email: "avatar-test@testfake.local",
+    email: TEST_EMAIL,
     user_metadata: { displayName: "Avatar Tester" },
     app_metadata: {},
     aud: "authenticated",
@@ -70,8 +72,17 @@ describe("POST/DELETE /api/me/avatar", () => {
 
   beforeEach(async () => {
     userId = randomUUID();
+    // This suite owns the TEST_EMAIL namespace in auth.users. Clear
+    // any residue from a prior run that didn't fully clean up (e.g.,
+    // the runner was killed mid-test) so the unique-email constraint
+    // doesn't poison this run. profiles → auth.users FK is RESTRICT,
+    // so drop the profile row first.
     await db.execute(
-      sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${userId}::uuid, 'avatar-test@testfake.local', false, false)`,
+      sql`DELETE FROM public.profiles WHERE id IN (SELECT id FROM auth.users WHERE email = ${TEST_EMAIL})`,
+    );
+    await db.execute(sql`DELETE FROM auth.users WHERE email = ${TEST_EMAIL}`);
+    await db.execute(
+      sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${userId}::uuid, ${TEST_EMAIL}, false, false)`,
     );
     await db.insert(profiles).values({ id: userId, displayName: "Avatar Tester" });
     mockAuth(makeUser(userId));

--- a/tests/functional/server/buttondown-bootstrap.test.ts
+++ b/tests/functional/server/buttondown-bootstrap.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import type { ButtondownSubscriber } from "@/server/buttondown";
+import { planBootstrap } from "@/server/buttondown-bootstrap";
+
+const subscriber = (over: Partial<ButtondownSubscriber> & { id: string; email_address: string }): ButtondownSubscriber => ({
+  type: "regular",
+  tags: [],
+  ...over,
+});
+
+describe("planBootstrap (decision logic)", () => {
+  it("skip-missing-subscriber when Buttondown returns null", () => {
+    const plan = planBootstrap({
+      subscriber: null,
+      appJoinedTaggedPrograms: [
+        { programId: "p1", programSlug: "weekly", buttondownTag: "weekly" },
+      ],
+      managedUniverse: new Set(["weekly"]),
+    });
+    expect(plan.kind).toBe("skip-missing-subscriber");
+  });
+
+  it("skip-unsubscribed leaves the app side untouched", () => {
+    const plan = planBootstrap({
+      subscriber: subscriber({
+        id: "sub_x",
+        email_address: "x@example.com",
+        type: "unsubscribed",
+        tags: ["weekly"],
+      }),
+      appJoinedTaggedPrograms: [
+        { programId: "p1", programSlug: "weekly", buttondownTag: "weekly" },
+      ],
+      managedUniverse: new Set(["weekly"]),
+    });
+    expect(plan).toEqual({ kind: "skip-unsubscribed", subscriberId: "sub_x" });
+  });
+
+  it("Buttondown-authoritative: queues leaveProgram for memberships Buttondown doesn't show", () => {
+    const plan = planBootstrap({
+      subscriber: subscriber({
+        id: "sub_x",
+        email_address: "x@example.com",
+        tags: ["weekly"], // Buttondown only shows weekly, not monthly
+      }),
+      appJoinedTaggedPrograms: [
+        { programId: "p1", programSlug: "weekly", buttondownTag: "weekly" },
+        { programId: "p2", programSlug: "monthly", buttondownTag: "monthly" },
+      ],
+      managedUniverse: new Set(["weekly", "monthly"]),
+    });
+    expect(plan.kind).toBe("reconcile");
+    if (plan.kind === "reconcile") {
+      expect(plan.programsToLeave).toEqual([{ programId: "p2", programSlug: "monthly" }]);
+      // After reconcile, final tags reflect Buttondown's view plus
+      // the standing markers — no monthly, since Buttondown didn't
+      // show it.
+      expect(plan.finalTags.sort()).toEqual(["isweb-member", "returning", "weekly"]);
+    }
+  });
+
+  it("final tag set includes only managed tags from Buttondown, plus standing markers", () => {
+    const plan = planBootstrap({
+      subscriber: subscriber({
+        id: "sub_x",
+        email_address: "x@example.com",
+        // human-set tags should be ignored; only managed tags pass through
+        tags: ["weekly", "human-vip", "active"],
+      }),
+      appJoinedTaggedPrograms: [
+        { programId: "p1", programSlug: "weekly", buttondownTag: "weekly" },
+      ],
+      managedUniverse: new Set(["weekly"]),
+    });
+    expect(plan.kind).toBe("reconcile");
+    if (plan.kind === "reconcile") {
+      // The legacy `active` tag drops off naturally because it's not
+      // in the managed universe and we're rewriting the tag array
+      // from scratch (full overwrite). `human-vip` is a human tag
+      // we don't authoritatively manage, so it would land outside
+      // our final set too — script callers should know that this
+      // bootstrap moment is the one time we blow human tags away.
+      expect(plan.finalTags.sort()).toEqual(["isweb-member", "returning", "weekly"]);
+    }
+  });
+
+  it("no leaves when Buttondown agrees with the app side", () => {
+    const plan = planBootstrap({
+      subscriber: subscriber({
+        id: "sub_x",
+        email_address: "x@example.com",
+        tags: ["weekly", "isweb-member"],
+      }),
+      appJoinedTaggedPrograms: [
+        { programId: "p1", programSlug: "weekly", buttondownTag: "weekly" },
+      ],
+      managedUniverse: new Set(["weekly"]),
+    });
+    expect(plan.kind).toBe("reconcile");
+    if (plan.kind === "reconcile") {
+      expect(plan.programsToLeave).toEqual([]);
+    }
+  });
+});

--- a/tests/functional/server/buttondown-first-save.test.ts
+++ b/tests/functional/server/buttondown-first-save.test.ts
@@ -108,8 +108,9 @@ describe("runFirstProfileSaveSync (inline hook)", () => {
 
     const after = await client.getSubscriber("sub_bob");
     // Full overwrite — legacy-active and human-vip both gone, as
-    // the design intends for the discrete signup moment.
-    expect(after?.tags).toEqual(["weekly", "isweb-member", "returning"]);
+    // the design intends for the discrete signup moment. Real
+    // Buttondown (and the fake) return tags sorted ascending.
+    expect(after?.tags).toEqual(["isweb-member", "returning", "weekly"]);
 
     const [row] = await db
       .select({ buttondownSubscriberId: profiles.buttondownSubscriberId })

--- a/tests/functional/server/buttondown-first-save.test.ts
+++ b/tests/functional/server/buttondown-first-save.test.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from "node:crypto";
+import { eq, inArray, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ButtondownSubscriber } from "@/server/buttondown";
+import { runFirstProfileSaveSync, type UnsubscribeAlert } from "@/server/buttondown-sync";
+import { db } from "@/server/db";
+import { profilePrograms, profiles, programs } from "@/server/schema";
+
+import { createFakeButtondownClient } from "./buttondown-fake";
+
+const insertUserAndProfile = async (
+  id: string,
+  opts: { email?: string; buttondownSubscriberId?: string | null; saved?: boolean } = {},
+) => {
+  const email = opts.email ?? `${id}@testfake.local`;
+  await db.execute(
+    sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${id}::uuid, ${email}, false, false)`,
+  );
+  await db.insert(profiles).values({
+    id,
+    lastUpdatedProfile: opts.saved === false ? null : new Date(),
+    buttondownSubscriberId: opts.buttondownSubscriberId ?? null,
+  });
+};
+
+const deleteUserAndProfile = async (id: string) => {
+  await db.delete(profiles).where(eq(profiles.id, id));
+  await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+};
+
+describe("runFirstProfileSaveSync (inline hook)", () => {
+  let profileIds: string[];
+  let programIds: string[];
+
+  beforeEach(() => {
+    profileIds = [];
+    programIds = [];
+  });
+
+  afterEach(async () => {
+    if (profileIds.length > 0) {
+      await db.delete(profilePrograms).where(inArray(profilePrograms.profileId, profileIds));
+    }
+    if (programIds.length > 0) {
+      await db.delete(programs).where(inArray(programs.id, programIds));
+    }
+    for (const id of profileIds) {
+      await deleteUserAndProfile(id);
+    }
+  });
+
+  const makeProfile = async (opts: Parameters<typeof insertUserAndProfile>[1] = {}): Promise<string> => {
+    const id = randomUUID();
+    profileIds.push(id);
+    await insertUserAndProfile(id, opts);
+    return id;
+  };
+
+  const makeProgram = async (opts: { slug?: string; buttondownTag?: string | null } = {}): Promise<string> => {
+    const id = randomUUID();
+    programIds.push(id);
+    await db.insert(programs).values({
+      id,
+      slug: opts.slug ?? `prog-${id.slice(0, 8)}`,
+      name: "First-save test program",
+      buttondownTag: opts.buttondownTag ?? null,
+    });
+    return id;
+  };
+
+  it("creates the subscriber with isweb-member + new when none exists", async () => {
+    const profileId = await makeProfile({ email: "fs-alice@example.com" });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await db.insert(profilePrograms).values({ profileId, programId });
+
+    const client = createFakeButtondownClient({ write: true });
+
+    await runFirstProfileSaveSync({ profileId, email: "fs-alice@example.com", client });
+
+    expect(client.effects).toHaveLength(1);
+    expect(client.effects[0]).toMatchObject({
+      kind: "create",
+      input: { email_address: "fs-alice@example.com", tags: ["weekly", "isweb-member", "new"] },
+    });
+
+    const [row] = await db
+      .select({ buttondownSubscriberId: profiles.buttondownSubscriberId })
+      .from(profiles)
+      .where(eq(profiles.id, profileId));
+    expect(row.buttondownSubscriberId).not.toBeNull();
+  });
+
+  it("does a full-overwrite PATCH with isweb-member + returning when subscriber exists and lacks isweb-member", async () => {
+    const profileId = await makeProfile({ email: "fs-bob@example.com" });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await db.insert(profilePrograms).values({ profileId, programId });
+
+    const initial: ButtondownSubscriber = {
+      id: "sub_bob",
+      email_address: "fs-bob@example.com",
+      type: "regular",
+      tags: ["legacy-active", "human-vip"],
+    };
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    await runFirstProfileSaveSync({ profileId, email: "fs-bob@example.com", client });
+
+    const after = await client.getSubscriber("sub_bob");
+    // Full overwrite — legacy-active and human-vip both gone, as
+    // the design intends for the discrete signup moment.
+    expect(after?.tags).toEqual(["weekly", "isweb-member", "returning"]);
+
+    const [row] = await db
+      .select({ buttondownSubscriberId: profiles.buttondownSubscriberId })
+      .from(profiles)
+      .where(eq(profiles.id, profileId));
+    expect(row.buttondownSubscriberId).toBe("sub_bob");
+  });
+
+  it("no-ops when the subscriber already has isweb-member (don't clobber human tags)", async () => {
+    const profileId = await makeProfile({ email: "fs-carol@example.com" });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await db.insert(profilePrograms).values({ profileId, programId });
+
+    const initial: ButtondownSubscriber = {
+      id: "sub_carol",
+      email_address: "fs-carol@example.com",
+      type: "regular",
+      tags: ["weekly", "human-vip", "isweb-member"],
+    };
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    await runFirstProfileSaveSync({ profileId, email: "fs-carol@example.com", client });
+
+    // Tags unchanged.
+    const after = await client.getSubscriber("sub_carol");
+    expect(after?.tags.sort()).toEqual(["human-vip", "isweb-member", "weekly"]);
+    // No write effects at all.
+    expect(client.effects).toHaveLength(0);
+    // Subscriber id still recorded.
+    const [row] = await db
+      .select({ buttondownSubscriberId: profiles.buttondownSubscriberId })
+      .from(profiles)
+      .where(eq(profiles.id, profileId));
+    expect(row.buttondownSubscriberId).toBe("sub_carol");
+  });
+
+  it("raises an unsubscribe alert and writes nothing when the subscriber is unsubscribed", async () => {
+    const profileId = await makeProfile({ email: "fs-dan@example.com" });
+    const programId = await makeProgram({ buttondownTag: "weekly", slug: "weekly-prog" });
+    await db.insert(profilePrograms).values({ profileId, programId });
+
+    const initial: ButtondownSubscriber = {
+      id: "sub_dan",
+      email_address: "fs-dan@example.com",
+      type: "unsubscribed",
+      tags: ["weekly"],
+    };
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    const alerts: UnsubscribeAlert[] = [];
+    await runFirstProfileSaveSync({
+      profileId,
+      email: "fs-dan@example.com",
+      client,
+      raiseUnsubscribeAlert: (a) => alerts.push(a),
+    });
+
+    expect(client.effects).toHaveLength(0);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toMatchObject({
+      profileId,
+      email: "fs-dan@example.com",
+      programSlugsHeld: ["weekly-prog"],
+    });
+  });
+
+  it("dry-run records the create effect without persisting subscriber id on the profile", async () => {
+    const profileId = await makeProfile({ email: "fs-eve@example.com" });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await db.insert(profilePrograms).values({ profileId, programId });
+
+    const client = createFakeButtondownClient({ write: false });
+
+    await runFirstProfileSaveSync({ profileId, email: "fs-eve@example.com", client });
+
+    expect(client.effects[0]).toMatchObject({ kind: "create", dryRun: true });
+    const [row] = await db
+      .select({ buttondownSubscriberId: profiles.buttondownSubscriberId })
+      .from(profiles)
+      .where(eq(profiles.id, profileId));
+    expect(row.buttondownSubscriberId).toBeNull();
+  });
+});

--- a/tests/functional/server/buttondown-routes.test.ts
+++ b/tests/functional/server/buttondown-routes.test.ts
@@ -237,7 +237,7 @@ describe("Buttondown sync routes", () => {
       // endpoint — the resync ran end-to-end against the real client.
       const buttondownCalls = fetchSpy.mock.calls.filter((args) => {
         const url = typeof args[0] === "string" ? args[0] : (args[0] as URL | Request).toString();
-        return url.includes("api.buttondown.com");
+        return url.startsWith("https://api.buttondown.com");
       });
       expect(buttondownCalls.length).toBeGreaterThan(0);
       // Specifically: a POST to /subscribers (the create path the

--- a/tests/functional/server/buttondown-routes.test.ts
+++ b/tests/functional/server/buttondown-routes.test.ts
@@ -249,5 +249,29 @@ describe("Buttondown sync routes", () => {
       });
       expect(created).toBeDefined();
     });
+
+    it("inline resync retries the lock after a 500ms delay when briefly held", async () => {
+      // Pre-seed a held lock that expires in 200ms — shorter than the
+      // 500ms retry delay — so the first acquireLock fails and the
+      // second succeeds via the lease-expired steal path. Proves the
+      // retry runs end-to-end instead of bailing on the first miss.
+      await db.execute(
+        sql`INSERT INTO sync_locks (name, locked_until, acquired_by)
+            VALUES ('buttondown', now() + interval '200 milliseconds', 'test:hold-briefly')`,
+      );
+
+      authAs(memberId);
+      const res = await app.request(`/api/programs/${programId}/join`, { method: "POST" });
+      expect(res.status).toBe(200);
+
+      // Retry succeeded: a POST /v1/subscribers fired, meaning the
+      // sync ran rather than skipping on lock_held.
+      const created = fetchSpy.mock.calls.find((args) => {
+        const url = typeof args[0] === "string" ? args[0] : (args[0] as URL | Request).toString();
+        const method = (args[1] as RequestInit | undefined)?.method ?? "GET";
+        return url.endsWith("/v1/subscribers") && method === "POST";
+      });
+      expect(created).toBeDefined();
+    });
   });
 });

--- a/tests/functional/server/buttondown-routes.test.ts
+++ b/tests/functional/server/buttondown-routes.test.ts
@@ -1,0 +1,165 @@
+// Route-level tests for the cron + admin Buttondown sync endpoints.
+//
+// These tests stand up the real Hono app and exercise its auth /
+// secret gates. The sync's effect on Buttondown isn't asserted here
+// (the core function has its own tests); these confirm the routes
+// reach the runner with the right arguments and reject unauthorized
+// callers.
+
+import { randomUUID } from "node:crypto";
+import type { User } from "@supabase/supabase-js";
+import { eq, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+import { createServerClient } from "@supabase/ssr";
+
+import app from "@/server/api";
+import { db } from "@/server/db";
+import { profiles, syncLocks } from "@/server/schema";
+
+const mockCreateServerClient = vi.mocked(createServerClient);
+
+const fakeUser = (id: string): User =>
+  ({
+    id,
+    email: `${id}@testfake.local`,
+    user_metadata: {},
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+  }) as User;
+
+const authAs = (userId: string | null) => {
+  mockCreateServerClient.mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? fakeUser(userId) : null },
+        error: null,
+      }),
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test mock shape
+  } as any);
+};
+
+const insertUserAndProfile = async (id: string, opts: { isAdmin?: boolean } = {}) => {
+  await db.execute(
+    sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${id}::uuid, ${`${id}@testfake.local`}, false, false)`,
+  );
+  await db.insert(profiles).values({ id, isAdmin: opts.isAdmin ?? false });
+};
+
+const deleteUserAndProfile = async (id: string) => {
+  await db.delete(profiles).where(eq(profiles.id, id));
+  await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+};
+
+describe("Buttondown sync routes", () => {
+  let admin: string;
+  let nonAdmin: string;
+  const originalApiKey = process.env.BUTTONDOWN_API_KEY;
+  const originalCronSecret = process.env.CRON_SECRET;
+  const originalWrite = process.env.BUTTONDOWN_SYNC_WRITE;
+
+  beforeEach(async () => {
+    admin = randomUUID();
+    nonAdmin = randomUUID();
+    await insertUserAndProfile(admin, { isAdmin: true });
+    await insertUserAndProfile(nonAdmin);
+    // Reset env per test so cases that touch the runner are isolated.
+    delete process.env.BUTTONDOWN_API_KEY;
+    delete process.env.CRON_SECRET;
+    delete process.env.BUTTONDOWN_SYNC_WRITE;
+    await db.delete(syncLocks);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(admin);
+    await deleteUserAndProfile(nonAdmin);
+    process.env.BUTTONDOWN_API_KEY = originalApiKey;
+    process.env.CRON_SECRET = originalCronSecret;
+    process.env.BUTTONDOWN_SYNC_WRITE = originalWrite;
+    await db.delete(syncLocks);
+  });
+
+  describe("POST /api/cron/buttondown-sync", () => {
+    it("rejects with 401 when no Authorization header", async () => {
+      process.env.CRON_SECRET = "secret-abc";
+      const res = await app.request("/api/cron/buttondown-sync", { method: "POST" });
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects with 401 when the bearer does not match CRON_SECRET", async () => {
+      process.env.CRON_SECRET = "secret-abc";
+      const res = await app.request("/api/cron/buttondown-sync", {
+        method: "POST",
+        headers: { authorization: "Bearer wrong-token" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects with 401 when CRON_SECRET is not set in env", async () => {
+      // The route must fail closed: even a request with a Bearer
+      // header should be rejected if the server has no secret set,
+      // otherwise the cron is effectively public.
+      const res = await app.request("/api/cron/buttondown-sync", {
+        method: "POST",
+        headers: { authorization: "Bearer anything" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns skipped:api_key_missing when CRON_SECRET matches but BUTTONDOWN_API_KEY is unset", async () => {
+      process.env.CRON_SECRET = "secret-abc";
+      const res = await app.request("/api/cron/buttondown-sync", {
+        method: "POST",
+        headers: { authorization: "Bearer secret-abc" },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string; reason?: string };
+      expect(body).toEqual({ status: "skipped", reason: "api_key_missing" });
+    });
+  });
+
+  describe("POST /api/admin/buttondown-sync/dry-run", () => {
+    it("returns 404 for non-admin", async () => {
+      authAs(nonAdmin);
+      const res = await app.request("/api/admin/buttondown-sync/dry-run", { method: "POST" });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 401 for unauthenticated", async () => {
+      authAs(null);
+      const res = await app.request("/api/admin/buttondown-sync/dry-run", { method: "POST" });
+      expect(res.status).toBe(401);
+    });
+
+    it("for admin, returns skipped:api_key_missing when BUTTONDOWN_API_KEY is unset", async () => {
+      authAs(admin);
+      const res = await app.request("/api/admin/buttondown-sync/dry-run", { method: "POST" });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string; reason?: string };
+      expect(body).toEqual({ status: "skipped", reason: "api_key_missing" });
+    });
+  });
+
+  describe("POST /api/admin/buttondown-sync/write", () => {
+    it("returns 404 for non-admin", async () => {
+      authAs(nonAdmin);
+      const res = await app.request("/api/admin/buttondown-sync/write", { method: "POST" });
+      expect(res.status).toBe(404);
+    });
+
+    it("for admin, returns skipped:api_key_missing when BUTTONDOWN_API_KEY is unset", async () => {
+      authAs(admin);
+      const res = await app.request("/api/admin/buttondown-sync/write", { method: "POST" });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string };
+      expect(body.status).toBe("skipped");
+    });
+  });
+});

--- a/tests/functional/server/buttondown-routes.test.ts
+++ b/tests/functional/server/buttondown-routes.test.ts
@@ -237,7 +237,7 @@ describe("Buttondown sync routes", () => {
       // endpoint — the resync ran end-to-end against the real client.
       const buttondownCalls = fetchSpy.mock.calls.filter((args) => {
         const url = typeof args[0] === "string" ? args[0] : (args[0] as URL | Request).toString();
-        return url.startsWith("https://api.buttondown.com");
+        return url.startsWith("https://api.buttondown.com/");
       });
       expect(buttondownCalls.length).toBeGreaterThan(0);
       // Specifically: a POST to /subscribers (the create path the

--- a/tests/functional/server/buttondown-routes.test.ts
+++ b/tests/functional/server/buttondown-routes.test.ts
@@ -19,7 +19,7 @@ import { createServerClient } from "@supabase/ssr";
 
 import app from "@/server/api";
 import { db } from "@/server/db";
-import { profiles, syncLocks } from "@/server/schema";
+import { profilePrograms, profiles, programs, syncLocks } from "@/server/schema";
 
 const mockCreateServerClient = vi.mocked(createServerClient);
 
@@ -160,6 +160,94 @@ describe("Buttondown sync routes", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as { status: string };
       expect(body.status).toBe("skipped");
+    });
+  });
+
+  // Inline resync wiring: program join/leave/admin-remove must each
+  // run a per-profile Buttondown sync after their DB write, so a tag
+  // change shows up within the request instead of waiting for the
+  // daily cron. The runner is exercised end-to-end with a stubbed
+  // global fetch that records every outbound call.
+  describe("inline resync on program changes", () => {
+    let memberId: string;
+    let programId: string;
+    let fetchSpy: ReturnType<typeof vi.fn>;
+    const originalFetch = global.fetch;
+
+    const buttondownResponse = (status: number, body: unknown): Response =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+
+    beforeEach(async () => {
+      memberId = randomUUID();
+      programId = randomUUID();
+      await db.execute(
+        sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous)
+            VALUES (${memberId}::uuid, ${`${memberId}@testfake.local`}, false, false)`,
+      );
+      // lastUpdatedProfile is what the sync's loadEligibleProfiles
+      // filters on — without it the resync is a no-op.
+      await db.insert(profiles).values({ id: memberId, lastUpdatedProfile: new Date() });
+      await db.insert(programs).values({
+        id: programId,
+        slug: `inline-resync-${programId.slice(0, 8)}`,
+        name: "Inline resync program",
+        buttondownTag: "weekly",
+        signupsOpen: true,
+      });
+
+      process.env.BUTTONDOWN_API_KEY = "test-key";
+      process.env.BUTTONDOWN_SYNC_WRITE = "1";
+
+      // Canned Buttondown responses: 404 on the initial id/email
+      // lookup, 201 on create. Enough for the runner to walk a happy
+      // path and call createSubscriber, which is what we assert on.
+      fetchSpy = vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        if (url.includes("/v1/subscribers/")) return buttondownResponse(404, { detail: "not found" });
+        if (url.endsWith("/v1/subscribers")) {
+          return buttondownResponse(201, {
+            id: "sub_test",
+            email_address: `${memberId}@testfake.local`,
+            type: "regular",
+            tags: ["weekly", "isweb-member", "new"],
+          });
+        }
+        return buttondownResponse(500, { error: `unexpected url: ${url}` });
+      });
+      global.fetch = fetchSpy as unknown as typeof fetch;
+    });
+
+    afterEach(async () => {
+      global.fetch = originalFetch;
+      await db.delete(profilePrograms).where(eq(profilePrograms.profileId, memberId));
+      await db.delete(programs).where(eq(programs.id, programId));
+      await db.delete(profiles).where(eq(profiles.id, memberId));
+      await db.execute(sql`DELETE FROM auth.users WHERE id = ${memberId}::uuid`);
+    });
+
+    it("POST /api/programs/:id/join hits Buttondown after the DB write", async () => {
+      authAs(memberId);
+      const res = await app.request(`/api/programs/${programId}/join`, { method: "POST" });
+      expect(res.status).toBe(200);
+
+      // At least one fetch landed on Buttondown's subscribers
+      // endpoint — the resync ran end-to-end against the real client.
+      const buttondownCalls = fetchSpy.mock.calls.filter((args) => {
+        const url = typeof args[0] === "string" ? args[0] : (args[0] as URL | Request).toString();
+        return url.includes("api.buttondown.com");
+      });
+      expect(buttondownCalls.length).toBeGreaterThan(0);
+      // Specifically: a POST to /subscribers (the create path the
+      // member with no prior subscriber should land on).
+      const created = fetchSpy.mock.calls.find((args) => {
+        const url = typeof args[0] === "string" ? args[0] : (args[0] as URL | Request).toString();
+        const method = (args[1] as RequestInit | undefined)?.method ?? "GET";
+        return url.endsWith("/v1/subscribers") && method === "POST";
+      });
+      expect(created).toBeDefined();
     });
   });
 });

--- a/tests/functional/server/buttondown-sync.test.ts
+++ b/tests/functional/server/buttondown-sync.test.ts
@@ -1,9 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { eq, inArray, sql } from "drizzle-orm";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ButtondownSubscriber } from "@/server/buttondown";
-import { runButtondownSync, type SyncLogEvent, type UnsubscribeAlert } from "@/server/buttondown-sync";
+import {
+  buildSubscriberLookup,
+  runButtondownSync,
+  type SyncLogEvent,
+  type UnsubscribeAlert,
+} from "@/server/buttondown-sync";
 import { db } from "@/server/db";
 import { profilePrograms, profiles, programs } from "@/server/schema";
 
@@ -331,5 +336,91 @@ describe("runButtondownSync (daily reconciler)", () => {
       input: { tags: ["isweb-member", "new"] },
     });
     expect(profileId).toBeTruthy();
+  });
+});
+
+// buildSubscriberLookup picks the right strategy based on whether
+// the caller passed a profile scope. The broad daily reconciler
+// gets a single listSubscribers preload (cheap when the audience is
+// mostly correct); the inline per-profile resync gets the legacy
+// per-profile getSubscriber path (cheap when only one row matters).
+//
+// These are pure-function tests against a stub client — no DB —
+// because the broad path is impossible to exercise hermetically
+// through runButtondownSync under parallel-file vitest: an
+// unscoped run reads every profile in the shared dev DB and races
+// other workers. Asserting the strategy at the helper level keeps
+// the test deterministic.
+describe("buildSubscriberLookup", () => {
+  const sub = (over: Partial<ButtondownSubscriber> & { id: string; email_address: string }): ButtondownSubscriber => ({
+    type: "regular",
+    tags: [],
+    ...over,
+  });
+
+  type SpyClient = {
+    listSubscribers: ReturnType<typeof vi.fn>;
+    getSubscriber: ReturnType<typeof vi.fn>;
+  };
+
+  const makeSpyClient = (subscribers: ButtondownSubscriber[]): SpyClient => ({
+    listSubscribers: vi.fn(async () => subscribers),
+    getSubscriber: vi.fn(async (idOrEmail: string) => {
+      for (const s of subscribers) {
+        if (s.id === idOrEmail) return s;
+        if (s.email_address.toLowerCase() === idOrEmail.toLowerCase()) return s;
+      }
+      return null;
+    }),
+  });
+
+  it("broad path: lists subscribers once and serves all lookups from the in-memory map", async () => {
+    const subs = [
+      sub({ id: "sub_a", email_address: "alpha@example.com" }),
+      sub({ id: "sub_b", email_address: "beta@example.com" }),
+    ];
+    const client = makeSpyClient(subs);
+    const lookup = await buildSubscriberLookup(client as never, undefined);
+
+    expect(client.listSubscribers).toHaveBeenCalledTimes(1);
+    expect(client.getSubscriber).not.toHaveBeenCalled();
+
+    // Lookups consult the cached map — no further HTTP.
+    const byId = await lookup({ profileId: "p1", email: "irrelevant@example.com", buttondownSubscriberId: "sub_a" });
+    expect(byId?.id).toBe("sub_a");
+    const byEmail = await lookup({ profileId: "p2", email: "beta@example.com", buttondownSubscriberId: null });
+    expect(byEmail?.id).toBe("sub_b");
+    const missing = await lookup({ profileId: "p3", email: "nobody@example.com", buttondownSubscriberId: null });
+    expect(missing).toBeNull();
+
+    expect(client.getSubscriber).not.toHaveBeenCalled();
+    expect(client.listSubscribers).toHaveBeenCalledTimes(1);
+  });
+
+  it("broad path: stale stored subscriberId falls back to the email index", async () => {
+    const subs = [sub({ id: "sub_real", email_address: "carla@example.com" })];
+    const client = makeSpyClient(subs);
+    const lookup = await buildSubscriberLookup(client as never, undefined);
+
+    const found = await lookup({
+      profileId: "p1",
+      email: "carla@example.com",
+      buttondownSubscriberId: "sub_stale_that_no_longer_exists",
+    });
+    expect(found?.id).toBe("sub_real");
+  });
+
+  it("scoped path: never calls listSubscribers; does per-profile getSubscriber", async () => {
+    const subs = [sub({ id: "sub_only", email_address: "solo@example.com" })];
+    const client = makeSpyClient(subs);
+    const lookup = await buildSubscriberLookup(client as never, ["p1"]);
+
+    expect(client.listSubscribers).not.toHaveBeenCalled();
+
+    const found = await lookup({ profileId: "p1", email: "solo@example.com", buttondownSubscriberId: "sub_only" });
+    expect(found?.id).toBe("sub_only");
+    // id-first, no email fallback when id resolves.
+    expect(client.getSubscriber).toHaveBeenCalledTimes(1);
+    expect(client.getSubscriber).toHaveBeenCalledWith("sub_only");
   });
 });

--- a/tests/functional/server/buttondown-sync.test.ts
+++ b/tests/functional/server/buttondown-sync.test.ts
@@ -9,11 +9,12 @@ import { profilePrograms, profiles, programs } from "@/server/schema";
 
 import { createFakeButtondownClient, type FakeButtondownEffect } from "./buttondown-fake";
 
-// The local dev DB may carry a small number of persistent seeded
-// profiles (`scripts/seed-e2e-users.mjs`). The sync correctly scans
-// every saved profile, so tests filter the recorded effects down to
-// the specific test profile under examination rather than asserting
-// on global summary totals — see .scratch/buttondown-emergent.md.
+// Every test scopes runButtondownSync to its own profile ids via
+// `scopeProfileIds`. Without that, parallel test files race on the
+// shared dev DB: the reconciler picks up other workers' profiles,
+// writes their `buttondownSubscriberId`, and the membership-join
+// query sometimes returns nothing for this worker's profile. Both
+// flakes resolve once each test only touches what it created.
 
 const insertUserAndProfile = async (
   id: string,
@@ -126,7 +127,7 @@ describe("runButtondownSync (daily reconciler)", () => {
     const client = createFakeButtondownClient({ write: true });
     const { log, events } = collectingLogger();
 
-    await runButtondownSync({ client, runId: "r1", write: true, log });
+    await runButtondownSync({ client, runId: "r1", write: true, log, scopeProfileIds: [profileId] });
 
     const myEffects = effectsForEmail(client.effects, "alice@example.com");
     expect(myEffects).toHaveLength(1);
@@ -147,14 +148,6 @@ describe("runButtondownSync (daily reconciler)", () => {
     ).toBeDefined();
   });
 
-  // TODO: flakes ~1-in-3 under Vitest's default parallel file
-  // execution; deterministic with --no-file-parallelism and in
-  // isolation. Bob's `desired` tag set computes empty even though the
-  // join was just inserted — looks like cross-file DB-state
-  // interference under parallel workers. Most disciplined fix is to
-  // scope runButtondownSync's queries to a caller-supplied profile-id
-  // allowlist (also enables a "sync just this member" admin
-  // affordance). Worth a real issue once this branch is on main.
   it("PATCHes a subscribed person's tags when the managed set has drifted", async () => {
     const profileId = await makeProfile({ email: "bob@example.com" });
     const weeklyProgramId = await makeProgram({ buttondownTag: "weekly" });
@@ -168,7 +161,7 @@ describe("runButtondownSync (daily reconciler)", () => {
     });
     const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
 
-    await runButtondownSync({ client, runId: "r2", write: true });
+    await runButtondownSync({ client, runId: "r2", write: true, scopeProfileIds: [profileId] });
 
     const myEffects = effectsForSubscriberId(client.effects, "sub_bob");
     expect(myEffects).toHaveLength(1);
@@ -195,7 +188,7 @@ describe("runButtondownSync (daily reconciler)", () => {
     });
     const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
 
-    await runButtondownSync({ client, runId: "r3", write: true });
+    await runButtondownSync({ client, runId: "r3", write: true, scopeProfileIds: [profileId] });
 
     expect(effectsForSubscriberId(client.effects, "sub_carol")).toHaveLength(0);
   });
@@ -215,7 +208,7 @@ describe("runButtondownSync (daily reconciler)", () => {
     });
     const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
 
-    await runButtondownSync({ client, runId: "r4", write: true });
+    await runButtondownSync({ client, runId: "r4", write: true, scopeProfileIds: [profileId] });
 
     const updated = await client.getSubscriber("sub_dan");
     expect(updated?.tags).toEqual(["isweb-member"]);
@@ -238,7 +231,7 @@ describe("runButtondownSync (daily reconciler)", () => {
     const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
     const { alerts, raise } = collectingAlerts();
 
-    await runButtondownSync({ client, runId: "r5", write: true, raiseUnsubscribeAlert: raise });
+    await runButtondownSync({ client, runId: "r5", write: true, raiseUnsubscribeAlert: raise, scopeProfileIds: [profileId] });
 
     expect(effectsForSubscriberId(client.effects, "sub_eve")).toHaveLength(0);
     const my = alerts.find((a) => a.profileId === profileId);
@@ -264,7 +257,7 @@ describe("runButtondownSync (daily reconciler)", () => {
     });
     const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
 
-    await runButtondownSync({ client, runId: "r6", write: true });
+    await runButtondownSync({ client, runId: "r6", write: true, scopeProfileIds: [profileId] });
 
     const updated = await client.getSubscriber("sub_frank");
     expect(updated?.email_address).toBe("frank-new@example.com");
@@ -283,7 +276,7 @@ describe("runButtondownSync (daily reconciler)", () => {
     });
     const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
 
-    await runButtondownSync({ client, runId: "r7", write: true });
+    await runButtondownSync({ client, runId: "r7", write: true, scopeProfileIds: [profileId] });
 
     const [row] = await db
       .select({ buttondownSubscriberId: profiles.buttondownSubscriberId })
@@ -299,7 +292,7 @@ describe("runButtondownSync (daily reconciler)", () => {
 
     const client = createFakeButtondownClient({ write: false });
 
-    await runButtondownSync({ client, runId: "r8", write: false });
+    await runButtondownSync({ client, runId: "r8", write: false, scopeProfileIds: [profileId] });
 
     const myEffects = effectsForEmail(client.effects, "henry@example.com");
     expect(myEffects[0]).toMatchObject({ kind: "create", dryRun: true });
@@ -317,7 +310,7 @@ describe("runButtondownSync (daily reconciler)", () => {
     await join(profileId, programId);
 
     const client = createFakeButtondownClient({ write: true });
-    await runButtondownSync({ client, runId: "r9", write: true });
+    await runButtondownSync({ client, runId: "r9", write: true, scopeProfileIds: [profileId] });
 
     // Isaac's email should never have been touched.
     expect(effectsForEmail(client.effects, "isaac@example.com")).toHaveLength(0);
@@ -329,7 +322,7 @@ describe("runButtondownSync (daily reconciler)", () => {
     await join(profileId, programId);
 
     const client = createFakeButtondownClient({ write: true });
-    await runButtondownSync({ client, runId: "r10", write: true });
+    await runButtondownSync({ client, runId: "r10", write: true, scopeProfileIds: [profileId] });
 
     const myEffects = effectsForEmail(client.effects, "jess@example.com");
     expect(myEffects).toHaveLength(1);

--- a/tests/functional/server/buttondown-sync.test.ts
+++ b/tests/functional/server/buttondown-sync.test.ts
@@ -1,0 +1,334 @@
+import { randomUUID } from "node:crypto";
+import { eq, inArray, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ButtondownSubscriber } from "@/server/buttondown";
+import { runButtondownSync, type SyncLogEvent, type UnsubscribeAlert } from "@/server/buttondown-sync";
+import { db } from "@/server/db";
+import { profilePrograms, profiles, programs } from "@/server/schema";
+
+import { createFakeButtondownClient, type FakeButtondownEffect } from "./buttondown-fake";
+
+// The local dev DB may carry a small number of persistent seeded
+// profiles (`scripts/seed-e2e-users.mjs`). The sync correctly scans
+// every saved profile, so tests filter the recorded effects down to
+// the specific test profile under examination rather than asserting
+// on global summary totals — see .scratch/buttondown-emergent.md.
+
+const insertUserAndProfile = async (
+  id: string,
+  opts: { displayName?: string; saved?: boolean; buttondownSubscriberId?: string | null; email?: string } = {},
+) => {
+  const email = opts.email ?? `${id}@testfake.local`;
+  await db.execute(
+    sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${id}::uuid, ${email}, false, false)`,
+  );
+  await db.insert(profiles).values({
+    id,
+    displayName: opts.displayName ?? null,
+    lastUpdatedProfile: opts.saved === false ? null : new Date(),
+    buttondownSubscriberId: opts.buttondownSubscriberId ?? null,
+  });
+};
+
+const deleteUserAndProfile = async (id: string) => {
+  await db.delete(profiles).where(eq(profiles.id, id));
+  await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+};
+
+const seedProgram = async (opts: {
+  name?: string;
+  slug?: string;
+  buttondownTag?: string | null;
+  archived?: boolean;
+} = {}): Promise<string> => {
+  const id = randomUUID();
+  await db.insert(programs).values({
+    id,
+    slug: opts.slug ?? `prog-${id.slice(0, 8)}`,
+    name: opts.name ?? "Test Program",
+    buttondownTag: opts.buttondownTag ?? null,
+    archivedAt: opts.archived ? new Date() : null,
+  });
+  return id;
+};
+
+const join = async (profileId: string, programId: string) => {
+  await db.insert(profilePrograms).values({ profileId, programId });
+};
+
+const collectingLogger = () => {
+  const events: SyncLogEvent[] = [];
+  return { events, log: (e: SyncLogEvent) => events.push(e) };
+};
+
+const collectingAlerts = () => {
+  const alerts: UnsubscribeAlert[] = [];
+  return { alerts, raise: (a: UnsubscribeAlert) => alerts.push(a) };
+};
+
+const sampleSubscriber = (
+  over: Partial<ButtondownSubscriber> & { id: string; email_address: string },
+): ButtondownSubscriber => ({ type: "regular", tags: [], ...over });
+
+// Pulls the effects relating to a single subscriber id or email, so
+// tests can assert against their own profile's actions without being
+// polluted by other rows the sync also processed.
+const effectsForEmail = (effects: FakeButtondownEffect[], email: string): FakeButtondownEffect[] =>
+  effects.filter((e) =>
+    e.kind === "create"
+      ? e.input.email_address.toLowerCase() === email.toLowerCase()
+      : false,
+  );
+
+const effectsForSubscriberId = (effects: FakeButtondownEffect[], id: string): FakeButtondownEffect[] =>
+  effects.filter((e) => (e.kind === "update" ? e.id === id : false));
+
+describe("runButtondownSync (daily reconciler)", () => {
+  let profileIds: string[];
+  let programIds: string[];
+
+  beforeEach(() => {
+    profileIds = [];
+    programIds = [];
+  });
+
+  afterEach(async () => {
+    if (profileIds.length > 0) {
+      await db.delete(profilePrograms).where(inArray(profilePrograms.profileId, profileIds));
+    }
+    if (programIds.length > 0) {
+      await db.delete(programs).where(inArray(programs.id, programIds));
+    }
+    for (const id of profileIds) {
+      await deleteUserAndProfile(id);
+    }
+  });
+
+  const makeProfile = async (opts: Parameters<typeof insertUserAndProfile>[1] = {}): Promise<string> => {
+    const id = randomUUID();
+    profileIds.push(id);
+    await insertUserAndProfile(id, opts);
+    return id;
+  };
+
+  const makeProgram = async (opts: Parameters<typeof seedProgram>[0] = {}): Promise<string> => {
+    const id = await seedProgram(opts);
+    programIds.push(id);
+    return id;
+  };
+
+  it("creates a subscriber when none exists, with isweb-member + new tags", async () => {
+    const profileId = await makeProfile({ email: "alice@example.com" });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    const client = createFakeButtondownClient({ write: true });
+    const { log, events } = collectingLogger();
+
+    await runButtondownSync({ client, runId: "r1", write: true, log });
+
+    const myEffects = effectsForEmail(client.effects, "alice@example.com");
+    expect(myEffects).toHaveLength(1);
+    expect(myEffects[0]).toMatchObject({
+      kind: "create",
+      input: { email_address: "alice@example.com", tags: ["weekly", "isweb-member", "new"] },
+      dryRun: false,
+    });
+
+    const [row] = await db
+      .select({ buttondownSubscriberId: profiles.buttondownSubscriberId })
+      .from(profiles)
+      .where(eq(profiles.id, profileId));
+    expect(row.buttondownSubscriberId).not.toBeNull();
+
+    expect(
+      events.find((e) => e.action === "subscriber-created" && e.profileId === profileId),
+    ).toBeDefined();
+  });
+
+  it("PATCHes a subscribed person's tags when the managed set has drifted", async () => {
+    const profileId = await makeProfile({ email: "bob@example.com" });
+    const weeklyProgramId = await makeProgram({ buttondownTag: "weekly" });
+    await makeProgram({ buttondownTag: "monthly" }); // in managed universe, Bob isn't in it
+    await join(profileId, weeklyProgramId);
+
+    const initial = sampleSubscriber({
+      id: "sub_bob",
+      email_address: "bob@example.com",
+      tags: ["monthly", "human-set", "isweb-member"],
+    });
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    await runButtondownSync({ client, runId: "r2", write: true });
+
+    const myEffects = effectsForSubscriberId(client.effects, "sub_bob");
+    expect(myEffects).toHaveLength(1);
+    expect(myEffects[0].kind).toBe("update");
+
+    const updated = await client.getSubscriber("sub_bob");
+    // Managed universe: {"weekly", "monthly"}. Bob is in "weekly" only.
+    // monthly stripped; weekly added; non-managed tags preserved.
+    expect(updated?.tags.sort()).toEqual(["human-set", "isweb-member", "weekly"]);
+  });
+
+  it("leaves non-managed tags alone and produces no PATCH when already current", async () => {
+    const profileId = await makeProfile({
+      email: "carol@example.com",
+      buttondownSubscriberId: "sub_carol",
+    });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    const initial = sampleSubscriber({
+      id: "sub_carol",
+      email_address: "carol@example.com",
+      tags: ["weekly", "vip", "donor-2025", "isweb-member"],
+    });
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    await runButtondownSync({ client, runId: "r3", write: true });
+
+    expect(effectsForSubscriberId(client.effects, "sub_carol")).toHaveLength(0);
+  });
+
+  it("strips a tag when its program is archived (archived drops out of the desired set)", async () => {
+    const profileId = await makeProfile({
+      email: "dan@example.com",
+      buttondownSubscriberId: "sub_dan",
+    });
+    const archivedProgramId = await makeProgram({ buttondownTag: "archived-weekly", archived: true });
+    await join(profileId, archivedProgramId);
+
+    const initial = sampleSubscriber({
+      id: "sub_dan",
+      email_address: "dan@example.com",
+      tags: ["archived-weekly", "isweb-member"],
+    });
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    await runButtondownSync({ client, runId: "r4", write: true });
+
+    const updated = await client.getSubscriber("sub_dan");
+    expect(updated?.tags).toEqual(["isweb-member"]);
+  });
+
+  it("raises an unsubscribe alert and skips writes for an unsubscribed subscriber", async () => {
+    const profileId = await makeProfile({
+      email: "eve@example.com",
+      buttondownSubscriberId: "sub_eve",
+    });
+    const programId = await makeProgram({ buttondownTag: "weekly", slug: "weekly-prog" });
+    await join(profileId, programId);
+
+    const initial = sampleSubscriber({
+      id: "sub_eve",
+      email_address: "eve@example.com",
+      type: "unsubscribed",
+      tags: ["weekly"],
+    });
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+    const { alerts, raise } = collectingAlerts();
+
+    await runButtondownSync({ client, runId: "r5", write: true, raiseUnsubscribeAlert: raise });
+
+    expect(effectsForSubscriberId(client.effects, "sub_eve")).toHaveLength(0);
+    const my = alerts.find((a) => a.profileId === profileId);
+    expect(my).toMatchObject({
+      profileId,
+      email: "eve@example.com",
+      programSlugsHeld: ["weekly-prog"],
+    });
+  });
+
+  it("PATCHes email when the stored subscriber id resolves but the email has changed", async () => {
+    const profileId = await makeProfile({
+      email: "frank-new@example.com",
+      buttondownSubscriberId: "sub_frank",
+    });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    const initial = sampleSubscriber({
+      id: "sub_frank",
+      email_address: "frank-old@example.com",
+      tags: ["weekly", "isweb-member"],
+    });
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    await runButtondownSync({ client, runId: "r6", write: true });
+
+    const updated = await client.getSubscriber("sub_frank");
+    expect(updated?.email_address).toBe("frank-new@example.com");
+    expect(profileId).toBeTruthy();
+  });
+
+  it("records the subscriber id on a profile we find by email lookup", async () => {
+    const profileId = await makeProfile({ email: "gina@example.com" });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    const initial = sampleSubscriber({
+      id: "sub_gina",
+      email_address: "gina@example.com",
+      tags: ["weekly", "isweb-member"],
+    });
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    await runButtondownSync({ client, runId: "r7", write: true });
+
+    const [row] = await db
+      .select({ buttondownSubscriberId: profiles.buttondownSubscriberId })
+      .from(profiles)
+      .where(eq(profiles.id, profileId));
+    expect(row.buttondownSubscriberId).toBe("sub_gina");
+  });
+
+  it("dry-runs without writing when write=false on the client", async () => {
+    const profileId = await makeProfile({ email: "henry@example.com" });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    const client = createFakeButtondownClient({ write: false });
+
+    await runButtondownSync({ client, runId: "r8", write: false });
+
+    const myEffects = effectsForEmail(client.effects, "henry@example.com");
+    expect(myEffects[0]).toMatchObject({ kind: "create", dryRun: true });
+    expect(await client.getSubscriber("henry@example.com")).toBeNull();
+    const [row] = await db
+      .select({ buttondownSubscriberId: profiles.buttondownSubscriberId })
+      .from(profiles)
+      .where(eq(profiles.id, profileId));
+    expect(row.buttondownSubscriberId).toBeNull();
+  });
+
+  it("skips profiles without a saved profile (lastUpdatedProfile IS NULL)", async () => {
+    const profileId = await makeProfile({ email: "isaac@example.com", saved: false });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    const client = createFakeButtondownClient({ write: true });
+    await runButtondownSync({ client, runId: "r9", write: true });
+
+    // Isaac's email should never have been touched.
+    expect(effectsForEmail(client.effects, "isaac@example.com")).toHaveLength(0);
+  });
+
+  it("includes profiles whose only programs have no buttondownTag (catch-up creates with empty managed set)", async () => {
+    const profileId = await makeProfile({ email: "jess@example.com" });
+    const programId = await makeProgram({ buttondownTag: null });
+    await join(profileId, programId);
+
+    const client = createFakeButtondownClient({ write: true });
+    await runButtondownSync({ client, runId: "r10", write: true });
+
+    const myEffects = effectsForEmail(client.effects, "jess@example.com");
+    expect(myEffects).toHaveLength(1);
+    expect(myEffects[0]).toMatchObject({
+      kind: "create",
+      input: { tags: ["isweb-member", "new"] },
+    });
+    expect(profileId).toBeTruthy();
+  });
+});

--- a/tests/functional/server/buttondown-sync.test.ts
+++ b/tests/functional/server/buttondown-sync.test.ts
@@ -147,6 +147,14 @@ describe("runButtondownSync (daily reconciler)", () => {
     ).toBeDefined();
   });
 
+  // TODO: flakes ~1-in-3 under Vitest's default parallel file
+  // execution; deterministic with --no-file-parallelism and in
+  // isolation. Bob's `desired` tag set computes empty even though the
+  // join was just inserted — looks like cross-file DB-state
+  // interference under parallel workers. Most disciplined fix is to
+  // scope runButtondownSync's queries to a caller-supplied profile-id
+  // allowlist (also enables a "sync just this member" admin
+  // affordance). Worth a real issue once this branch is on main.
   it("PATCHes a subscribed person's tags when the managed set has drifted", async () => {
     const profileId = await makeProfile({ email: "bob@example.com" });
     const weeklyProgramId = await makeProgram({ buttondownTag: "weekly" });

--- a/tests/functional/server/buttondown-sync.test.ts
+++ b/tests/functional/server/buttondown-sync.test.ts
@@ -386,11 +386,11 @@ describe("buildSubscriberLookup", () => {
     expect(client.getSubscriber).not.toHaveBeenCalled();
 
     // Lookups consult the cached map — no further HTTP.
-    const byId = await lookup({ profileId: "p1", email: "irrelevant@example.com", buttondownSubscriberId: "sub_a" });
+    const byId = await lookup({ email: "irrelevant@example.com", buttondownSubscriberId: "sub_a" });
     expect(byId?.id).toBe("sub_a");
-    const byEmail = await lookup({ profileId: "p2", email: "beta@example.com", buttondownSubscriberId: null });
+    const byEmail = await lookup({ email: "beta@example.com", buttondownSubscriberId: null });
     expect(byEmail?.id).toBe("sub_b");
-    const missing = await lookup({ profileId: "p3", email: "nobody@example.com", buttondownSubscriberId: null });
+    const missing = await lookup({ email: "nobody@example.com", buttondownSubscriberId: null });
     expect(missing).toBeNull();
 
     expect(client.getSubscriber).not.toHaveBeenCalled();
@@ -403,7 +403,6 @@ describe("buildSubscriberLookup", () => {
     const lookup = await buildSubscriberLookup(client as never, undefined);
 
     const found = await lookup({
-      profileId: "p1",
       email: "carla@example.com",
       buttondownSubscriberId: "sub_stale_that_no_longer_exists",
     });
@@ -417,7 +416,7 @@ describe("buildSubscriberLookup", () => {
 
     expect(client.listSubscribers).not.toHaveBeenCalled();
 
-    const found = await lookup({ profileId: "p1", email: "solo@example.com", buttondownSubscriberId: "sub_only" });
+    const found = await lookup({ email: "solo@example.com", buttondownSubscriberId: "sub_only" });
     expect(found?.id).toBe("sub_only");
     // id-first, no email fallback when id resolves.
     expect(client.getSubscriber).toHaveBeenCalledTimes(1);

--- a/tests/functional/server/sync-locks.test.ts
+++ b/tests/functional/server/sync-locks.test.ts
@@ -1,3 +1,4 @@
+import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { db } from "@/server/db";
@@ -6,20 +7,27 @@ import { acquireLock, releaseLock } from "@/server/sync-locks";
 
 const LOCK_NAME = "test-lock-buttondown";
 
+// Scope every read/write to this test's lock name. Vitest runs files
+// in parallel against the shared dev DB, so concurrent routes tests
+// can have a "buttondown" lock row in flight; an unscoped query
+// counts those and breaks length assertions.
+const rowsForOurLock = () => db.select().from(syncLocks).where(eq(syncLocks.name, LOCK_NAME));
+const wipeOurLock = () => db.delete(syncLocks).where(eq(syncLocks.name, LOCK_NAME));
+
 describe("sync-locks", () => {
   beforeEach(async () => {
-    await db.delete(syncLocks);
+    await wipeOurLock();
   });
 
   afterEach(async () => {
-    await db.delete(syncLocks);
+    await wipeOurLock();
   });
 
   it("acquires when no lock exists", async () => {
     const ok = await acquireLock(LOCK_NAME, "caller-a");
     expect(ok).toBe(true);
 
-    const rows = await db.select().from(syncLocks);
+    const rows = await rowsForOurLock();
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ name: LOCK_NAME, acquiredBy: "caller-a" });
   });
@@ -28,7 +36,7 @@ describe("sync-locks", () => {
     expect(await acquireLock(LOCK_NAME, "caller-a")).toBe(true);
     expect(await acquireLock(LOCK_NAME, "caller-b")).toBe(false);
 
-    const rows = await db.select().from(syncLocks);
+    const rows = await rowsForOurLock();
     expect(rows[0].acquiredBy).toBe("caller-a");
   });
 
@@ -45,7 +53,7 @@ describe("sync-locks", () => {
     expect(await acquireLock(LOCK_NAME, "caller-a", 0)).toBe(true);
     expect(await acquireLock(LOCK_NAME, "caller-b")).toBe(true);
 
-    const rows = await db.select().from(syncLocks);
+    const rows = await rowsForOurLock();
     expect(rows[0].acquiredBy).toBe("caller-b");
   });
 
@@ -53,7 +61,7 @@ describe("sync-locks", () => {
     await acquireLock(LOCK_NAME, "caller-a");
     await releaseLock(LOCK_NAME, "caller-a");
 
-    const rows = await db.select().from(syncLocks);
+    const rows = await rowsForOurLock();
     expect(rows).toHaveLength(0);
   });
 
@@ -61,7 +69,7 @@ describe("sync-locks", () => {
     await acquireLock(LOCK_NAME, "caller-a");
     await releaseLock(LOCK_NAME, "caller-b");
 
-    const rows = await db.select().from(syncLocks);
+    const rows = await rowsForOurLock();
     expect(rows).toHaveLength(1);
     expect(rows[0].acquiredBy).toBe("caller-a");
   });

--- a/tests/functional/server/sync-locks.test.ts
+++ b/tests/functional/server/sync-locks.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { db } from "@/server/db";
+import { syncLocks } from "@/server/schema";
+import { acquireLock, releaseLock } from "@/server/sync-locks";
+
+const LOCK_NAME = "test-lock-buttondown";
+
+describe("sync-locks", () => {
+  beforeEach(async () => {
+    await db.delete(syncLocks);
+  });
+
+  afterEach(async () => {
+    await db.delete(syncLocks);
+  });
+
+  it("acquires when no lock exists", async () => {
+    const ok = await acquireLock(LOCK_NAME, "caller-a");
+    expect(ok).toBe(true);
+
+    const rows = await db.select().from(syncLocks);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ name: LOCK_NAME, acquiredBy: "caller-a" });
+  });
+
+  it("refuses a second acquire while the lease is still valid", async () => {
+    expect(await acquireLock(LOCK_NAME, "caller-a")).toBe(true);
+    expect(await acquireLock(LOCK_NAME, "caller-b")).toBe(false);
+
+    const rows = await db.select().from(syncLocks);
+    expect(rows[0].acquiredBy).toBe("caller-a");
+  });
+
+  it("refuses re-acquire from the same caller while the lease is valid", async () => {
+    expect(await acquireLock(LOCK_NAME, "caller-a")).toBe(true);
+    // Same caller, still within lease — the WHERE expired clause
+    // protects against double-acquire regardless of caller identity.
+    expect(await acquireLock(LOCK_NAME, "caller-a")).toBe(false);
+  });
+
+  it("acquires when the existing lock has expired (lease=0 forces immediate expiry)", async () => {
+    // 0ms lease — the just-acquired row is already expired by the
+    // time the next acquire attempts to read it.
+    expect(await acquireLock(LOCK_NAME, "caller-a", 0)).toBe(true);
+    expect(await acquireLock(LOCK_NAME, "caller-b")).toBe(true);
+
+    const rows = await db.select().from(syncLocks);
+    expect(rows[0].acquiredBy).toBe("caller-b");
+  });
+
+  it("releases a held lock", async () => {
+    await acquireLock(LOCK_NAME, "caller-a");
+    await releaseLock(LOCK_NAME, "caller-a");
+
+    const rows = await db.select().from(syncLocks);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("does not release when the acquired_by doesn't match", async () => {
+    await acquireLock(LOCK_NAME, "caller-a");
+    await releaseLock(LOCK_NAME, "caller-b");
+
+    const rows = await db.select().from(syncLocks);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].acquiredBy).toBe("caller-a");
+  });
+
+  it("is idempotent when no lock exists", async () => {
+    // Releasing nothing is fine — useful for finally-blocks.
+    await expect(releaseLock(LOCK_NAME, "caller-a")).resolves.toBeUndefined();
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
   "buildCommand": "if [ \"$VERCEL_ENV\" = \"production\" ]; then node scripts/migrate.mjs; fi && next build",
-  "ignoreCommand": "{ [ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] && git fetch --depth=1 \"https://github.com/$VERCEL_GIT_REPO_OWNER/$VERCEL_GIT_REPO_SLUG.git\" main && git diff --quiet FETCH_HEAD HEAD -- . ':!docs/' ':!CLAUDE.md' ; } || exit 1"
+  "ignoreCommand": "{ [ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] && git fetch --depth=1 \"https://github.com/$VERCEL_GIT_REPO_OWNER/$VERCEL_GIT_REPO_SLUG.git\" main && git diff --quiet FETCH_HEAD HEAD -- . ':!docs/' ':!CLAUDE.md' ; } || exit 1",
+  "crons": [
+    {
+      "path": "/api/cron/buttondown-sync",
+      "schedule": "0 8 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Wires the app to Buttondown so program membership keeps the newsletter audience and per-program tags in sync. Ships in dry-run by default — `BUTTONDOWN_SYNC_WRITE` gates real PATCHes — so we can land + observe before flipping the switch and retiring the legacy Apps Script.

**Architecture (see `docs/design-buttondown.md`):**
- New `sync_locks` table (lease-based concurrency) + `profiles.buttondown_subscriber_id` + `programs.buttondown_tag` (opt-in per program, NULL = skip). Migration `0010` is pure expand (new table, two nullable columns).
- `src/server/buttondown-sync.ts` — diff-only reconciler: pulls eligible profiles, computes desired tag set per profile, PATCHes Buttondown subscribers only where state diverges.
- `src/server/buttondown-runner.ts` — orchestrates lock acquire/release, retry-on-lock-held with telemetry, Sentry alarms, Axiom structured logging.
- Cron path (broad daily reconcile) + inline path (join/leave/admin-remove + first-profile-save) + admin buttons.
- `scripts/buttondown-bootstrap.ts` — one-shot cutover reconciliation with dry-run and `--write` modes.

**Observability:** HTTP-level Buttondown telemetry, `errorKind`/`durationMs` on every sync, Sentry capture for hard failures, dashboard pointers in `docs/doc-axiom.md`.

**Tests:** 5 new test files (sync, runner, routes, bootstrap, first-save, sync-locks) — full functional suite green.

## Cutover sequence

Merge does **not** start writing to Buttondown. The stage-gated rollout:

1. Merge & deploy with `BUTTONDOWN_SYNC_WRITE` unset — cron + inline run dry-run.
2. Watch a cron or two in Axiom (`message == "buttondown sync"`, `fields.action == "summary"`).
3. `npx tsx scripts/buttondown-bootstrap.ts --prod` — dry-run, eyeball every `PLAN reconcile` line.
4. `npx tsx scripts/buttondown-bootstrap.ts --prod --write` — confirm at prompt.
5. Flip `BUTTONDOWN_SYNC_WRITE=1` in Vercel.
6. Disable the legacy Apps Script.

Before merging: dispatch `prod:db:expand` so migration `0010` is applied to prod (previews share prod DB but skip migrations).

## Deferred follow-ups

- Distinguish cron-vs-inline lock-held for Sentry alerting (mitigated by retry budgets).
- Bootstrap script doesn't acquire the sync lock (mitigated by step ordering above).
- Per-profile locks instead of global `"buttondown"` (mitigated by retries + daily cron).
- Six code-review punch-list items captured in memory; none block rollout.

## Test plan

- [x] Dispatch `prod:db:expand` and confirm migration `0010` applied
- [x] Merge with `BUTTONDOWN_SYNC_WRITE` unset; verify deploy green
- [ ] Watch one daily cron in Axiom; confirm `summary.errors=0`
- [x] Trigger admin "Sync now" button; confirm dry-run log
- [x] Run bootstrap dry-run against prod; review plan
- [x] Run bootstrap with `--write`; confirm subscriber state in Buttondown
- [ ] Flip `BUTTONDOWN_SYNC_WRITE=1`; watch next cron for real PATCHes
- [ ] Disable legacy Apps Script

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@