### PR TITLE
Refuse Buttondown calls for RFC-reserved test TLDs

### DIFF
--- a/src/server/buttondown-sync.ts
+++ b/src/server/buttondown-sync.ts
@@ -20,6 +20,7 @@ import {
   ButtondownApiError,
   type ButtondownSubscriber,
   isDryRunOutcome,
+  isReservedTestEmail,
   type UpdateSubscriberInput,
 } from "./buttondown";
 import { db } from "./db";
@@ -51,6 +52,12 @@ export const runFirstProfileSaveSync = async (params: {
   raiseUnsubscribeAlert?: (alert: UnsubscribeAlert) => void;
 }): Promise<void> => {
   const { profileId, email, client } = params;
+
+  // RFC-reserved TLDs (.local, .test, etc.) can never be real email
+  // addresses — see isReservedTestEmail. Bail before any client call
+  // so test users that somehow reach a prod-keyed runner are silently
+  // dropped instead of generating Buttondown 404s.
+  if (isReservedTestEmail(email)) return;
 
   // Pull the profile's hidden flag — hidden profiles never get a
   // Buttondown row spun up on their behalf, even if they exist in
@@ -167,6 +174,7 @@ export type SyncLogEvent =
   | { action: "skipped-missing-email"; runId: string; profileId: string }
   | { action: "skipped-already-current"; runId: string; profileId: string; subscriberId: string }
   | { action: "skipped-hidden-create"; runId: string; profileId: string }
+  | { action: "skipped-reserved-email"; runId: string; profileId: string; email: string }
   | { action: "error"; runId: string; profileId: string; message: string; errorKind: SyncErrorKind };
 
 export type SyncLogger = (event: SyncLogEvent) => void;
@@ -192,6 +200,11 @@ export type SyncRunSummary = {
   // sync would otherwise have created. Tag updates still flow for
   // hidden profiles that already have a subscriber row.
   skippedHiddenCreate: number;
+  // Profiles whose email ends in an RFC-reserved TLD (.local, .test,
+  // .invalid, .example, .localhost). These can't be real members; the
+  // sync drops them before any client call. Should normally be 0 — a
+  // non-zero count in prod means a test user reached prod somehow.
+  skippedReservedEmail: number;
   errors: number;
   // Wall-clock duration of the run, from entry to summary emission.
   // Use for the "is this cron getting slower?" trend in Axiom.
@@ -422,6 +435,7 @@ export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary>
     unsubscribeAlerts: 0,
     missingProfileEmail: 0,
     skippedHiddenCreate: 0,
+    skippedReservedEmail: 0,
     errors: 0,
     durationMs: 0,
   };
@@ -520,6 +534,15 @@ const syncOneProfile = async (args: SyncOneProfileArgs): Promise<void> => {
     return;
   }
   const email = profile.email;
+
+  // Reserved-TLD guard: skip before any client call. The client also
+  // refuses these at the wire, so this layer is mainly so the summary
+  // surfaces "we saw N test users" instead of N thrown errors.
+  if (isReservedTestEmail(email)) {
+    summary.skippedReservedEmail++;
+    log({ action: "skipped-reserved-email", runId, profileId, email });
+    return;
+  }
 
   // Prefer id-based lookup (stable across email changes); falls back
   // to email for profiles we haven't seen before. In the broad path

--- a/src/server/buttondown.ts
+++ b/src/server/buttondown.ts
@@ -18,6 +18,25 @@
 
 const BUTTONDOWN_BASE_URL = "https://api.buttondown.com/v1";
 
+// RFC 6761 reserves `.test`, `.example`, `.invalid`, `.localhost` for
+// non-routable use; RFC 6762 reserves `.local` for multicast DNS. None
+// of these can be the right-hand side of a real, deliverable email
+// address — so an input matching them is, by construction, a test
+// fixture that must never reach Buttondown. Defense in depth on top
+// of the env-key + workflow-trigger gates: the client refuses these
+// at the wire, and the sync skips them per-profile.
+const RESERVED_EMAIL_TLDS = [".local", ".test", ".invalid", ".example", ".localhost"];
+
+export const isReservedTestEmail = (input: string): boolean => {
+  const at = input.lastIndexOf("@");
+  // No `@` means the input is a subscriber id, not an email — the
+  // getSubscriber overload accepts both. Real Buttondown ids never
+  // end in a reserved TLD, so passthrough is safe.
+  if (at < 0) return false;
+  const host = input.slice(at + 1).toLowerCase();
+  return RESERVED_EMAIL_TLDS.some((tld) => host === tld.slice(1) || host.endsWith(tld));
+};
+
 // Lifecycle state of a Buttondown subscriber: regular (active),
 // premium (paid), unactivated (pending confirmation), unsubscribed,
 // removed.
@@ -285,6 +304,9 @@ export const createButtondownClient = (config: ButtondownClientConfig): Buttondo
     },
 
     async getSubscriber(idOrEmail) {
+      if (isReservedTestEmail(idOrEmail)) {
+        throw new ButtondownApiError(0, `Refusing to query reserved-TLD email: ${idOrEmail}`);
+      }
       // The endpoint accepts either id or email at the same slot; we
       // URL-encode either way so the "+" and "/" that can appear in
       // emails don't break routing.
@@ -298,6 +320,9 @@ export const createButtondownClient = (config: ButtondownClientConfig): Buttondo
     },
 
     async createSubscriber(input) {
+      if (isReservedTestEmail(input.email_address)) {
+        throw new ButtondownApiError(0, `Refusing to create reserved-TLD email: ${input.email_address}`);
+      }
       if (!config.write) {
         return { dryRun: true, intent: "create", payload: input };
       }
@@ -311,6 +336,9 @@ export const createButtondownClient = (config: ButtondownClientConfig): Buttondo
     },
 
     async updateSubscriber(id, patch) {
+      if (patch.email_address !== undefined && isReservedTestEmail(patch.email_address)) {
+        throw new ButtondownApiError(0, `Refusing to set reserved-TLD email: ${patch.email_address}`);
+      }
       if (!config.write) {
         return { dryRun: true, intent: "update", payload: { id, patch } };
       }

--- a/tests/functional/server/buttondown-first-save.test.ts
+++ b/tests/functional/server/buttondown-first-save.test.ts
@@ -230,4 +230,25 @@ describe("runFirstProfileSaveSync (inline hook)", () => {
     const after = await client.getSubscriber("sub_gina");
     expect(after?.tags).toEqual(["isweb-member", "returning", "weekly"]);
   });
+
+  // Defense in depth against an E2E or fixture user reaching this
+  // hook in a prod-keyed environment. The hook must not call into the
+  // client for a reserved-TLD email — no mutations, no recorded id.
+  it("skips entirely when the email ends in a reserved TLD", async () => {
+    const profileId = await makeProfile({ email: "fs-test@testfake.local" });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await db.insert(profilePrograms).values({ profileId, programId });
+
+    const client = createFakeButtondownClient({ write: true });
+
+    await runFirstProfileSaveSync({ profileId, email: "fs-test@testfake.local", client });
+
+    expect(client.effects).toHaveLength(0);
+    expect(client.subscribers.size).toBe(0);
+    const [row] = await db
+      .select({ buttondownSubscriberId: profiles.buttondownSubscriberId })
+      .from(profiles)
+      .where(eq(profiles.id, profileId));
+    expect(row.buttondownSubscriberId).toBeNull();
+  });
 });

