### PR TITLE
experiment: try postgres-js `prepare: false` to isolate #149

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -20,7 +20,13 @@ declare global {
   var __pgClient: ReturnType<typeof postgres> | undefined;
 }
 
-const client = globalThis.__pgClient ?? postgres(connectionString);
+// `prepare: false` — Variable reduction for #149. Supavisor's
+// transaction-pooler prepared-statement support is "partial" (see the
+// FAQ + supavisor#239). If a per-connection prepared-statement cache
+// in postgres-js is interacting badly with Supavisor re-preparing
+// against fresh backends, dropping prepared statements could eliminate
+// the issue. May revert if no difference.
+const client = globalThis.__pgClient ?? postgres(connectionString, { prepare: false });
 if (process.env.NODE_ENV !== "production") {
   globalThis.__pgClient = client;
 }


### PR DESCRIPTION
## Summary

- A/B isolation experiment for #149: flip postgres-js to `prepare: false` so the Supavisor transaction-pooler prepared-statement path is no longer exercised in prod.
- One-line diff in `src/server/db.ts`, plus a short comment explaining the reasoning and how to revert.
- Designed in #234; #233's probe is in place to read the result over the next several runs.

## Why this might matter

On the most recent failing run [26463715483](https://github.com/Intentional-Society/is-app/actions/runs/26463715483), `[debug-149] home` captured a stale-snapshot read of `bio` on `GET /` ~5s after the reset connection's own read-back showed `bio=null`. Same row, same primary (`inRecovery=false`), three distinct Supavisor `backendPid`s in play across the run. That's consistent with — though not proof of — the prepared-statement-path hypothesis. See [the latest #149 status comment](https://github.com/Intentional-Society/is-app/issues/149#issuecomment-4547180226) for the full reasoning.

A gap in the current probe (it instruments `/api/me` and `/api/_test/reset` but not the welcome gate's server-side `getProfileForSelf` read) is being tracked separately in #295.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:functional` — 331 pass
- [x] `npm run test:e2e` (local Chromium, 25 tests) — pass
- [x] Vercel preview deploys cleanly
- [x] E2E run against the preview either reproduces the stale-snapshot shape (no signal → revert) or shows a clean run (signal → leave in place, watch a few more runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)