### PR TITLE
Fix two local-dev sign-in bugs from #291

### DIFF
--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -10,9 +10,11 @@ import { SigninForm } from "./signin-form";
 // Public page — opt back in to indexing (root layout is noindex by default).
 export const metadata: Metadata = { robots: { index: true, follow: true } };
 
+// Keys must match the error codes emitted by /auth/callback —
+// unknown codes silently render no message.
 const ERROR_MESSAGES: Record<string, string> = {
-  missing_code: "That sign-in link was incomplete. Please request a new one.",
-  exchange_failed:
+  missing_token: "That sign-in link was incomplete. Please request a new one.",
+  verify_failed:
     "That sign-in link couldn't be verified. It must be opened in the same browser where you requested it, and before it expires. Please request a new one.",
   profile_error: "We signed you in but couldn't finish setting up your profile. Please try again.",
   invite_invalid:

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -159,7 +159,7 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:3000"
 # A list of URLs that auth providers are permitted to redirect to post authentication. Supabase
 # matches these with trailing-`*` wildcard support. Cover both 127.0.0.1 and localhost because
 # window.location.origin on the client depends on which host the dev server was opened with.


### PR DESCRIPTION
## Summary

Two follow-ups to the cross-browser auth refactor (#291) that broke local-dev sign-in in different ways:

- **`/signin` silently rendered no message for callback errors.** PR #291 renamed the codes `/auth/callback` redirects with (`missing_code` → `missing_token`, `exchange_failed` → `verify_failed`) but the lookup map on `src/app/signin/page.tsx` still keyed off the old names, so `/signin?error=verify_failed` showed no error. Functional tests asserted the redirect URL, nothing asserted the page rendered the matching copy.
- **Magic links on local dev landed users on the wrong cookie jar.** `supabase/config.toml`'s `site_url` was `http://127.0.0.1:3000`, so emails carried `127.0.0.1` links. Next.js dev advertises and binds `http://localhost:3000`, so people browse there. The session cookie was set under `127.0.0.1` and invisible to a tab on `localhost`. `verifyOtp` succeeded server-side every time but `/api/me` returned 401. Flipping `site_url` to `localhost` aligns the host. `additional_redirect_urls` already lists both, so 127.0.0.1 bookmarks still work. Prod uses the hosted dashboard's `site_url` — unaffected.

## Test plan

- [x] `npm test` — 331 functional + 25 e2e green
- [x] Manual: request a fresh magic link from `localhost:3000/signin`, click in Mailpit, confirm signed-in landing
- [x] Visit `/signin?error=verify_failed` and confirm the error message renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)