### PR TITLE
Buttondown sync: skip create for hidden profiles

### DIFF
--- a/docs/doc-axiom.md
+++ b/docs/doc-axiom.md
@@ -28,22 +28,24 @@ No Axiom-specific env vars are needed in the app. The Vercel Log Drain integrati
 
 ## Buttondown sync — canonical queries
 
-The sync emits two message families: `"buttondown sync"` (structured events with a `fields.action`) and `"buttondown http"` (one per outbound Buttondown API call). Every event carries `fields.runId`, which for cron runs is `cron:<iso-timestamp>`, for admin runs is `admin:<profileId>:(dry-run|write)`, and for inline first-save is `first-save:<profileId>`.
+The sync emits two message families: `"buttondown sync"` (structured events with an action) and `"buttondown http"` (one per outbound Buttondown API call). The `next-axiom` package nests every structured key under a top-level `fields` object, and Axiom indexes the nested JSON as flattened column names — so the canonical queries below access them as `['fields.x']` (the whole dotted path inside one bracketed string). Every event carries `['fields.runId']`, which for cron runs is `cron:<iso-timestamp>`, for admin runs is `admin:<profileId>:(dry-run|write)`, and for inline first-save is `first-save:<profileId>`.
 
 - **Cron summary trend (run duration, counts):**
-  `["vercel"] | where ['service.name'] == "is-app" | where message == "buttondown sync" and fields.action == "summary" | summarize avg(fields.durationMs), sum(fields.errors), sum(fields.tagsUpdated) by bin_auto(_time)`
+  `["vercel"] | where ['service.name'] == "is-app" | where message == "buttondown sync" and ['fields.action'] == "summary" | summarize avg(['fields.durationMs']), sum(['fields.errors']), sum(['fields.tagsUpdated']) by bin_auto(_time)`
 - **Per-profile errors by kind:**
-  `["vercel"] | where message == "buttondown sync" and fields.action == "error" | summarize count() by fields.errorKind, bin_auto(_time)`
+  `["vercel"] | where message == "buttondown sync" and ['fields.action'] == "error" | summarize count() by ['fields.errorKind'], bin_auto(_time)`
 - **Unsubscribe alerts (operator follow-up queue):**
-  `["vercel"] | where message == "buttondown sync" and fields.action == "unsubscribe-alert"`
+  `["vercel"] | where message == "buttondown sync" and ['fields.action'] == "unsubscribe-alert"`
 - **Buttondown HTTP health (status distribution, p95 latency):**
-  `["vercel"] | where message == "buttondown http" | summarize count(), avg(fields.durationMs), percentile(fields.durationMs, 95) by fields.status, fields.path`
+  `["vercel"] | where message == "buttondown http" | summarize count(), avg(['fields.durationMs']), percentile(['fields.durationMs'], 95) by ['fields.status'], ['fields.path']`
 - **Rate-limit hits:**
-  `["vercel"] | where message == "buttondown http" and fields.status == 429`
+  `["vercel"] | where message == "buttondown http" and ['fields.status'] == 429`
 - **Dry-run vs write traffic split:**
-  `["vercel"] | where message == "buttondown sync" and fields.action == "summary" | summarize count() by fields.write`
+  `["vercel"] | where message == "buttondown sync" and ['fields.action'] == "summary" | summarize count() by ['fields.write']`
 - **Lock retry budget — how often does retry save us?**
-  `["vercel"] | where message == "buttondown sync" and fields.action == "lock-acquired" | summarize count() by fields.attempts`
+  `["vercel"] | where message == "buttondown sync" and ['fields.action'] == "lock-acquired" | summarize count() by ['fields.attempts']`
   Distribution of `attempts` across runs. `1` means no contention; `>1` means a retry succeeded. Pair with `skipped-lock-held` count (retries exhausted) to size the budget.
