### PR TITLE
docs: fill missing rows in README Documentation table

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,19 @@ drizzle/            Database migration files
 | [setup-dev-machine.md](docs/setup-dev-machine.md) | System prerequisites for new developers |
 | [strategy-branching.md](docs/strategy-branching.md) | Branching strategy |
 | [strategy-committing.md](docs/strategy-committing.md) | Commit conventions |
+| [strategy-db-transactions.md](docs/strategy-db-transactions.md) | Writing transactions that survive the Supabase connection pooler |
+| [strategy-project-management.md](docs/strategy-project-management.md) | GitHub Projects board conventions |
+| [strategy-security.md](docs/strategy-security.md) | Security headers and rationale |
+| [strategy-ui.md](docs/strategy-ui.md) | Theme tokens, Button variants, UI conventions |
+| [design-welcome.md](docs/design-welcome.md) | Multi-step onboarding/welcome flow design |
+| [design-emails.md](docs/design-emails.md) | Auth email template authoring and prod sync |
+| [design-profile-pictures.md](docs/design-profile-pictures.md) | Avatar uploads, storage bucket, signed URLs |
+| [design-relations.md](docs/design-relations.md) | The relationship web (schema, flows, rationale) |
+| [design-buttondown.md](docs/design-buttondown.md) | Buttondown sync (program tag mirror, cron, write policy) |
 | [doc-sentry.md](docs/doc-sentry.md) | Sentry error tracking config |
 | [doc-axiom.md](docs/doc-axiom.md) | Axiom logging config |
 | [doc-vercel.md](docs/doc-vercel.md) | Vercel dashboard settings |
+| [doc-supabase.md](docs/doc-supabase.md) | Supabase dashboard settings (auth URLs, API keys) |
+| [doc-resend.md](docs/doc-resend.md) | Resend transactional email (sending domain, DMARC) |
 | [doc-github.md](docs/doc-github.md) | GitHub settings and CI workflows |
 | [devjournal.md](docs/devjournal.md) | Development decision log |


### PR DESCRIPTION
## Summary

The README's Documentation table listed ~10 docs, but CLAUDE.md's
"Key docs" list referenced 11 more. Adds the missing rows so the
two top-level doc indexes stay in sync.

## Why

CLAUDE.md is loaded into AI assistants by default; the README is the
human entry point for new contributors. Having one list out of step
with the other made the README look stale.

## Behavior

- README.md Documentation table now lists the following alongside
  the existing rows:
  - `strategy-db-transactions.md`, `strategy-project-management.md`,
    `strategy-security.md`, `strategy-ui.md`
  - all five `design-*.md` files (welcome, emails, profile-pictures,
    relations, buttondown)
  - `doc-supabase.md`, `doc-resend.md`
- All 11 new link targets verified to exist.

## Test Plan

- ran `npm run lint` -> Checked 212 files, 0 issues.
- ran `npm run typecheck` -> clean.
- ran existence check on all 11 added link targets -> all present.

## Notes

This PR is also the Phase 8.2 smoke-test for the upcoming PR-133
implementation PR (portable AI procedure framework). It exercises
`/ship` end-to-end on a small real change to de-risk the higher-
stakes self-host that will ship the Skills themselves. The Skills
don't exist on \`main\` yet -- this run is "follow the SKILL.md bodies
manually" rather than slash-invocation.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>