### PR TITLE
docs: warn against `git stash && X; git stash pop` verification idiom

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -6,7 +6,7 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ## 2026-05-26 | Blake | Stash-pop antipattern callout in committing strategy
 
-Added a callout to `docs/strategy-committing.md` warning against `git stash && X; git stash pop` as a clean-slate verification idiom — instead, use `git stash list` to check the stack first, and only pop if you actually put something there.
+Added a callout to `docs/strategy-committing.md` warning against `git stash && X; git stash pop` as a clean-slate verification idiom — instead, use `git stash list` to check the stack first, and only pop if you actually put something there. Surfaced from RCA #284 (Gap 4); resolves #287.
 
 ## 2026-05-25 | James | Buttondown sync
 

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -6,7 +6,7 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ## 2026-05-26 | Blake | Stash-pop antipattern callout in committing strategy
 
-Added a short note to `docs/strategy-committing.md` ("Before committing") warning against `git stash && X; git stash pop` as a verification idiom on a clean tree: `git stash` is silently a no-op when there's nothing to stash, so the trailing pop falls through to whatever was already on the stack. Surfaced during RCA #284 (Gap 4); resolves #287, replacing the issue's original broader stash-hygiene framing with this narrower antipattern callout (corrected on the issue in place; original framing preserved for audit). Companion note on #284 records the Gap 4 5-Whys refinement.
+Added a callout to `docs/strategy-committing.md` warning against `git stash && X; git stash pop` as a verification idiom on a clean tree: `git stash` is a no-op when there's nothing to stash, so the trailing pop falls through to whatever was already on the stack. Surfaced from RCA #284 (Gap 4). (#287)
 
 ## 2026-05-25 | James | Buttondown sync
 

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-26 | Blake | Stash-pop antipattern callout in committing strategy
+
+Added a short note to `docs/strategy-committing.md` ("Before committing") warning against `git stash && X; git stash pop` as a verification idiom on a clean tree: `git stash` is silently a no-op when there's nothing to stash, so the trailing pop falls through to whatever was already on the stack. Surfaced during RCA #284 (Gap 4); resolves #287, replacing the issue's original broader stash-hygiene framing with this narrower antipattern callout (corrected on the issue in place; original framing preserved for audit). Companion note on #284 records the Gap 4 5-Whys refinement.
+
 ## 2026-05-25 | James | Buttondown sync
 
 Mirrors program memberships into Buttondown subscriber tags via a daily cron plus inline hooks on join/leave/admin-remove, replacing the Apps Script pipeline. Per-program opt-in via `programs.buttondown_tag`; ships in dry-run, then `scripts/buttondown-bootstrap.ts` reconciles the existing audience and `BUTTONDOWN_SYNC_WRITE=1` flips writes on. Design: `docs/design-buttondown.md`. (#280)

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -6,7 +6,7 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ## 2026-05-26 | Blake | Stash-pop antipattern callout in committing strategy
 
-Added a callout to `docs/strategy-committing.md` warning against `git stash && X; git stash pop` as a verification idiom on a clean tree: `git stash` is a no-op when there's nothing to stash, so the trailing pop falls through to whatever was already on the stack. Surfaced from RCA #284 (Gap 4). (#287)
+Added a callout to `docs/strategy-committing.md` warning against `git stash && X; git stash pop` as a clean-slate verification idiom — instead, use `git stash list` to check the stack first, and only pop if you actually put something there.
 
 ## 2026-05-25 | James | Buttondown sync
 

--- a/docs/strategy-committing.md
+++ b/docs/strategy-committing.md
@@ -8,7 +8,7 @@ If you've done work your teammates should know about, add a `docs/devjournal.md`
 
 Run `npm test` (all suites) and confirm green before committing. Don't push code that you haven't tested locally. If you're changing frontend layout, check both phone and desktop rendering.
 
-**Watch out:** `git stash && <command>; git stash pop` is not a safe verification idiom against an apparently-clean tree. `git stash` is a no-op when there's nothing to stash — it does not push an empty marker — so the trailing `git stash pop` applies whatever entry was already on top of the stack, often leftover work from another branch. Use `git stash list` to inspect the stack without side effects.
+**Watch out:** `git stash && <command>; git stash pop` looks like a safe way to test against a clean slate, but it isn't. `git stash` is a no-op when the tree is already clean — it does not push an empty marker — so the trailing `git stash pop` falls through to whatever was already on the stack, potentially applying leftover work from another branch. Use `git stash list` to inspect the stack without side effects.
 
 ## Branch discipline
 

--- a/docs/strategy-committing.md
+++ b/docs/strategy-committing.md
@@ -8,7 +8,7 @@ If you've done work your teammates should know about, add a `docs/devjournal.md`
 
 Run `npm test` (all suites) and confirm green before committing. Don't push code that you haven't tested locally. If you're changing frontend layout, check both phone and desktop rendering.
 
-**Watch out:** `git stash && <command>; git stash pop` looks like a safe way to test against a clean slate, but it isn't. `git stash` is a no-op when the tree is already clean — it does not push an empty marker — so the trailing `git stash pop` falls through to whatever was already on the stack, potentially applying leftover work from another branch. Use `git stash list` to inspect the stack without side effects.
+**Watch out:** `git stash && <command>; git stash pop` looks like a safe way to test against a clean slate, but it isn't. `git stash` is a no-op when the tree is already clean — it does not push an empty marker — so the trailing `git stash pop` falls through to whatever was already on the stack, potentially applying leftover work from another branch. Instead, use `git stash list` to check the stack first, and only pop if you actually put something there.
 
 ## Branch discipline
 

--- a/docs/strategy-committing.md
+++ b/docs/strategy-committing.md
@@ -8,6 +8,8 @@ If you've done work your teammates should know about, add a `docs/devjournal.md`
 
 Run `npm test` (all suites) and confirm green before committing. Don't push code that you haven't tested locally. If you're changing frontend layout, check both phone and desktop rendering.
 
+**Watch out:** `git stash && <command>; git stash pop` is not a safe verification idiom against an apparently-clean tree. `git stash` is a no-op when there's nothing to stash — it does not push an empty marker — so the trailing `git stash pop` applies whatever entry was already on top of the stack, often leftover work from another branch. Use `git stash list` to inspect the stack without side effects.
+
 ## Branch discipline
 
 Always commit on a feature branch, never directly to `main`. PRs into `main` require CI to pass before merge.


### PR DESCRIPTION
Resolves #287.

## Summary

Adds a one-paragraph callout to `docs/strategy-committing.md` (in the "Before committing" section) naming the antipattern surfaced in RCA #284 (Gap 4):

> **Watch out:** `git stash && <command>; git stash pop` is not a safe verification idiom against an apparently-clean tree. `git stash` is a no-op when there's nothing to stash — it does not push an empty marker — so the trailing `git stash pop` applies whatever entry was already on top of the stack, often leftover work from another branch. Use `git stash list` to inspect the stack without side effects.

Plus a devjournal entry recording the correction.

## Background: why this is narrower than #287's original framing

#287 originally proposed broader stash-hygiene guidance + optional preflight tooling (Options A/B/C). Re-reading the RCA, the actual trigger of the 2026-05-25 incident wasn't generic stash accumulation — it was using `git stash && X; git stash pop` as a verification idiom on a clean tree, where the leading `git stash` is silently a no-op and the trailing pop falls through to a leftover entry.

That makes the prevention takeaway narrower: name the antipattern, recommend `git stash list` for read-only inspection. No tooling, no preflight check, no policy. Consistent with @james-baker's "first, do no harm" note on #284.

Issue trail was groomed before this PR:
- #287 body edited in place with an `Edited 2026-05-26` note; original Options A/B/C preserved in a collapsed "Previous framing" section for audit.
- #284 has a "Note on Gap 4 root cause" comment recording the 5-Whys refinement; the RCA body itself is unchanged (kept as a snapshot of what we understood on 2026-05-25).

## Test plan

- [x] `docs/strategy-committing.md` renders cleanly (markdown only; no code paths affected)
- [x] `docs/devjournal.md` entry placed at the top in the existing `Date | Author | Title` format
- [x] No app code, schema, or tests touched — Vercel build will skip via the `docs/**` path filter (per `vercel.json` ignore rule); CI lint+test job will short-circuit via `dorny/paths-filter` in `ci.yml`

## Related

- Resolves #287
- Parent RCA: #284 (see "Note on Gap 4 root cause" comment)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLYbghq8K5hJjhmsHaCNgy)_