### PR TITLE
Relational web canvas: zoom controls, hint, persistence + polish (#271)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,6 +42,8 @@
   --color-card: var(--card);
   --color-foreground: var(--foreground);
   --color-background: var(--background);
+  --color-canvas: var(--canvas);
+  --color-canvas-foreground: var(--canvas-foreground);
   --color-success: var(--success);
   --color-success-foreground: var(--success-foreground);
   --radius-sm: calc(var(--radius) * 0.6);
@@ -64,6 +66,14 @@
        a faint mint tint, not the full site cast. */
   --background: oklch(0.965 0.007 165);
   --foreground: oklch(0.18 0.012 250);
+
+  /* Canvas — near-white / near-black pair that flips with the theme.
+       5/256 step in from absolute white/black keeps the contrast close to
+       maximum while taking the edge off pure #fff and #000. Use for
+       neutral data-viz surfaces (e.g. the graph canvas) rather than the
+       faintly-tinted --background/--foreground. */
+  --canvas: #fafafa;
+  --canvas-foreground: #050505;
 
   /* Card — elevated surface. Unused today; kept for future panels. */
   --card: oklch(1 0 0);
@@ -136,6 +146,8 @@
 .dark {
   --background: oklch(0.18 0.005 230);
   --foreground: oklch(0.96 0.002 170);
+  --canvas: #050505;
+  --canvas-foreground: #fafafa;
   --card: oklch(0.22 0.005 230);
   --card-foreground: oklch(0.96 0.002 170);
   --popover: oklch(0.22 0.005 230);

--- a/src/app/myweb/page.tsx
+++ b/src/app/myweb/page.tsx
@@ -16,15 +16,14 @@ export default async function MyWebPage() {
   // Prefetch the default-view subgraph and dehydrate it into the client
   // QueryClient via HydrationBoundary, so WebGraph's useQuery hits a
   // warm cache on mount instead of doing a post-hydration roundtrip.
-  // Toggling Show-incoming or 2-hops still falls through to a client
-  // fetch (those view variants aren't prefetched).
+  // Toggling 2-hops still falls through to a client fetch (that view
+  // variant isn't prefetched).
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({
     queryKey: [...RELATION_SUBGRAPH_QUERY_KEY, DEFAULT_SUBGRAPH_VIEW],
     queryFn: async () => {
       const res = await serverApiClient.api.relations.subgraph.$get({
         query: {
-          in: DEFAULT_SUBGRAPH_VIEW.includeIncoming ? "true" : "false",
           hops: String(DEFAULT_SUBGRAPH_VIEW.hops),
         },
       });

--- a/src/app/myweb/query-keys.ts
+++ b/src/app/myweb/query-keys.ts
@@ -4,13 +4,11 @@ export const RELATION_SUBGRAPH_QUERY_KEY = ["relations", "subgraph"] as const;
 export const relationValueQueryKey = (relateeId: string) => ["relations", "value", relateeId] as const;
 
 export type SubgraphViewOptions = {
-  includeIncoming: boolean;
   hops: 1 | 2;
 };
 
 // Default view for the WebGraph — server prefetch and client useState
 // must agree on this exact shape so the prefetched cache hits on mount.
 export const DEFAULT_SUBGRAPH_VIEW: SubgraphViewOptions = {
-  includeIncoming: false,
   hops: 2,
 };

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -84,10 +84,7 @@ const HANDLE_STYLE = { opacity: 0, top: "50%", pointerEvents: "none" as const };
 
 function MemberNode({ data }: NodeProps<Node<MemberNodeData>>) {
   return (
-    <div
-      className="flex flex-col items-center gap-1"
-      title={data.isCenter ? undefined : (data.displayName ?? undefined)}
-    >
+    <div className="flex cursor-pointer flex-col items-center gap-1" title={data.displayName ?? undefined}>
       <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
       <Handle type="source" position={Position.Top} style={HANDLE_STYLE} />
       <Avatar
@@ -323,7 +320,6 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
         elementsSelectable={false}
         proOptions={{ hideAttribution: true }}
         onNodeClick={(_event, node) => {
-          if (node.data.isCenter) return;
           // Re-center the viewport on the clicked node so members can
           // explore the graph without navigating away. Double-click
           // navigates to the member's profile page.
@@ -333,7 +329,6 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
           });
         }}
         onNodeDoubleClick={(_event, node) => {
-          if (node.data.isCenter) return;
           const slug = node.data.slug ?? node.data.id;
           router.push(`/members/${slug}`);
         }}

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -71,6 +71,13 @@ const fetchSubgraph = async (opts: SubgraphViewOptions) => {
 // distinct from a 1-rated acquaintance without dominating the canvas.
 const edgeStrokeWidth = (value: number) => 1.5 + value * 1.25;
 
+// 1..4 → linear ramp from 0.4 to 0.8 over the theme foreground (so
+// ≈0.4/0.53/0.67/0.8). Reinforces the thickness signal without letting
+// the strongest edges read as full-black ink. Both light and dark
+// themes ride foreground, so each stays readable against its own
+// background.
+const edgeStrokeOpacity = (value: number) => 0.4 + ((value - 1) / 3) * 0.4;
+
 // Handles are required for ReactFlow to anchor edges; rendering both at
 // the same vertically-centered position with opacity 0 makes edges read
 // as center-to-center lines without showing connector dots.
@@ -87,8 +94,8 @@ function MemberNode({ data }: NodeProps<Node<MemberNodeData>>) {
       <Avatar
         name={data.displayName}
         url={data.avatarUrl}
-        className={`flex h-12 w-12 items-center justify-center overflow-hidden rounded-full border-2 ${
-          data.isCenter ? "border-primary" : "border-border"
+        className={`flex items-center justify-center overflow-hidden rounded-full border-2 ${
+          data.isCenter ? "h-16 w-16 border-primary" : "h-12 w-12 border-border"
         } bg-muted text-base font-semibold text-muted-foreground`}
       />
       <div className="max-w-[8rem] truncate text-sm font-medium">{data.displayName ?? "—"}</div>
@@ -140,6 +147,8 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
         source: e.relatorId,
         target: e.relateeId,
         style: {
+          stroke: "var(--color-canvas-foreground)",
+          strokeOpacity: edgeStrokeOpacity(e.value),
           strokeWidth: edgeStrokeWidth(e.value),
           cursor: isOutgoing ? "pointer" : "default",
         },
@@ -301,7 +310,7 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
   }
 
   return (
-    <div className="h-[500px] w-full rounded border border-border bg-background">
+    <div className="h-[500px] w-full overflow-hidden rounded border border-border bg-canvas [--xy-background-color:var(--color-canvas)]">
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -392,7 +392,7 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
          * want to scroll-zoom (trackpad pinch, mouse wheel). Lock toggle
          * is hidden — selection and connection are already disabled. */}
         <Controls position="top-left" showInteractive={false} />
-        <Panel position="bottom-right" className="flex items-end gap-2">
+        <Panel position="bottom-right" className="flex flex-row-reverse items-end gap-2">
           {/* Click-to-toggle (not hover) so the hints stay reachable on
            * touch devices where hover doesn't exist. */}
           <Button
@@ -414,6 +414,8 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
             >
               <li>Drag the background to pan.</li>
               <li>Scroll or pinch to zoom.</li>
+              <li>Single-click a node to center the view on it.</li>
+              <li>Double-click a node to open their profile.</li>
               <li>
                 <span className="font-medium text-foreground">2 hops</span> adds friends of friends.
               </li>

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -59,7 +59,6 @@ type EdgeData = {
 const fetchSubgraph = async (opts: SubgraphViewOptions) => {
   const res = await apiClient.api.relations.subgraph.$get({
     query: {
-      in: opts.includeIncoming ? "true" : "false",
       hops: String(opts.hops),
     },
   });
@@ -387,14 +386,6 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
           position="top-right"
           className="flex flex-col gap-1 rounded border border-border bg-background/90 p-2 text-sm"
         >
-          <label className="flex cursor-pointer items-center gap-2">
-            <input
-              type="checkbox"
-              checked={view.includeIncoming}
-              onChange={(e) => setView((v) => ({ ...v, includeIncoming: e.target.checked }))}
-            />
-            Show incoming
-          </label>
           <label className="flex cursor-pointer items-center gap-2">
             <input
               type="checkbox"

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -4,6 +4,7 @@ import "@xyflow/react/dist/style.css";
 
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
+  Controls,
   type Edge,
   Handle,
   type Node,
@@ -339,6 +340,10 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
           });
         }}
       >
+        {/* Built-in +/-/fit-view buttons for users who can't or don't
+         * want to scroll-zoom (trackpad pinch, mouse wheel). Lock toggle
+         * is hidden — selection and connection are already disabled. */}
+        <Controls showInteractive={false} />
         <Panel
           position="top-right"
           className="flex flex-col gap-1 rounded border border-border bg-background/90 p-2 text-sm"

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -141,10 +141,48 @@ function NumberedEdge({ id, sourceX, sourceY, targetX, targetY, style, data }: E
 
 const edgeTypes = { numbered: NumberedEdge };
 
+const VIEW_STORAGE_KEY = "isweb-graph-view";
+
+// Permissive parser — any malformed/legacy payload falls back to the
+// default. Strict validation matters because the parsed shape feeds the
+// useQuery key and would otherwise produce a failing API request on
+// every mount.
+function parseStoredView(raw: string | null): SubgraphViewOptions | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "hops" in parsed &&
+      (parsed.hops === 1 || parsed.hops === 2)
+    ) {
+      return { hops: parsed.hops };
+    }
+  } catch {
+    // fall through to null
+  }
+  return null;
+}
+
 export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: RelatingTarget) => void }) {
   const router = useRouter();
   const [view, setView] = useState<SubgraphViewOptions>(DEFAULT_SUBGRAPH_VIEW);
   const [hintOpen, setHintOpen] = useState(false);
+
+  // Restore the user's last filter choice across reloads. Done in an
+  // effect rather than the useState initializer so SSR-rendered markup
+  // matches the hydrated client tree; the prefetched cache covers only
+  // the default view, so this triggers a single client refetch when the
+  // stored shape differs (placeholderData below suppresses the flash).
+  useEffect(() => {
+    const stored = parseStoredView(window.localStorage.getItem(VIEW_STORAGE_KEY));
+    if (stored && stored.hops !== DEFAULT_SUBGRAPH_VIEW.hops) setView(stored);
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(VIEW_STORAGE_KEY, JSON.stringify(view));
+  }, [view]);
   // The view options become part of the query key so toggling refetches
   // automatically and the rating-mutation invalidator (which uses the
   // bare ["relations", "subgraph"] key) still hits every variant.

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -19,6 +19,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Avatar } from "@/components/avatar";
+import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api";
 import type { RelationSubgraph } from "@/lib/api-types";
 import { isRelationValue } from "@/lib/relation-value";
@@ -100,6 +101,7 @@ const nodeTypes = { member: MemberNode };
 export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: RelatingTarget) => void }) {
   const router = useRouter();
   const [view, setView] = useState<SubgraphViewOptions>(DEFAULT_SUBGRAPH_VIEW);
+  const [hintOpen, setHintOpen] = useState(false);
   // The view options become part of the query key so toggling refetches
   // automatically and the rating-mutation invalidator (which uses the
   // bare ["relations", "subgraph"] key) still hits every variant.
@@ -343,7 +345,35 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
         {/* Built-in +/-/fit-view buttons for users who can't or don't
          * want to scroll-zoom (trackpad pinch, mouse wheel). Lock toggle
          * is hidden — selection and connection are already disabled. */}
-        <Controls showInteractive={false} />
+        <Controls position="top-left" showInteractive={false} />
+        <Panel position="bottom-right" className="flex items-end gap-2">
+          {/* Click-to-toggle (not hover) so the hints stay reachable on
+           * touch devices where hover doesn't exist. */}
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={hintOpen ? "Hide canvas tips" : "Show canvas tips"}
+            aria-expanded={hintOpen}
+            aria-controls="web-graph-hints"
+            onClick={() => setHintOpen((h) => !h)}
+            className="rounded-full border border-border bg-background/90 font-bold"
+          >
+            ?
+          </Button>
+          {hintOpen && (
+            <ul
+              id="web-graph-hints"
+              className="flex max-w-[18rem] flex-col gap-1 rounded border border-border bg-background/90 p-2 text-sm text-muted-foreground"
+            >
+              <li>Drag the background to pan.</li>
+              <li>Scroll or pinch to zoom.</li>
+              <li>
+                <span className="font-medium text-foreground">2 hops</span> adds friends of friends.
+              </li>
+            </ul>
+          )}
+        </Panel>
         <Panel
           position="top-right"
           className="flex flex-col gap-1 rounded border border-border bg-background/90 p-2 text-sm"

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -4,8 +4,12 @@ import "@xyflow/react/dist/style.css";
 
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
+  BaseEdge,
   Controls,
   type Edge,
+  EdgeLabelRenderer,
+  type EdgeProps,
+  getStraightPath,
   Handle,
   type Node,
   type NodeProps,
@@ -101,6 +105,35 @@ function MemberNode({ data }: NodeProps<Node<MemberNodeData>>) {
 
 const nodeTypes = { member: MemberNode };
 
+// Straight-line edge with an HTML circle label at the geometric midpoint
+// of the line between source and target. ReactFlow's default bezier
+// edges arc upward (both ends are Position.Top), so their parametric
+// midpoint sits above the visual line — using a straight edge keeps the
+// label on the line, and HTML labels (via EdgeLabelRenderer) give us a
+// real circular pill that an SVG <rect> can't.
+function NumberedEdge({ id, sourceX, sourceY, targetX, targetY, style, data }: EdgeProps<Edge<EdgeData>>) {
+  const [edgePath, labelX, labelY] = getStraightPath({ sourceX, sourceY, targetX, targetY });
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} style={style} />
+      <EdgeLabelRenderer>
+        <div
+          style={{
+            position: "absolute",
+            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            pointerEvents: "none",
+          }}
+          className="flex h-5 w-5 items-center justify-center rounded-full bg-canvas/60 text-xs font-semibold text-canvas-foreground"
+        >
+          {data?.value}
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+}
+
+const edgeTypes = { numbered: NumberedEdge };
+
 export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: RelatingTarget) => void }) {
   const router = useRouter();
   const [view, setView] = useState<SubgraphViewOptions>(DEFAULT_SUBGRAPH_VIEW);
@@ -142,6 +175,7 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
         id: `${e.relatorId}->${e.relateeId}`,
         source: e.relatorId,
         target: e.relateeId,
+        type: "numbered",
         style: {
           stroke: "var(--color-canvas-foreground)",
           strokeOpacity: edgeStrokeOpacity(e.value),
@@ -311,6 +345,7 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
         fitView
         fitViewOptions={{ padding: 0.15 }}
         onInit={(instance) => {

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -51,6 +51,7 @@ type SimNode = {
 type SimEdge = {
   source: string | SimNode;
   target: string | SimNode;
+  value: number;
 };
 
 type EdgeData = {
@@ -73,6 +74,12 @@ const fetchSubgraph = async (opts: SubgraphViewOptions) => {
 // 1..4 → edge thickness; chosen so a 4-rated friend reads visually
 // distinct from a 1-rated acquaintance without dominating the canvas.
 const edgeStrokeWidth = (value: number) => 1.5 + value * 1.25;
+
+// 1..4 → spring rest-length for the d3-force link constraint. Stronger
+// relations want to sit closer (230 → 110 across the range). Charge,
+// collide, and other-link tensions still resolve the layout, so this
+// biases without ranking nodes strictly by edge weight.
+const linkDistance = (value: number) => 270 - value * 40;
 
 // 1..4 → linear ramp from 0.4 to 0.8 over the theme foreground (so
 // ≈0.4/0.53/0.67/0.8). Reinforces the thickness signal without letting
@@ -215,6 +222,7 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
     const simEdges: SimEdge[] = data.edges.map((e) => ({
       source: e.relatorId,
       target: e.relateeId,
+      value: e.value,
     }));
 
     setNodes(
@@ -250,7 +258,7 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
         "link",
         forceLink<SimNode, SimEdge>(simEdges)
           .id((d) => d.id)
-          .distance(180),
+          .distance((link) => linkDistance(link.value)),
       )
       .force("collide", forceCollide(60))
       .on("tick", () => {

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -44,6 +44,8 @@ type SimNode = {
   id: string;
   x: number;
   y: number;
+  vx?: number;
+  vy?: number;
   fx?: number | null;
   fy?: number | null;
 };
@@ -290,6 +292,40 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
     // origin via fx/fy, so forceCenter would only pull the other nodes
     // toward the pinned center, fighting the link-distance equilibrium
     // and causing them to bunch on top of the center.
+    //
+    // Custom force: gently push nodes off the segments of edges they
+    // don't belong to. Stock forceCollide handles node-on-node overlap
+    // but doesn't know about edges, so without this a node can settle
+    // straight on top of someone else's line. Scaled by alpha (d3's
+    // simulation "heat") so it fades as the layout cools.
+    const AVOID_THRESHOLD = 70;
+    const AVOID_STRENGTH = 0.7;
+    const forceAvoidEdges = (alpha: number) => {
+      for (const n of simNodes) {
+        for (const e of simEdges) {
+          const a = e.source as SimNode;
+          const b = e.target as SimNode;
+          if (n === a || n === b) continue;
+          const dx = b.x - a.x;
+          const dy = b.y - a.y;
+          const len2 = dx * dx + dy * dy;
+          if (len2 < 1) continue;
+          // t = projection of n onto the line through a,b, clamped to
+          // [0,1] so the closest point stays on the segment.
+          let t = ((n.x - a.x) * dx + (n.y - a.y) * dy) / len2;
+          if (t < 0) t = 0;
+          else if (t > 1) t = 1;
+          const rx = n.x - (a.x + t * dx);
+          const ry = n.y - (a.y + t * dy);
+          const dist = Math.sqrt(rx * rx + ry * ry);
+          if (dist >= AVOID_THRESHOLD || dist < 0.001) continue;
+          const push = ((AVOID_THRESHOLD - dist) / AVOID_THRESHOLD) * AVOID_STRENGTH * alpha;
+          n.vx = (n.vx ?? 0) + (rx / dist) * push;
+          n.vy = (n.vy ?? 0) + (ry / dist) * push;
+        }
+      }
+    };
+
     const sim = forceSimulation(simNodes)
       .force("charge", forceManyBody().strength(-800))
       .force(
@@ -299,6 +335,7 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
           .distance((link) => linkDistance(link.value)),
       )
       .force("collide", forceCollide(60))
+      .force("avoid-edges", forceAvoidEdges)
       .on("tick", () => {
         const now = performance.now();
         if (now - lastUpdate < FRAME_MS) return;


### PR DESCRIPTION
## Summary

Addresses all three sub-tasks in #271 (zoom controls, navigation hint, sticky filter state) and bundles in a batch of related polish on the same surface.

### #271 acceptance criteria

- **Zoom controls** — ReactFlow's built-in `<Controls />` at top-left provides +/-/fit-view buttons.
- **Navigation hint** — bottom-right `?` toggles a card explaining pan, zoom, single-click/double-click, and the 2-hops filter.
- **Persisted filter** — "2 hops" state lives in `localStorage["isweb-graph-view"]`; restored on mount via effect (kept out of the `useState` initializer to stay SSR-safe).

### Polish bundled in

- Self-node loses its hover/click special-casing and is treated as a regular clickable node; visual identity (40% larger, primary-color border) and physics (pinned at origin) stay.
- "Show incoming" filter UI removed (server keeps the `in` param as a no-op for a follow-up retirement).
- Edges:
  - Linear opacity ramp 0.4 → 0.8 over rating 1..4, reinforcing the existing width signal.
  - Stroke color now rides a new `--canvas` / `--canvas-foreground` theme pair (near-white / near-black, flipped in dark mode).
  - Custom straight-edge type with HTML circle label at the geometric midpoint showing the rating digit.
  - `forceLink.distance` is now an accessor over each edge's rating — stronger ties pull tighter (230 → 110).
- New custom d3-force `avoid-edges` pushes nodes off non-incident segments so they stop settling on someone else's line.
- Wrapper picks up `overflow-hidden` so the rounded border actually clips ReactFlow's inner container (fixes a 1–2px corner gap).

### Server-side follow-up

The `Show incoming` UI is gone but the server endpoint still accepts `in` (defaulting to `false` when absent). A separate PR can retire the concept end-to-end including `getPersonalWeb`'s `includeIncoming` parameter and the tests around it.

## Test plan

- [x] `npm test` — 331 functional + 25 e2e green
- [x] Manual: toggle "2 hops", reload, confirm it sticks
- [x] Manual: click `?` at bottom-right, confirm card pops to its left
- [x] Manual: confirm rating digits render at line midpoints, edges thicker/darker with higher rating, stronger ties pulled tighter
- [x] Manual: confirm nodes nudge off edges they aren't endpoints of

Closes #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)