--- a/tests/functional/server/buttondown-routes.test.ts
+++ b/tests/functional/server/buttondown-routes.test.ts
@@ -185,7 +185,7 @@ describe("Buttondown sync routes", () => {
       programId = randomUUID();
       await db.execute(
         sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous)
-            VALUES (${memberId}::uuid, ${`${memberId}@testfake.local`}, false, false)`,
+            VALUES (${memberId}::uuid, ${`${memberId}@example.com`}, false, false)`,
       );
       // lastUpdatedProfile is what the sync's loadEligibleProfiles
       // filters on — without it the resync is a no-op.
@@ -210,7 +210,7 @@ describe("Buttondown sync routes", () => {
         if (url.endsWith("/v1/subscribers")) {
           return buttondownResponse(201, {
             id: "sub_test",
-            email_address: `${memberId}@testfake.local`,
+            email_address: `${memberId}@example.com`,
             type: "regular",
             tags: ["weekly", "isweb-member", "new"],
           });

--- a/tests/functional/server/buttondown-sync.test.ts
+++ b/tests/functional/server/buttondown-sync.test.ts
@@ -369,6 +369,36 @@ describe("runButtondownSync (daily reconciler)", () => {
     ).toBeDefined();
   });
 
+  // Defense in depth against an E2E or fixture user that somehow has
+  // a saved profile in prod. The reconciler must skip these before
+  // any client call and surface them in the summary.
+  it("skips a profile whose email ends in a reserved TLD", async () => {
+    const profileId = await makeProfile({ email: "sweep-test@testfake.local" });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    const client = createFakeButtondownClient({ write: true });
+    const { events, log } = collectingLogger();
+
+    const summary = await runButtondownSync({
+      client,
+      runId: "r-reserved",
+      write: true,
+      scopeProfileIds: [profileId],
+      log,
+    });
+
+    expect(client.effects).toHaveLength(0);
+    expect(summary.skippedReservedEmail).toBe(1);
+    expect(summary.created).toBe(0);
+    expect(events).toContainEqual({
+      action: "skipped-reserved-email",
+      runId: "r-reserved",
+      profileId,
+      email: "sweep-test@testfake.local",
+    });
+  });
+
   it("still PATCHes tags for a hidden profile that already has a Buttondown subscriber", async () => {
     const profileId = await makeProfile({
       email: "leo@example.com",

--- a/tests/functional/server/buttondown.test.ts
+++ b/tests/functional/server/buttondown.test.ts
@@ -7,6 +7,7 @@ import {
   type ButtondownSubscriber,
   createButtondownClient,
   isDryRunOutcome,
+  isReservedTestEmail,
 } from "@/server/buttondown";
 
 import { createFakeButtondownClient } from "./buttondown-fake";
@@ -346,6 +347,93 @@ describe("createButtondownClient", () => {
       const client = createButtondownClient({ apiKey: "k", write: true, fetcher });
       await expect(client.getAccount()).rejects.toBeInstanceOf(ButtondownApiError);
     });
+  });
+
+  // Wire-level guard against ever hitting Buttondown with a test
+  // fixture email. RFC 6761 reserves .test/.example/.invalid/.localhost
+  // and RFC 6762 reserves .local — none can be a real deliverable
+  // address. The sync layer also filters these before reaching the
+  // client; this is the belt-and-suspenders layer for a future caller
+  // that bypasses the sync.
+  describe("reserved-TLD wire guard", () => {
+    it("getSubscriber refuses an email ending in .local without calling fetch", async () => {
+      const fetcher = mockFetch(200, sampleSubscriber);
+      const client = createButtondownClient({ apiKey: "k", write: true, fetcher });
+      await expect(client.getSubscriber("e2e-regular@testfake.local")).rejects.toBeInstanceOf(ButtondownApiError);
+      expect(fetcher).not.toHaveBeenCalled();
+    });
+
+    it("createSubscriber refuses a reserved-TLD email without calling fetch", async () => {
+      const fetcher = mockFetch(201, sampleSubscriber);
+      const client = createButtondownClient({ apiKey: "k", write: true, fetcher });
+      await expect(
+        client.createSubscriber({ email_address: "x@example.test", tags: [] }),
+      ).rejects.toBeInstanceOf(ButtondownApiError);
+      expect(fetcher).not.toHaveBeenCalled();
+    });
+
+    it("updateSubscriber refuses an email patch with a reserved TLD without calling fetch", async () => {
+      const fetcher = mockFetch(200, sampleSubscriber);
+      const client = createButtondownClient({ apiKey: "k", write: true, fetcher });
+      await expect(
+        client.updateSubscriber("sub_abc123", { email_address: "x@some.invalid" }),
+      ).rejects.toBeInstanceOf(ButtondownApiError);
+      expect(fetcher).not.toHaveBeenCalled();
+    });
+
+    it("updateSubscriber with a tags-only patch is unaffected by the guard", async () => {
+      const fetcher = mockFetch(200, sampleSubscriber);
+      const client = createButtondownClient({ apiKey: "k", write: true, fetcher });
+      await client.updateSubscriber("sub_abc123", { tags: ["weekly"] });
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it("getSubscriber with a bare subscriber id passes the guard", async () => {
+      // Real subscriber ids contain no `@`, so the helper bails out
+      // before checking the TLD. Verifies we don't accidentally block
+      // id-keyed lookups.
+      const fetcher = mockFetch(200, sampleSubscriber);
+      const client = createButtondownClient({ apiKey: "k", write: true, fetcher });
+      await client.getSubscriber("sub_abc123");
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("isReservedTestEmail", () => {
+  it("returns true for each RFC-reserved TLD", () => {
+    expect(isReservedTestEmail("a@b.local")).toBe(true);
+    expect(isReservedTestEmail("a@b.test")).toBe(true);
+    expect(isReservedTestEmail("a@b.invalid")).toBe(true);
+    expect(isReservedTestEmail("a@b.example")).toBe(true);
+    expect(isReservedTestEmail("a@localhost")).toBe(true);
+  });
+
+  it("is case-insensitive on the host portion", () => {
+    expect(isReservedTestEmail("a@FOO.LOCAL")).toBe(true);
+    expect(isReservedTestEmail("a@foo.Test")).toBe(true);
+  });
+
+  it("matches multi-label hosts that end in a reserved TLD", () => {
+    expect(isReservedTestEmail("a@deep.sub.testfake.local")).toBe(true);
+  });
+
+  it("returns false for production-shaped addresses", () => {
+    expect(isReservedTestEmail("alice@example.com")).toBe(false);
+    expect(isReservedTestEmail("alice@gmail.com")).toBe(false);
+    expect(isReservedTestEmail("alice@intentionalsociety.org")).toBe(false);
+  });
+
+  it("does not match when the reserved TLD appears mid-label", () => {
+    // The host is `not-local.com`, which ends in `.com`, not `.local`.
+    expect(isReservedTestEmail("a@not-local.com")).toBe(false);
+  });
+
+  it("returns false for inputs with no `@` (subscriber ids)", () => {
+    expect(isReservedTestEmail("sub_abc123")).toBe(false);
+    // Even an id that contains a reserved-TLD-like substring stays a
+    // passthrough — the helper only looks past the last `@`.
+    expect(isReservedTestEmail("sub-test")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Defense in depth for the Buttondown integration: refuses any client call (`getSubscriber`, `createSubscriber`, `updateSubscriber`) whose input email ends in an RFC-reserved TLD (`.local`, `.test`, `.invalid`, `.example`, `.localhost`).
- The sync core also skips matching profiles before any client call, with a new `skippedReservedEmail` counter on the run summary and a `skipped-reserved-email` log event for Axiom visibility.
- Sits on top of the existing prod-only locks (`BUTTONDOWN_API_KEY` scope, `BUTTONDOWN_SYNC_WRITE` toggle, workflow trigger). Even if a test user reaches a prod-keyed runner, no Buttondown call is made.

## Motivation

E2E tests sign in as `e2e-regular@testfake.local` and `e2e-admin@testfake.local`. `.github/workflows/e2e.yml` currently fires on both Preview and Production deployment statuses, so every merge to `main` runs Playwright against `app.intentionalsociety.org` with production env vars. The inline first-save hook then issues `GET /v1/subscribers/e2e-regular@testfake.local` against the real audience newsletter — visible as a string of 404s in Buttondown's logs. No mutations occurred (`BUTTONDOWN_SYNC_WRITE` is unset), but reads against the real audience are still noise we'd rather not produce, and the lock would silently break if write were ever enabled.

This change adds an email-shape guard that's independent of any env var, so a `.local`/`.test`/`.invalid`/`.example`/`.localhost` email can never reach Buttondown.

## Test plan

- [x] `npm run test:functional` — 328 passed (5 new Buttondown cases)
- [x] `npm test` (full suite incl. Playwright) — 328 functional + 25 E2E, all green
- [x] `npm run lint`, `npx tsc --noEmit` — clean
- [ ] After merge: Buttondown logs no longer show GETs on `e2e-*@testfake.local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)