+- **One specific run (all events, by runId):**
+  `["vercel"] | where message == "buttondown sync" and ['fields.runId'] == "<runId>"`
 
 Sentry surfaces the page-worthy events: `buttondown.sync_profile_error` (one per failing profile, tagged with `errorKind`), `buttondown.sync_lock_held` (cron overlap), and `buttondown.unsubscribed_member` (member-with-active-program who unsubscribed). Each Sentry issue's `runId` tag links back to the Axiom query above.

--- a/src/server/buttondown-bootstrap.ts
+++ b/src/server/buttondown-bootstrap.ts
@@ -16,7 +16,7 @@
 import { and, eq, isNotNull, isNull } from "drizzle-orm";
 
 import { type ButtondownClient, type ButtondownSubscriber, isDryRunOutcome } from "./buttondown";
-import { type SubscriberLookup } from "./buttondown-sync";
+import type { SubscriberLookup } from "./buttondown-sync";
 import { db } from "./db";
 import { authUsers, profilePrograms, profiles, programs } from "./schema";
 import { leaveProgram } from "./programs";

--- a/src/server/buttondown-sync.ts
+++ b/src/server/buttondown-sync.ts
@@ -52,6 +52,16 @@ export const runFirstProfileSaveSync = async (params: {
 }): Promise<void> => {
   const { profileId, email, client } = params;
 
+  // Pull the profile's hidden flag — hidden profiles never get a
+  // Buttondown row spun up on their behalf, even if they exist in
+  // the app. (Tag updates for already-existing subscribers still run
+  // below.) One row read, fine on the first-save fast path.
+  const [profileRow] = await db
+    .select({ hidden: profiles.hidden })
+    .from(profiles)
+    .where(eq(profiles.id, profileId));
+  const hidden = profileRow?.hidden ?? false;
+
   // This profile's current tagged-program memberships — same shape
   // the daily reconciler computes but for one profile only.
   const memberships = await db
@@ -77,6 +87,7 @@ export const runFirstProfileSaveSync = async (params: {
   const subscriber = await client.getSubscriber(email);
 
   if (!subscriber) {
+    if (hidden) return;
     const result = await client.createSubscriber({
       email_address: email,
       tags: [...desiredTags, "isweb-member", "new"],
@@ -155,6 +166,7 @@ export type SyncLogEvent =
   | { action: "unsubscribe-alert"; runId: string; profileId: string; email: string; programSlugsHeld: string[] }
   | { action: "skipped-missing-email"; runId: string; profileId: string }
   | { action: "skipped-already-current"; runId: string; profileId: string; subscriberId: string }
+  | { action: "skipped-hidden-create"; runId: string; profileId: string }
   | { action: "error"; runId: string; profileId: string; message: string; errorKind: SyncErrorKind };
 
 export type SyncLogger = (event: SyncLogEvent) => void;
@@ -176,6 +188,10 @@ export type SyncRunSummary = {
   unchanged: number;
   unsubscribeAlerts: number;
   missingProfileEmail: number;
+  // Hidden profiles with no existing Buttondown subscriber that the
+  // sync would otherwise have created. Tag updates still flow for
+  // hidden profiles that already have a subscriber row.
+  skippedHiddenCreate: number;
   errors: number;
   // Wall-clock duration of the run, from entry to summary emission.
   // Use for the "is this cron getting slower?" trend in Axiom.
@@ -201,6 +217,10 @@ type ProfileRow = {
   profileId: string;
   email: string | null;
   buttondownSubscriberId: string | null;
+  // Hidden profiles are app-only — test accounts, scrubbed members.
+  // The sync suppresses CREATE for them (no new Buttondown row), but
+  // still reconciles tags if a subscriber already exists.
+  hidden: boolean;
 };
 
 type ProfileMembership = {
@@ -275,6 +295,7 @@ const loadEligibleProfiles = async (scopeProfileIds?: string[]): Promise<Profile
       profileId: profiles.id,
       email: authUsers.email,
       buttondownSubscriberId: profiles.buttondownSubscriberId,
+      hidden: profiles.hidden,
     })
     .from(profiles)
     .innerJoin(authUsers, eq(authUsers.id, profiles.id))
@@ -400,6 +421,7 @@ export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary>
     unchanged: 0,
     unsubscribeAlerts: 0,
     missingProfileEmail: 0,
+    skippedHiddenCreate: 0,
     errors: 0,
     durationMs: 0,
   };
@@ -506,6 +528,14 @@ const syncOneProfile = async (args: SyncOneProfileArgs): Promise<void> => {
   const subscriber = await lookup(profile);
 
   if (!subscriber) {
+    if (profile.hidden) {
+      // Hidden profiles are app-only (test accounts, scrubbed
+      // members). Don't seed Buttondown with them. If a subscriber
+      // ever exists for one, the update branches below still run.
+      summary.skippedHiddenCreate++;
+      log({ action: "skipped-hidden-create", runId, profileId });
+      return;
+    }
     // Catch-up create: this is the path that runs when the inline
     // first-save hook failed (or hasn't shipped yet). Tag with the
     // managed set + isweb-member + new.

--- a/tests/functional/server/buttondown-first-save.test.ts
+++ b/tests/functional/server/buttondown-first-save.test.ts
@@ -11,7 +11,7 @@ import { createFakeButtondownClient } from "./buttondown-fake";
 
 const insertUserAndProfile = async (
   id: string,
-  opts: { email?: string; buttondownSubscriberId?: string | null; saved?: boolean } = {},
+  opts: { email?: string; buttondownSubscriberId?: string | null; saved?: boolean; hidden?: boolean } = {},
 ) => {
   const email = opts.email ?? `${id}@testfake.local`;
   await db.execute(
@@ -21,6 +21,7 @@ const insertUserAndProfile = async (
     id,
     lastUpdatedProfile: opts.saved === false ? null : new Date(),
     buttondownSubscriberId: opts.buttondownSubscriberId ?? null,
+    hidden: opts.hidden ?? false,
   });
 };
 
@@ -192,5 +193,41 @@ describe("runFirstProfileSaveSync (inline hook)", () => {
       .from(profiles)
       .where(eq(profiles.id, profileId));
     expect(row.buttondownSubscriberId).toBeNull();
+  });
+
+  it("skips the create entirely for a hidden profile with no existing subscriber", async () => {
+    const profileId = await makeProfile({ email: "fs-frank@example.com", hidden: true });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await db.insert(profilePrograms).values({ profileId, programId });
+
+    const client = createFakeButtondownClient({ write: true });
+
+    await runFirstProfileSaveSync({ profileId, email: "fs-frank@example.com", client });
+
+    expect(client.effects).toHaveLength(0);
+    const [row] = await db
+      .select({ buttondownSubscriberId: profiles.buttondownSubscriberId })
+      .from(profiles)
+      .where(eq(profiles.id, profileId));
+    expect(row.buttondownSubscriberId).toBeNull();
+  });
+
+  it("still PATCHes tags for a hidden profile whose subscriber already exists", async () => {
+    const profileId = await makeProfile({ email: "fs-gina@example.com", hidden: true });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await db.insert(profilePrograms).values({ profileId, programId });
+
+    const initial: ButtondownSubscriber = {
+      id: "sub_gina",
+      email_address: "fs-gina@example.com",
+      type: "regular",
+      tags: ["legacy-active"],
+    };
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    await runFirstProfileSaveSync({ profileId, email: "fs-gina@example.com", client });
+
+    const after = await client.getSubscriber("sub_gina");
+    expect(after?.tags).toEqual(["isweb-member", "returning", "weekly"]);
   });
 });

--- a/tests/functional/server/buttondown-sync.test.ts
+++ b/tests/functional/server/buttondown-sync.test.ts
@@ -23,7 +23,13 @@ import { createFakeButtondownClient, type FakeButtondownEffect } from "./buttond
 
 const insertUserAndProfile = async (
   id: string,
-  opts: { displayName?: string; saved?: boolean; buttondownSubscriberId?: string | null; email?: string } = {},
+  opts: {
+    displayName?: string;
+    saved?: boolean;
+    buttondownSubscriberId?: string | null;
+    email?: string;
+    hidden?: boolean;
+  } = {},
 ) => {
   const email = opts.email ?? `${id}@testfake.local`;
   await db.execute(
@@ -34,6 +40,7 @@ const insertUserAndProfile = async (
     displayName: opts.displayName ?? null,
     lastUpdatedProfile: opts.saved === false ? null : new Date(),
     buttondownSubscriberId: opts.buttondownSubscriberId ?? null,
+    hidden: opts.hidden ?? false,
   });
 };
 
@@ -336,6 +343,59 @@ describe("runButtondownSync (daily reconciler)", () => {
       input: { tags: ["isweb-member", "new"] },
     });
     expect(profileId).toBeTruthy();
+  });
+
+  it("skips create for a hidden profile not yet in Buttondown", async () => {
+    const profileId = await makeProfile({ email: "kelvin@example.com", hidden: true });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    const client = createFakeButtondownClient({ write: true });
+    const { log, events } = collectingLogger();
+
+    const summary = await runButtondownSync({
+      client,
+      runId: "r-hidden-create",
+      write: true,
+      log,
+      scopeProfileIds: [profileId],
+    });
+
+    expect(effectsForEmail(client.effects, "kelvin@example.com")).toHaveLength(0);
+    expect(summary.created).toBe(0);
+    expect(summary.skippedHiddenCreate).toBe(1);
+    expect(
+      events.find((e) => e.action === "skipped-hidden-create" && e.profileId === profileId),
+    ).toBeDefined();
+  });
+
+  it("still PATCHes tags for a hidden profile that already has a Buttondown subscriber", async () => {
+    const profileId = await makeProfile({
+      email: "leo@example.com",
+      hidden: true,
+      buttondownSubscriberId: "sub_leo",
+    });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    const initial = sampleSubscriber({
+      id: "sub_leo",
+      email_address: "leo@example.com",
+      tags: ["isweb-member"],
+    });
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    const summary = await runButtondownSync({
+      client,
+      runId: "r-hidden-update",
+      write: true,
+      scopeProfileIds: [profileId],
+    });
+
+    const updated = await client.getSubscriber("sub_leo");
+    expect(updated?.tags.sort()).toEqual(["isweb-member", "weekly"]);
+    expect(summary.tagsUpdated).toBe(1);
+    expect(summary.skippedHiddenCreate).toBe(0);
   });
 });
 


### PR DESCRIPTION
@
## Summary

Hidden profiles are app-only — test accounts, scrubbed members — and shouldn't end up in Buttondown's audience. The sync now suppresses the CREATE path for them.

Hidden profiles that *already* have a Buttondown subscriber still flow through tag updates (so a profile flipped to hidden after the fact keeps its tags reconciled).

**Coverage:**
- Broad daily cron (`runButtondownSync`)
- Admin "Sync now" buttons (same runner)
- Per-profile inline resync on join/leave/admin-remove (scoped variant of the same runner)
- Inline first-profile-save hook (`runFirstProfileSaveSync`)
- Bootstrap script already skips members not in Buttondown via `planBootstrap` → `skip-missing-subscriber`; no change needed there.

**Observability:**
- New `skippedHiddenCreate` counter on `SyncRunSummary`
- New `skipped-hidden-create` log action per skipped profile

**Bundled cleanup (second commit):**
- `docs/doc-axiom.md` — `fields.x` → `[fields.x]` everywhere; APL treats `fields` as a reserved word so the unbracketed form errors. Discovered while watching today's admin "Sync now" run in Axiom.
- `src/server/buttondown-bootstrap.ts` — hoist the lone type-only import to `import type { ... }` so Biome's `useImportType` is quiet.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:functional` (320 tests, +4 new)
- [x] `npm run test:e2e`
- [x] Confirm preview deploy green
- [x] Merge & verify next admin "Sync now" dry-run skips the two hidden test profiles (`ecb183c8…`, `25e1f862…`) — `summary.created` should drop to 0, `summary.skippedHiddenCreate` should be 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@