### PR TITLE
feat: redesign sign-in form with explicit email/password mode toggle

### DIFF
--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -36,7 +36,7 @@ export default async function SigninPage({ searchParams }: SigninPageProps) {
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
       <AppWordmark asLink />
       <p className="max-w-sm text-center text-base text-muted-foreground">
-        Receive a sign-in link by email, or sign in with your password if you've set one.
+        Enter your email and we'll send you a sign-in link.
       </p>
       {process.env.NODE_ENV === "development" && (
         <p className="max-w-sm rounded border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
@@ -57,11 +57,6 @@ export default async function SigninPage({ searchParams }: SigninPageProps) {
         </p>
       )}
       <SigninForm />
-      <p className="text-base text-muted-foreground">
-        <Link href="/forgot-password" className="underline text-muted-foreground hover:text-foreground">
-          Forgot your password?
-        </Link>
-      </p>
       <p className="text-base text-muted-foreground">
         Have an invite code?{" "}
         <Link href="/signup" className="underline text-muted-foreground hover:text-foreground">

--- a/src/app/signin/signin-form.tsx
+++ b/src/app/signin/signin-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -10,11 +11,12 @@ import { createClient } from "@/lib/supabase/client";
 
 const RESEND_COOLDOWN_SECONDS = 60;
 
+type Mode = "email" | "password";
+
 type FormState =
   | { status: "idle" }
   | { status: "submitting" }
   | { status: "sent"; email: string }
-  | { status: "resending" }
   | { status: "error"; message: string };
 
 function SentView({ email, origin }: { email: string; origin: string }) {
@@ -70,7 +72,20 @@ export function SigninForm() {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [mode, setMode] = useState<Mode>("email");
   const [state, setState] = useState<FormState>({ status: "idle" });
+  const passwordRef = useRef<HTMLInputElement>(null);
+
+  const switchToPassword = () => {
+    setMode("password");
+    setTimeout(() => passwordRef.current?.focus(), 0);
+  };
+
+  const switchToEmail = () => {
+    setMode("email");
+    setPassword("");
+    setState({ status: "idle" });
+  };
 
   const handleSubmit = async (event: React.SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -78,15 +93,11 @@ export function SigninForm() {
 
     const supabase = createClient();
 
-    if (password.length > 0) {
-      const { error } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-      });
+    if (mode === "password") {
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
       if (error) {
         // No fallback to the email sign-in link — a failed password means the
-        // member mistyped it; falling through silently would be
-        // confusing. They can clear the field and resubmit.
+        // member mistyped it; falling through silently would be confusing.
         setState({ status: "error", message: error.message });
         return;
       }
@@ -145,26 +156,43 @@ export function SigninForm() {
         onChange={(event) => setEmail(event.target.value)}
         disabled={state.status === "submitting"}
       />
-      <Label htmlFor="password">Password (optional)</Label>
-      <Input
-        id="password"
-        type="password"
-        autoComplete="current-password"
-        placeholder="Leave blank to receive a sign-in link by email"
-        value={password}
-        onChange={(event) => setPassword(event.target.value)}
-        disabled={state.status === "submitting"}
-      />
-      <p className="text-sm text-muted-foreground">Only needed if you've previously set one.</p>
-      <Button type="submit" disabled={state.status === "submitting"}>
+
+      {mode === "password" && (
+        <>
+          <Label htmlFor="password">Password</Label>
+          <Input
+            ref={passwordRef}
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            disabled={state.status === "submitting"}
+          />
+          <p className="text-sm text-muted-foreground">
+            <Link href="/forgot-password" className="underline hover:text-foreground">
+              Forgot your password?
+            </Link>
+          </p>
+        </>
+      )}
+
+      <Button type="submit" variant="secondary" disabled={state.status === "submitting"}>
         {state.status === "submitting"
-          ? password.length > 0
-            ? "Signing in…"
-            : "Sending…"
-          : password.length > 0
-            ? "Sign in"
-            : "Send sign-in link"}
+          ? mode === "password" ? "Signing in…" : "Sending…"
+          : mode === "password" ? "Sign in" : "Send sign-in link"}
       </Button>
+
+      {mode === "email" ? (
+        <Button type="button" variant="ghost" onClick={switchToPassword}>
+          Sign in with password instead
+        </Button>
+      ) : (
+        <Button type="button" variant="ghost" onClick={switchToEmail}>
+          Use email link instead
+        </Button>
+      )}
+
       {state.status === "error" && (
         <p role="alert" className="text-base text-destructive">
           {state.message}

--- a/tests/e2e/helpers/session.ts
+++ b/tests/e2e/helpers/session.ts
@@ -39,8 +39,11 @@ export const signInAs = async (page: Page, role: TestRole): Promise<TestUser> =>
   const email = EMAILS[role];
   await page.goto("/signin");
   await page.getByLabel("Email").fill(email);
-  await page.getByLabel("Password (optional)").fill(passwordFor(role));
-  await page.getByRole("button", { name: "Sign in" }).click();
+  // Signin form defaults to email-link mode; switch to password mode
+  // before the seeded password field is rendered.
+  await page.getByRole("button", { name: "Sign in with password instead" }).click();
+  await page.getByLabel("Password", { exact: true }).fill(passwordFor(role));
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
   await page.waitForURL((url) => !url.pathname.startsWith("/signin"), {
     timeout: TIMEOUT_MS,
   });

--- a/tests/e2e/password-reset.spec.ts
+++ b/tests/e2e/password-reset.spec.ts
@@ -12,6 +12,9 @@ const SUPABASE_AUTH = "**/auth/v1/**";
 
 test('"Forgot your password?" navigates to /forgot-password and back', async ({ page }) => {
   await page.goto("/signin");
+  // The forgot-password link only renders in the password mode of the
+  // sign-in form; default mode is email-link with no link visible.
+  await page.getByRole("button", { name: "Sign in with password instead" }).click();
   await page.getByRole("link", { name: "Forgot your password?" }).click();
 
   await expect(page).toHaveURL(/\/forgot-password$/);

--- a/tests/e2e/signin-password.spec.ts
+++ b/tests/e2e/signin-password.spec.ts
@@ -35,8 +35,9 @@ test("password provided → signInWithPassword is called", async ({ page }) => {
 
   await page.goto("/signin");
   await page.getByLabel("Email").fill("member@example.test");
-  await page.getByLabel("Password (optional)").fill("hunter2");
-  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.getByRole("button", { name: "Sign in with password instead" }).click();
+  await page.getByLabel("Password", { exact: true }).fill("hunter2");
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
 
   // Next.js renders a hidden route-announcer with role="alert" too, so
   // we target our error message by text rather than by role.


### PR DESCRIPTION
## Summary

- Replace the always-visible optional password field with a two-mode toggle: email link (default) and password (user-initiated)
- Password field only renders when in password mode — keeps autofill / password managers working correctly
- "Forgot your password?" link moves from the page footer into the form, contextually below the password field
- Primary CTA uses `variant="secondary"` (filled teal); mode switch uses `variant="ghost"` for clear visual hierarchy
- Page subtitle simplified to "Enter your email and we'll send you a sign-in link." to match default mode

## Test plan

- [ ] Default state: only email field + "Send sign-in link" (teal) + "Sign in with password instead" (ghost) visible
- [ ] Click "Sign in with password instead": password field appears, focus moves to it, button becomes "Sign in"
- [ ] "Forgot your password?" link appears below password field only in password mode
- [ ] Click "Use email link instead": reverts to email mode, password field hidden, error cleared
- [ ] Password autofill works (field not in DOM until needed)
- [ ] Submitting with email only sends OTP link; submitting with password signs in directly

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)