### PR TITLE
docs: tighten PR #283 plan guidance for policy-doc edits

### DIFF
--- a/docs/plan-portable-ai-procedures.md
+++ b/docs/plan-portable-ai-procedures.md
@@ -123,6 +123,7 @@
 All 7b edits share the same per-substep fields:
 - **Effort:** < 1h per file
 - **Dependencies:** Phase 7a complete (wording can reference Skill names and paths as they actually exist)
+- **Acceptance:** Policy-doc additions are brief, practical, and easy to follow for the intended audience; avoid verbosity unless the added detail materially improves correct use.
 - **Risks:** Target sections may have evolved since the spec was written — re-read each file before editing to find the right insertion point
 - **Resume checkpoint:** `git diff --stat` shows which files have been touched; the table below serves as a per-file checklist; mark each ✓ in tracker Resume notes as completed
 


### PR DESCRIPTION
## Summary

- Pre-implementation fast-follow to PR #283 for `docs/plan-portable-ai-procedures.md`
- Adds a shared Phase 7b acceptance bar so generated policy-doc edits stay brief, practical, audience-appropriate, and only as detailed as needed for correct use

## Test Plan

- Not run; docs-only one-line plan clarification.