### PR TITLE
fix: Buttondown cron handler must be GET, not POST

### DIFF
--- a/docs/design-buttondown.md
+++ b/docs/design-buttondown.md
@@ -89,7 +89,7 @@ This path exists only to shorten the new-member time-to-first-email. It is a lat
 
 ### 2. Daily reconciler (Vercel cron)
 
-`POST /api/cron/buttondown-sync`, scheduled daily at **08:00 UTC** via `vercel.json` `crons`, gated by a `CRON_SECRET` bearer check. Acquires the [sync concurrency lock](#concurrency-lock) before doing any work and releases it at the end.
+`GET /api/cron/buttondown-sync`, scheduled daily at **08:00 UTC** via `vercel.json` `crons`, gated by a `CRON_SECRET` bearer check. (Vercel cron invokes endpoints via HTTP GET.) Acquires the [sync concurrency lock](#concurrency-lock) before doing any work and releases it at the end.
 
 For each profile where `lastUpdatedProfile IS NOT NULL`:
 
@@ -205,7 +205,7 @@ All expand-step migrations (see `strategy-committing.md`): land the columns and 
 ## Endpoint shape
 
 ```
-POST /api/cron/buttondown-sync
+GET /api/cron/buttondown-sync
 Authorization: Bearer ${CRON_SECRET}
 
 → 200 { scanned: 47, created: 2, tagged: 5, untagged: 1, unsubscribe_alerts: 3, email_updates: 0, errors: [] }

--- a/docs/doc-axiom.md
+++ b/docs/doc-axiom.md
@@ -31,7 +31,7 @@ No Axiom-specific env vars are needed in the app. The Vercel Log Drain integrati
 The sync emits two message families: `"buttondown sync"` (structured events with an action) and `"buttondown http"` (one per outbound Buttondown API call). The `next-axiom` package nests every structured key under a top-level `fields` object, and Axiom indexes the nested JSON as flattened column names — so the canonical queries below access them as `['fields.x']` (the whole dotted path inside one bracketed string). Every event carries `['fields.runId']`, which for cron runs is `cron:<iso-timestamp>`, for admin runs is `admin:<profileId>:(dry-run|write)`, and for inline first-save is `first-save:<profileId>`.
 
 - **Cron summary trend (run duration, counts):**
-  `["vercel"] | where ['service.name'] == "is-app" | where message == "buttondown sync" and ['fields.action'] == "summary" | summarize avg(['fields.durationMs']), sum(['fields.errors']), sum(['fields.tagsUpdated']) by bin_auto(_time)`
+  `["vercel"] | where message == "buttondown sync" and ['fields.action'] == "summary" | summarize avg(['fields.durationMs']), sum(['fields.errors']), sum(['fields.tagsUpdated']) by bin_auto(_time)`
 - **Per-profile errors by kind:**
   `["vercel"] | where message == "buttondown sync" and ['fields.action'] == "error" | summarize count() by ['fields.errorKind'], bin_auto(_time)`
 - **Unsubscribe alerts (operator follow-up queue):**

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -693,7 +693,8 @@ api.post("/_test/reset", async (c) => {
 // else with 401. The write toggle is BUTTONDOWN_SYNC_WRITE=1 — the
 // design's "Prod-only by construction" lock #4. Unset (the default)
 // means dry-run; set means writes go through.
-api.post("/cron/buttondown-sync", async (c) => {
+// GET because Vercel cron invokes endpoints via HTTP GET.
+api.get("/cron/buttondown-sync", async (c) => {
   const provided = c.req.header("authorization");
   const cronSecret = process.env.CRON_SECRET;
   if (!cronSecret || provided !== `Bearer ${cronSecret}`) {

--- a/tests/functional/server/buttondown-routes.test.ts
+++ b/tests/functional/server/buttondown-routes.test.ts
@@ -86,17 +86,17 @@ describe("Buttondown sync routes", () => {
     await db.delete(syncLocks);
   });
 
-  describe("POST /api/cron/buttondown-sync", () => {
+  describe("GET /api/cron/buttondown-sync", () => {
     it("rejects with 401 when no Authorization header", async () => {
       process.env.CRON_SECRET = "secret-abc";
-      const res = await app.request("/api/cron/buttondown-sync", { method: "POST" });
+      const res = await app.request("/api/cron/buttondown-sync", { method: "GET" });
       expect(res.status).toBe(401);
     });
 
     it("rejects with 401 when the bearer does not match CRON_SECRET", async () => {
       process.env.CRON_SECRET = "secret-abc";
       const res = await app.request("/api/cron/buttondown-sync", {
-        method: "POST",
+        method: "GET",
         headers: { authorization: "Bearer wrong-token" },
       });
       expect(res.status).toBe(401);
@@ -107,7 +107,7 @@ describe("Buttondown sync routes", () => {
       // header should be rejected if the server has no secret set,
       // otherwise the cron is effectively public.
       const res = await app.request("/api/cron/buttondown-sync", {
-        method: "POST",
+        method: "GET",
         headers: { authorization: "Bearer anything" },
       });
       expect(res.status).toBe(401);
@@ -116,7 +116,7 @@ describe("Buttondown sync routes", () => {
     it("returns skipped:api_key_missing when CRON_SECRET matches but BUTTONDOWN_API_KEY is unset", async () => {
       process.env.CRON_SECRET = "secret-abc";
       const res = await app.request("/api/cron/buttondown-sync", {
-        method: "POST",
+        method: "GET",
         headers: { authorization: "Bearer secret-abc" },
       });
       expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary

Vercel cron invokes endpoints via HTTP GET, but the daily Buttondown reconcile at `src/server/api.ts:696` was `api.post`. The first scheduled run (2026-05-26 08:00 UTC) and presumably every one before that 404'd at the route layer — Axiom shows the GET hits in the access log but zero `buttondown sync` structured events because the handler never executed.

Confirmed in Axiom on the Vercel log drain:

```
['vercel']
| where ['request.path'] == "/api/cron/buttondown-sync"
| project _time, ['request.method'], ['request.statusCode'], ['request.userAgent']
```

→ 4 rows, all `GET` from `vercel-cron/1.0`, `statusCode: 404`.

## Changes

- `src/server/api.ts` — `api.post` → `api.get`. `Authorization: Bearer ${CRON_SECRET}` check unchanged (Vercel sends the header on the GET).
- `tests/functional/server/buttondown-routes.test.ts` — describe label and four `method` strings flipped to `"GET"`.
- `docs/design-buttondown.md` — two `POST /api/cron/...` mentions corrected; added a parenthetical noting Vercel cron invokes via GET.
- `docs/doc-axiom.md` — dropped the `['service.name'] == "is-app"` filter from the cron-summary canonical query (the field doesn't exist in our drain).

After merge, tonight's 08:00 UTC cron should actually run, dry-run, and produce a `buttondown sync … action == "summary"` event in Axiom — completing the unchecked test-plan item from #280.

## Test plan

- [x] `npm test` — 331 functional + 25 e2e all green
- [ ] After merge, watch the 2026-05-27 08:00 UTC cron in Axiom; confirm `summary.errors == 0`, `write == false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)