### PR TITLE
feat: portable AI procedure framework: /commit /pr /ship (#133)

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: commit
+description: Stage, commit, and push the current local changes for the Intentional Society repo. Invoke explicitly as `/commit [issue-or-context]` to draft a Conventional Commit-style message, run the local `npm test` gate, surface a single bundled human approval block (message + staged payload + optional devjournal draft), and push the branch. Auto-creates a feature branch when invoked on `main`. Refuses suspicious payloads, combined expand+contract schema changes, and missing `gh` auth. This Skill fires only on explicit `/commit` invocation; natural-language phrasings ("commit this") are guidance for the reader, not triggers.
+disable-model-invocation: true
+---
+
+# /commit
+
+The leaf Skill in the commit → PR → ship chain. `/commit` is the only place changes leave the working tree; both `/pr` and `/ship` delegate here when the tree is dirty or HEAD is `main`.
+
+## Invocation
+
+`/commit [issue-or-context]`
+
+| Argument shape | Interpretation |
+|---|---|
+| *(none)* | Infer context from branch name and diff. |
+| `#<N>` or bare `<N>` | Treat as a GitHub issue number; resolve with `gh issue view <N>`. |
+| Any other text | Use as plain-language context for branch naming, issue-lookup hints, and commit-message draft. |
+
+Cache the argument for `/pr` and `/ship` in this session so chained invocations reuse the same context.
+
+Natural-language phrasings ("commit this for issue 142", "go ahead and commit") are guidance for the human reading this Skill, **not** triggers. With `disable-model-invocation: true`, this Skill fires only when the user types `/commit` explicitly.
+
+## Steps
+
+Run these in order. Each step's failure mode is in the Failure modes section below.
+
+1. **Parse the argument** and cache it for downstream Skills (`/pr`, `/ship`) in the same session.
+
+2. **Inspect working state.** Run `git status --short`, `git diff --name-status`, and `git diff --cached --name-status`. Inspect `git log origin/main..HEAD` for branch-history context.
+
+3. **Refuse if there's nothing to commit.** If there are no staged, unstaged, or untracked payload files, say "nothing to commit" and stop.
+
+4. **Auto-branch if HEAD is `main`.** Generate a slug `<N>-<short-summary>` (from `gh issue view <N>` when the argument is an issue) or `<short-summary>` from the diff. `git switch -c <branch>`. Never commit directly to `main`.
+
+5. **Build the proposed payload** from the current task context and changed files. Do not use `git add .` or `git add -A` — those sweep in everything in the working tree and defeat the point of a deliberate payload.
+
+6. **Apply the suspicious-file blocker check.** Refuse and surface the file(s) if any of the following match:
+
+   - `.env*` files (any environment file)
+   - Files matching common secret patterns (keys, tokens, credentials)
+   - Generated or build artifacts: `.next/`, `out/`, `build/`, `playwright-report/`, `test-results/`
+   - Lockfile changes (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`) when the commit doesn't intentionally bump dependencies
+   - Files unrelated to the apparent task area
+   - Unexpectedly large files
+
+   On match, refuse, name the file(s), and ask the human for direction (e.g., "remove from payload," "yes this is intentional, please include," or "split into a separate commit").
+
+7. **Stage explicit paths.** `git add -- <paths>` for the approved files only. Never `git add .` or `git add -A`.
+
+8. **Verify staging.** Run `git diff --cached --name-status`. If nothing is staged, refuse with the reason.
+
+9. **Schema-change handling.** If the staged payload includes `src/server/schema.ts` or anything under `drizzle/`, identify the expand vs contract phase per `docs/strategy-committing.md`.
+
+   - **Refuse combined expand+contract payloads.** The two phases must ship as separate commits so deploy ordering can be preserved. Ask the human to split.
+   - **Expand-phase change.** In the eventual approval block, note that `npm run prod:db:expand` will need to be dispatched after PR creation (the dispatcher pauses on a maintainer approval gate in the `prod-db` environment before injecting prod credentials), and that the post-deploy `e2e.yml` run must pass before `/ship` merges.
+   - **Contract-phase change.** No dispatch needed; the migration runs in Vercel's production build per `vercel.json`.
+
+10. **Validate issue argument if present.** If the parsed argument looks like an issue, `gh issue view <N>` to confirm it exists and is open. **Fail fast and hard if `gh` is unavailable or unauthenticated** — suggest `gh auth login` / `gh auth status` as the next command.
+
+11. **Run the local gate.** `npm test`. All suites must pass. This is the only local gate; if it's slow or flaky, the fix is to `npm test` itself, not to skip it here.
+
+12. **Draft the commit message.** Use a Conventional Commit-style subject and the repo's structured body. First inspect `git log --oneline -20 origin/main` to follow the repo-observed style. Reference: https://www.conventionalcommits.org/en/v1.0.0/
+
+    **Subject:** `<type>[(scope)]: <imperative summary>`, ≤70 chars.
+
+    - Prefer repo-observed types: `feat`, `fix`, `a11y`, `test`, `docs`, `chore`. Use common CC types (`refactor`, `perf`, `ci`, `build`) when they fit.
+    - If several types apply, pick the dominant intent. If unclear, surface the chosen type in the approval block so the human can correct it.
+    - For breaking changes, add `!` before the colon and include a `BREAKING CHANGE:` footer that explains the compatibility impact. Surface this explicitly in the approval block.
+
+    **Body sections, in order:**
+
+    - `Summary:` — one sentence describing what the commit does.
+    - `Why:` — the motivation; the constraint, bug, request, or hypothesis that drove the change.
+    - `Behavior:` — the observable change (UI, API, schema, build, log output, etc.).
+    - `Test Plan:` — evidence the change works.
+
+    **Trailers, in order:**
+
+    - `Closes #N` for issues this commit resolves. `(#N)` for non-resolving references.
+    - AI co-author trailer (see protocol below).
+
+    **Test-plan provenance.** Every line in `Test Plan:` is either (a) a command the agent actually ran with captured output, (b) a verbatim human attestation ("Blake checked the new modal on mobile Safari, no clipping"), or (c) the single collapsed line `ran \`npm test\` locally` when the full suite was run with no surprises. Never invent test results. Fabrication is the failure mode this provenance rule exists to prevent.
+
+    **Test-plan formatting.** Use plain bullets (`- ran ...`), **not** Markdown task-list checkboxes (`- [ ]` / `- [x]`). The PR body becomes the durable merge commit message in this repo (`merge_commit_message: PR_BODY`), and unchecked task-list boxes look like outstanding work. If human-only verification remains, surface it as a pending action or reviewer note, not as completed test evidence. Don't add task-list checkboxes to commit messages or PR bodies unless they already come from the repo's PR template.
+
+13. **Draft a devjournal entry if a trigger fires.** Triggers list below. Default length: **1–2 sentences.** Expand only on explicit human confirmation. Never auto-write more than three sentences.
+
+14. **Human approval checkpoint — one bundled block.** Present all three together:
+
+    - The full commit message (subject, body, trailers).
+    - The exact staged payload: `git diff --cached --name-status`, the diffstat, and a list of any unstaged or untracked leftovers in the working tree.
+    - The devjournal draft, if any.
+
+    Wait for Y/n. Do not proceed without an explicit yes. After approval, run to completion through step 19.
+
+15. **Re-verify staging after approval.** Run `git diff --cached --name-status` again. If the staged set has changed between approval and commit (race with another tool, edited a file, etc.), stop and re-show the approval block.
+
+16. **Commit.** `git commit` with the message passed via a heredoc so multi-line formatting is preserved exactly.
+
+17. **Verify post-commit working tree.** `git status --short`. If unexpected changes remain (a hook modified files, a generated artifact reappeared, etc.), report them.
+
+18. **Push.** `git push -u origin <branch>` so the upstream is set on first push.
+
+19. **Report.** Print the commit SHA and the remote-tracking info (e.g., `branch impl/portable-ai-procedures set up to track origin/impl/portable-ai-procedures`).
+
+## Devjournal trigger list
+
+A devjournal entry exists to change other teammates' behavior. Skip it for purely internal changes.
+
+**Hard triggers — always draft:**
+
+- New or removed dependency in `package.json`.
+- New or changed required environment variable.
+- New required local setup step (new Docker service, new daemon, new auth flow).
+- CI or branch-protection change.
+- New `.claude/skills/<name>/` Skill added.
+- AI co-author trailer or commit-convention change.
+- Schema migration requiring multi-deploy timing.
+
+**Soft triggers — offer to draft; default skip unless human accepts:**
+
+- Security-relevant change (auth, permission boundary, session handling) not covered above.
+- Architectural decision affecting future code in the area.
+- Convention-changing refactor visible to anyone editing the area.
+
+**Don't trigger:**
+
+- Bug fixes.
+- Internal refactors with no API surface change.
+- Performance optimizations.
+- Test additions.
+- Doc typo fixes.
+- Internal renames.
+
+## AI co-author trailer protocol
+
+Every commit `/commit` writes includes an AI co-author trailer. This is required, not optional.
+
+- **Detection path (preferred).** When the agent can read its own model identity from runtime context, emit the canonical form:
+
+  `Co-Authored-By: <Model Name> <Version> <noreply@anthropic.com>`
+
+  Example: `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`.
+
+- **Fallback path (when detection fails).** Ask the human **once** for the attribution string. Emit:
+
+  `Co-Authored-By: <human-provided string> <noreply@unspecified>`
+
+  And append a one-line caveat to the commit body: `Note: AI co-author identity provided by human; auto-detection failed.`
+
+- **No multi-vendor matrix.** v1 is Claude-only. Don't try to recognize or emit non-Claude attribution.
+
+## Stash safety
+
+Do not use `git stash && <command>; git stash pop` to "test against a clean slate." `git stash` is a no-op when the tree is already clean — it does not push an empty marker — so the trailing `git stash pop` falls through to whatever was already on the stack, potentially applying leftover work from another branch. Read the current tree with `git status --short` / `git status --porcelain` and explicit diffs instead. If a branch switch would cross a dirty tree, refuse with a manual commit-or-stash suggestion to the human.
+
+## Failure modes
+
+- **No diff or branch identical to `main`.** Refuse; suggest the next command.
+- **Suspicious-file match in the blocker list.** Refuse; surface the file; await human direction.
+- **Combined expand+contract schema payload.** Refuse; ask the human to split into two commits.
+- **`gh` unavailable or unauthenticated** when issue lookup is needed. Refuse; name the command to run (`gh auth login` / `gh auth status`).
+- **`npm test` fails.** Refuse; show the failing test output.
+- **Schema touch with unresolved expand-vs-contract phase.** Refuse; ask which phase.
+- **Human rejects message draft, devjournal draft, or staged payload** at the approval checkpoint. Return to staging with the rejection reason captured.
+- **Staged payload changes between approval and commit.** Stop and re-show the approval block.
+- **Commit hook fails.** Report the hook's exit; do not retry without human input.
+- **Push fails.** Report the error; do not retry blindly.
+- **Never** use `--no-verify`, `--amend` without explicit human approval, force-push, `git add -A` / `git add .`, admin bypass, or invented attribution.
+
+## Depends on
+
+- `CLAUDE.md`
+- `package.json` (for `npm test`)
+- `docs/strategy-committing.md` (commit format, expand-contract phase rules, AI-trailer subsection, stash-safety note)
+- `docs/strategy-branching.md` (feature-branch-from-main rule)
+- `docs/doc-github.md` (GitHub settings, merge-commit-only, `merge_commit_message: PR_BODY`)
+- `docs/strategy-project-management.md` (issue → board automation; closing-keyword behavior)
+- `.github/workflows/ci.yml` (the gate the local `npm test` mirrors)
+- `.github/workflows/forward-migrate-prod-schema-expansion.yml` (the workflow `/ship` dispatches for expand changes)
+- `gh` CLI (issue lookup, authentication state)

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: pr
+description: Open a new PR or update an existing PR for the current branch in the Intentional Society repo. Invoke explicitly as `/pr [PR#|URL|issue-or-context]`. Always fetches `origin/main` first, rebases if main has moved (re-running `npm test` after rebase), then pushes. On a fresh branch with no open PR, drafts a Conventional Commit-style title and structured body for human approval before `gh pr create`. On an existing PR, posts a brief per-commit summary comment and only updates the PR body on material scope change (with human approval, because the body becomes the merge commit message). Delegates dirty / on-main states to `/commit`. Refuses branch-switching — that's `/ship`'s job. Does not poll CI checks. Fires only on explicit `/pr` invocation.
+disable-model-invocation: true
+---
+
+# /pr
+
+The middle Skill in the commit → PR → ship chain. `/pr` ensures the branch is current with `origin/main`, runs `npm test` again if anything changed during rebase, and either opens a new PR or summarizes new commits on the existing one. It does **not** watch CI and it does **not** merge — that's `/ship`'s job.
+
+## Invocation
+
+`/pr [PR#|URL|issue-or-context]`
+
+Argument resolution order:
+
+1. **URL parses as a PR URL** → existing PR.
+2. **Integer resolves via `gh pr view <N>`** → existing PR.
+3. **Integer resolves via `gh issue view <N>`** → issue context (treated the same as `/commit`'s issue-or-context — used for branch naming, PR-title hints, and `Closes #N` linking).
+4. **Anything else** → plain-language context.
+
+No `/pr --auto-ship` and no `/pr --auto-merge`. `/ship` is the chained workflow; `/pr` stops after opening or updating the PR.
+
+Natural-language phrasings ("open the PR for this branch", "make a PR") are guidance, not triggers. With `disable-model-invocation: true`, this Skill fires only on explicit `/pr`.
+
+## Steps
+
+1. **Check `gh` auth.** `gh auth status`. If it fails, refuse and print `gh auth login` as the suggested next command.
+
+2. **Resolve the argument** using the order above.
+
+3. **Refuse to switch branches.** If the resolved PR is on a branch different from the current checkout, refuse — `/pr` does not switch branches. Name both branches and suggest `/ship <PR#>` (which is allowed to switch when the working tree is clean).
+
+4. **Working-tree pre-flight.** If `git status --porcelain` is non-empty OR HEAD is `main`, delegate to `/commit` with the same argument. When `/commit` returns, continue with this Skill from step 5.
+
+5. **Fetch.** `git fetch origin main`.
+
+6. **Freshness check + rebase if needed.** Run `git merge-base --is-ancestor origin/main HEAD`. If it fails (main has moved relative to the branch), run `git rebase origin/main`. On rebase conflict, abort the rebase, report the conflicted files, and hand control to the human — don't try to resolve conflicts automatically.
+
+7. **Re-run the gate after rebase.** If the rebase changed anything, re-run `npm test`. Skip the re-run when the rebase was a no-op.
+
+8. **Push.** `git push -u origin <branch>`. Use `--force-with-lease` only if the rebase rewrote already-pushed commits. Never plain `--force`.
+
+9. **If no open PR for this branch — draft and create.**
+
+    Draft a PR title and body for human approval, then run `gh pr create`.
+
+    **Title:** same Conventional Commit-style headline rule as `/commit`. `<type>[(scope)]: <imperative summary>`, ≤70 chars, including `!` for breaking changes. The title is durable: GitHub uses it verbatim as the merge commit subject (`merge_commit_title: PR_TITLE`).
+
+    **Body:** the same structured convention as `/commit`'s message body.
+
+    - `Summary:` — one sentence.
+    - `Why:` — motivation.
+    - `Behavior:` — observable change.
+    - `Test Plan:` — evidence (commands run with output, human attestations, or the collapsed `ran \`npm test\` locally` line). Same provenance rule as `/commit` — never invented.
+    - `Closes #N` / `(#N)` references.
+    - AI co-author trailer (same protocol as `/commit`: canonical form when detection succeeds, ask-once + body caveat on fallback).
+
+    **Test-plan formatting.** Plain bullets, not Markdown task-list checkboxes. The body becomes the durable merge commit message in this repo (`merge_commit_message: PR_BODY`), and unchecked task-list boxes look like outstanding work. If human-only verification remains, surface it as a pending action or reviewer note, not as completed test evidence. Don't add task-list checkboxes unless they already come from `.github/PULL_REQUEST_TEMPLATE.md`.
+
+    Present the full draft (title + body) for human Y/n approval before `gh pr create`. On approval, run `gh pr create`.
+
+10. **If an open PR for this branch exists — comment-by-default, body-update only on material scope change.**
+
+    Post a short PR-conversation comment summarizing each new commit pushed in this run (one bullet per commit; subject + short rationale).
+
+    Update the PR body **only** if the new commits materially change the PR's scope. Because the body is the durable merge commit message, ask for human approval before saving any body update. Phrase the question concretely — show the proposed diff to the body, not just "want me to update?"
+
+11. **Print the PR URL and stop.** `/pr` does not poll CI checks. Watching CI and merging is `/ship`'s job.
+
+## Failure modes
+
+- **`gh` unavailable or unauthenticated.** Refuse loudly; print `gh auth login`.
+- **Argument resolves to a PR on a different branch from the current checkout.** Refuse; name both branches; suggest `/ship <PR#>` for switching.
+- **Rebase conflict during `git rebase origin/main`.** Abort the rebase; report conflicted files; hand to human. Do not auto-resolve.
+- **`npm test` fails after rebase.** Refuse; surface the failing test output.
+- **`gh pr create` fails or the PR-comment update fails.** Report the error; do not retry blindly.
+- **Human rejects the PR draft text or the body-update proposal.** Return to step 9 or 10 with the rejection reason captured.
+- **Duplicate PR would result** (an open PR already exists for the branch and the argument asked to create another). Refuse.
+- **Never enable GitHub-side auto-merge.** `allow_auto_merge` is off at the repo level; do not work around it.
+- **Never silently force-push.** Use `--force-with-lease` and only when the rebase actually rewrote already-pushed commits.
+
+## Depends on
+
+- `CLAUDE.md`
+- `package.json` (for `npm test`)
+- `docs/strategy-committing.md` (commit/PR format, AI-trailer subsection)
+- `docs/strategy-branching.md` (rebase-when-main-moves rule; up-to-date branch protection)
+- `docs/doc-github.md` (PR settings: merge-commit-only; `merge_commit_title: PR_TITLE`; `merge_commit_message: PR_BODY`; `allow_update_branch: true` but local rebase preferred so the post-update `npm test` gate can re-run)
+- `docs/strategy-project-management.md` (PR-linked → board "In progress" automation)
+- `.github/workflows/ci.yml` (the required check that gates merge)
+- `gh` CLI
+- `.claude/skills/commit/SKILL.md` (delegated to on dirty / on-main pre-flight)

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: ship
+description: Orchestrate the full commit → PR → merge → post-merge-watch chain for a branch or PR in the Intentional Society repo. Invoke explicitly as `/ship [PR#|URL|issue-or-context]`. Delegates dirty / on-main states to `/pr` (which delegates to `/commit`). Fetches `origin/main`, rebases if needed, dispatches the schema-expand workflow when a schema expand is pending and waits for the `prod-db` approval gate + post-deploy e2e, watches all required and visible advisory pre-merge checks for up to 5 minutes (offering `wait+5` / `troubleshoot` / `abort` — never `proceed anyway`), runs `gh pr merge --merge --delete-branch` (the only valid merge form per repo settings), tidies the local branch, then watches `main` for up to 5 minutes for the production deploy and post-merge e2e. Fires only on explicit `/ship` invocation.
+disable-model-invocation: true
+---
+
+# /ship
+
+The orchestrator. `/ship` is the only way to run the chained commit → PR → merge sequence — there is no second path. It delegates downward (`/ship` → `/pr` → `/commit`) and never auto-acts past the merge: the post-merge watch reports, the human decides whether to hotfix or revert if anything goes red.
+
+## Invocation
+
+`/ship [PR#|URL|issue-or-context]`
+
+Argument resolution: same order as `/pr` (PR URL → `gh pr view <N>` → `gh issue view <N>` → plain-language context).
+
+**Branch-switching policy.** If `[PR#|URL]` resolves to a PR on a branch different from the current checkout, `/ship` **may** switch branches — but only after verifying the current branch's working tree is clean. If the tree is dirty, refuse with a suggestion to commit or stash; never auto-stash (see Stash safety below). `/pr` refuses to switch under all conditions; `/ship` is the only Skill that switches.
+
+**No `--squash` flag.** Repo PR settings disable squash and rebase merging — only merge-commit is allowed. The merge command is always `gh pr merge --merge --delete-branch`. Re-enabling squash is a repo-policy decision, not a Skill flag.
+
+Natural-language phrasings ("ship it", "merge this PR") are guidance, not triggers. With `disable-model-invocation: true`, this Skill fires only on explicit `/ship`.
+
+## Steps
+
+1. **Check `gh` auth.** `gh auth status`. If it fails, refuse and print `gh auth login`.
+
+2. **Parse arguments; resolve target PR.** If the argument names a different branch AND the current working tree is clean, `git switch <target-branch>`. If the current working tree is dirty, refuse with a clear suggestion (commit or stash). Do not auto-stash.
+
+3. **Working-tree pre-flight.** If dirty or on `main` with no PR for the current branch, delegate to `/pr` (which delegates to `/commit` per `/pr` step 4). When `/pr` returns with a PR URL, continue.
+
+4. **Fetch — no shallow shortcuts.** `git fetch origin main`. Do not use shallow-fetch shortcuts (`--depth=1` etc.) for freshness checks — a shallow fetch breaks `git merge-base` and was the root cause of a recent expand-workflow bug ([PR #254](https://github.com/Intentional-Society/is-app/pull/254)).
+
+5. **Freshness check + rebase if needed.** Run `git merge-base --is-ancestor origin/main HEAD`. If it fails (main has moved), `git rebase origin/main`. On rebase conflict, abort and surface — do not auto-resolve.
+
+6. **Re-gate after rebase.** If the rebase changed anything, re-run `npm test`, then `git push --force-with-lease`.
+
+7. **Dispatch schema expand if pending.** If a schema expand from `/commit` is pending and not yet deployed, run `npm run prod:db:expand` to dispatch the `forward-migrate-prod-schema-expansion` workflow against the pushed branch.
+
+   **While-you-wait narration.** The workflow pauses on a manual approval gate in the `prod-db` GitHub Actions environment before injecting production credentials. This gate can take minutes to hours depending on maintainer availability — that is expected and normal, not a hang. While waiting:
+
+   - Surface the workflow run URL (so the human can find the approval button on the GitHub Actions page).
+   - Surface the migration SQL preview (so the human can review what will be applied).
+   - Surface the PR link (so the maintainer reviewing has full context).
+   - Stay in the wait loop. Do not time out the way the CI wait at step 8 does — there is no realistic upper bound on team availability here.
+
+   Once the workflow completes successfully, wait for the next `e2e.yml` run to fire on the post-deploy commit. Require it to pass before continuing to step 8. If the dispatch fails, maintainer approval is denied, or post-deploy e2e fails, surface the failing run and refuse.
+
+8. **Wait for CI checks.** `gh pr checks <N> --watch`. The required check (`Lint & Functional Tests`) plus every visible advisory check (E2E, CodeQL, and any others present) must be green.
+
+   Wait up to **5 minutes** for pending advisories. After 5 minutes, present three options:
+
+   - `wait+5` — wait another 5 minutes.
+   - `troubleshoot` — exit the wait loop and surface the still-pending check name(s) and URL(s) for human investigation.
+   - `abort` — abandon the merge attempt.
+
+   **There is no `proceed` option.** Anything not green blocks the merge.
+
+9. **Docs-only PR handling.** If the PR's diff is confined to `docs/**` and root `CLAUDE.md`:
+
+   - `ci.yml`'s `dorny/paths-filter` step skips the test steps but still posts `Lint & Functional Tests` green within seconds (satisfies branch protection).
+   - Vercel preview is skipped per `vercel.json`'s `ignoreCommand`, so no preview `deployment_status` event fires and preview `e2e.yml` does not run.
+   - Treat the absent pre-merge advisory checks (E2E, anything else gated on the preview deploy) as **expected** per `docs/doc-github.md`'s docs-only rule. Proceed on required-green only — do not wait for advisories that the docs-only path skipped by design.
+
+10. **Merge confirmation policy.**
+
+    - **If `/ship` opened the PR during this same run** (via delegated `/pr` create at step 3), present a final Y/n merge confirmation.
+    - **If the PR pre-existed at `/ship` invocation**, the `/ship` invocation itself is the merge confirmation. Narrate the merge in one line and proceed without a second prompt.
+
+11. **Merge.** `gh pr merge <N> --merge --delete-branch`.
+
+    - Do **not** pass `--merge-title` or `--body` flags. GitHub uses the PR title and body verbatim per the repo's `merge_commit_title: PR_TITLE` / `merge_commit_message: PR_BODY` settings; custom flags would override that and create inconsistent history.
+    - Never `--admin`, `--auto`, force-merge, `--squash` (repo-disabled), or any branch-protection bypass.
+
+12. **Tidy.** `git switch main && git pull --ff-only`. Then `git branch -d <feature-branch>` if the local branch still exists and is fully merged. The remote branch is auto-deleted on merge (`delete_branch_on_merge: true`); the explicit `--delete-branch` flag on `gh pr merge` covers both the local-cleanup intent and the rare case where remote deletion didn't happen.
+
+13. **Capture merge SHA + discover post-merge runs.** `git log -1 --format=%H` on `main` after the pull gives the merge SHA. Then `gh run list --branch main --commit <merge-sha> --limit 10` to discover the post-merge runs (typically Vercel production deploy and `e2e.yml` against the production environment).
+
+14. **Post-merge watch on `main` (up to 5 minutes).** Poll the discovered runs via `gh run watch <run-id>`. Expected runs:
+
+    - Vercel production deploy.
+    - `e2e.yml` against the production environment (gated on the production `deployment_status` event).
+
+    Outcomes:
+
+    - **All-green within 5 minutes.** Report merge SHA + Vercel production URL + `main: green.`
+    - **Red on any check.** Alert immediately with the failing check name, run URL, and a suggested next action (open hotfix branch or revert). The watch reports — it does not auto-act.
+    - **Still pending at 5 minutes.** Report what's pending; offer `wait+5`.
+
+## Stash safety
+
+Do not use `git stash && <command>; git stash pop` to switch branches across a dirty tree. `git stash` is a no-op when the tree is already clean — it doesn't push an empty marker — so the trailing `git stash pop` falls through to whatever was already on the stack, potentially applying leftover work from another branch. When step 2's branch-switch precondition fails on a dirty tree, refuse with a manual commit-or-stash suggestion to the human; do not mutate the stash stack on the human's behalf.
+
+## Failure modes
+
+- **No resolvable PR for the argument.** Refuse with a clear next command (e.g., "no open PR for branch X; run `/pr` first").
+- **Target branch can't be safely checked out** (dirty working tree on current branch). Refuse with a suggestion to commit or stash; do not auto-stash.
+- **`gh` unavailable or unauthenticated.** Refuse loudly.
+- **Rebase conflict during freshness update.** Abort the rebase; surface the conflicted files; hand to human.
+- **`npm test` fails after rebase.** Refuse; surface the failing test.
+- **Any pre-merge check is red, pending past wait limits, or missing where it shouldn't be missing.** Refuse and offer the three supervised-handoff options (`wait+5`, `troubleshoot`, `abort`). No `proceed`.
+- **Schema expand required but `npm run prod:db:expand` dispatch fails, maintainer approval is denied, or post-deploy e2e fails.** Refuse; surface the failing run.
+- **`gh pr merge` rejected by branch protection or ruleset enforcement.** Surface the protection rule that blocked the merge (e.g., "Branches must be up to date with `main`"). Do not retry blindly.
+- **Local branch deletion fails.** Report; do not retry blindly.
+- **Post-merge `main` check goes red within the 5-minute watch window.** Alert; suggest hotfix or revert. The watch reports; it does not auto-act.
+- **Never** use "Proceed anyway," force-merge, admin bypass, `gh pr merge --auto`, `--squash`, `--merge-title`, or `--body` flags.
+
+## Depends on
+
+- `CLAUDE.md`
+- `package.json` (for `npm test`; for `npm run prod:db:expand`)
+- `docs/strategy-committing.md` (expand-contract phase rules; AI-trailer subsection)
+- `docs/strategy-branching.md` (rebase-when-main-moves rule; merge-commit default)
+- `docs/doc-github.md` (PR settings: merge-commit-only; `merge_commit_title`/`merge_commit_message`; `delete_branch_on_merge: true`; `prod-db` environment + required-reviewers gate; docs-only check semantics)
+- `docs/strategy-project-management.md` (PR-merged → board "Done" automation)
+- `vercel.json` (`ignoreCommand` for docs-only PRs; `drizzle-kit migrate` ahead of `next build` on production deploys)
+- `scripts/update-main-branch-protection.mjs` (required check name `Lint & Functional Tests`; `strict_required_status_checks_policy: true`)
+- `.github/workflows/ci.yml` (required check; `dorny/paths-filter` docs-only handling)
+- `.github/workflows/e2e.yml` (post-deploy advisory; gated on `deployment_status.environment` ∈ {Preview, Production})
+- `.github/workflows/forward-migrate-prod-schema-expansion.yml` (the workflow `/ship` dispatches for expand changes)
+- `gh` CLI
+- `.claude/skills/pr/SKILL.md` (delegated to on dirty / on-main pre-flight; delegates further to `/commit`)
+- `.claude/skills/commit/SKILL.md` (leaf in the delegation chain)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- One sentence describing what this PR does. -->
+
+## Why
+
+<!-- The motivation: the bug, the request, the constraint that drove this change. -->
+
+## Behavior
+
+<!-- The observable change (UI, API, schema, build, log output, etc.). -->
+
+## Test Plan
+
+<!--
+Plain bullets — commands you ran with results, human attestations, or the
+collapsed "ran `npm test` locally" line. Never invented; never speculative.
+This body becomes the durable merge commit message in this repo
+(`merge_commit_message: PR_BODY`), so unchecked task-list boxes look like
+outstanding work. Use plain bullets, not `- [ ]` checkboxes.
+-->
+
+-
+
+## Checklist
+
+- [ ] If this PR changes `.claude/skills/**/SKILL.md`, smoke-test the affected Skill on a realistic prompt.

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,13 @@ Thumbs.db
 playwright-report/
 test-results/
 
-# claude
-.claude/
+# claude — ignore everything in .claude/ EXCEPT .claude/skills/, which holds
+# the portable AI procedure framework from PR #133 (docs/spec-portable-ai-procedures.md)
+# and must ship in the repo. Note: gitignore can't re-include children of an
+# excluded parent, so we exclude .claude/* (contents) rather than .claude/ (dir)
+# and re-include .claude/skills/ explicitly.
+.claude/*
+!.claude/skills/
 .vercel
 
 # agent scratch notes — emergent design decisions, working memory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,16 @@ Requires Docker Desktop. `npm run dev` auto-starts a local Supabase stack (Postg
 - **e2e.yml**: Playwright against Vercel preview URL, triggered by `deployment_status` event. Not a required GitHub check, but team policy requires it green before merging to `main`.
 - Vercel auto-deploys `main` to production; the build command runs `drizzle-kit migrate` before `next build` on production deploys only (gated by `VERCEL_ENV`)
 
+## AI Skills
+
+Three Claude Code Skills live at `.claude/skills/` and encode the team's check-in workflow. They fire on explicit slash invocation only (`disable-model-invocation: true`).
+
+- `/commit [issue-or-context]` — stage, run `npm test`, draft a Conventional Commit-style message, bundled human approval, push. See [.claude/skills/commit/SKILL.md](.claude/skills/commit/SKILL.md).
+- `/pr [PR#|URL|issue-or-context]` — fetch + rebase if main moved, push, open or update the PR. Does not watch CI. See [.claude/skills/pr/SKILL.md](.claude/skills/pr/SKILL.md).
+- `/ship [PR#|URL|issue-or-context]` — orchestrates `/pr` (which orchestrates `/commit`), waits for CI green, merges via `gh pr merge --merge --delete-branch`, watches `main` for 5 minutes post-merge. See [.claude/skills/ship/SKILL.md](.claude/skills/ship/SKILL.md).
+
+Design and rationale: [docs/spec-portable-ai-procedures.md](docs/spec-portable-ai-procedures.md).
+
 ## Key docs
 
 - `docs/strategy-branching.md` — branching strategy and rationale

--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ supabase/           Local Supabase config (config.toml)
 drizzle/            Database migration files
 ```
 
+## Working with AI assistants
+
+Three Claude Code Skills under [.claude/skills/](.claude/skills/) encode the team's check-in workflow. Invoke them explicitly by name:
+
+- `/commit [issue-or-context]` — stage, test, draft a Conventional Commit-style message, bundled human approval, push.
+- `/pr [PR#|URL|issue-or-context]` — fetch + rebase if needed, push, open or update the PR.
+- `/ship [PR#|URL|issue-or-context]` — orchestrates the full chain (`/pr` → `/commit` as needed), waits for CI green, merges, watches `main`.
+
+Design rationale and the full step lists are in [docs/spec-portable-ai-procedures.md](docs/spec-portable-ai-procedures.md).
+
 ## Documentation
 
 | Doc | Description |

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -12,6 +12,10 @@ De-duplicate keywords on save in `parseEditableProfile` (server-side) and in `Ke
 
 Added a 6th card to the logged-in homepage grid linking to the Google Form feedback survey. Opens in a new tab, styled to match the existing NavCard pattern.
 
+## 2026-05-27 | Blake | Portable AI procedure framework (#133)
+
+Three Claude Code Skills (`/commit`, `/pr`, `/ship`) added under `.claude/skills/`, encoding the team's check-in workflow per the merged v5 spec from PR #133 and dev plan from PR #283. See `docs/spec-portable-ai-procedures.md` for behavior and `.claude/skills/{commit,pr,ship}/SKILL.md` for the per-Skill bodies.
+
 ## 2026-05-26 | Blake | Stash-pop antipattern callout in committing strategy
 
 Added a callout to `docs/strategy-committing.md` warning against `git stash && X; git stash pop` as a clean-slate verification idiom — instead, use `git stash list` to check the stack first, and only pop if you actually put something there. Surfaced from RCA #284 (Gap 4); resolves #287.

--- a/docs/doc-github.md
+++ b/docs/doc-github.md
@@ -35,6 +35,10 @@ Enforced via a GitHub Ruleset, managed as code in `scripts/update-main-branch-pr
 - **Code-owner review required** on paths listed in `.github/CODEOWNERS` (currently `.github/workflows/` and `.github/CODEOWNERS` itself). A CI-secret-touching workflow change can't land without a second codeowner's approval.
 - **Repository Admin can bypass per-PR** by ticking the bypass checkbox in the merge box (`bypass_mode: "pull_request"`). Not silent — admin merges that don't tick it still enforce every rule, including codeowner review. Previously was `"always"`, which silently skipped every rule for admins and defeated the codeowner gate; tightened after PR #159 merged without triggering review.
 
+## Related Skills
+
+The `/ship` Skill (`.claude/skills/ship/SKILL.md`) reads the required + visible advisory checks via `gh pr checks <N> --watch`, refuses to merge through anything not green (no "Proceed" option), and runs `gh pr merge --merge --delete-branch` — the only merge form the repo accepts. It never passes `--merge-title` or `--body` flags, so the PR title and body land verbatim in `main` history per the `merge_commit_title` / `merge_commit_message` settings above.
+
 ## CI workflows
 
 - `.github/workflows/ci.yml` — lint + functional tests, triggers on `pull_request` to main. Spins up the full local Supabase stack via `supabase/setup-cli@v1` + `supabase start`, then applies Drizzle migrations before running Vitest. Functional tests that hit the DB (e.g. `profiles.test.ts`) run against this stack, matching the dev-box setup exactly.

--- a/docs/strategy-branching.md
+++ b/docs/strategy-branching.md
@@ -37,3 +37,7 @@ Branch protection enforces *up-to-date-with-main* before the merge button works 
 Default to a merge commit (`gh pr merge --merge --delete-branch`). The merge commit preserves the branch boundary: `git log --first-parent main` reads as one line per PR, with each PR's individual commits still reachable through the merge commit's second parent. Squash loses the commits; rebase keeps the commits but loses the boundary.
 
 `--delete-branch` removes the local and remote branch copies in one shot. Repository settings disable squash and rebase merging entirely, so the merge button can't pick a different method by accident — see `docs/doc-github.md` for the full PR settings.
+
+### Related Skills
+
+`/commit` (`.claude/skills/commit/SKILL.md`) auto-creates a feature branch when invoked on `main`; `/pr` (`.claude/skills/pr/SKILL.md`) rebases onto `origin/main` when main has moved and re-runs `npm test` before pushing; `/ship` (`.claude/skills/ship/SKILL.md`) handles the merge step (`gh pr merge --merge --delete-branch`) and tidies the local branch.

--- a/docs/strategy-committing.md
+++ b/docs/strategy-committing.md
@@ -91,3 +91,28 @@ This works because Drizzle's schema is TypeScript code, so removing a column tur
 ## AI-assisted commits
 
 We allow and encourage AI coding support, but you are responsible for the quality of both the code changes and the commit message. Commits made fully by AI assistance include a `Co-Authored-By` trailer for attribution and traceability.
+
+### Conventional Commit style
+
+Commit subjects (and PR titles, since PR titles become the merge commit subject per `merge_commit_title: PR_TITLE` in `docs/doc-github.md`) follow the [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format:
+
+`<type>[(scope)]: <imperative summary>`, **≤70 characters**.
+
+Repo-observed types: `feat`, `fix`, `a11y`, `test`, `docs`, `chore`. Use the common CC types (`refactor`, `perf`, `ci`, `build`) when they fit. If several apply, pick the dominant intent.
+
+Breaking changes get `!` before the colon AND a `BREAKING CHANGE:` footer in the body that explains the compatibility impact. Example: `feat!: remove deprecated profile.legacyId field`.
+
+Commit body sections, in order: `Summary:` (one sentence), `Why:`, `Behavior:`, `Test Plan:`. Use plain bullets in `Test Plan:`, not Markdown task-list checkboxes — the body becomes the durable merge commit message (`merge_commit_message: PR_BODY`), and unchecked task boxes look like outstanding work. Don't add task-list checkboxes unless they already come from the PR template.
+
+### AI co-author trailer
+
+Every AI-authored commit (whether typed by hand from an AI suggestion or run via `/commit`) ends with a `Co-Authored-By:` trailer. Two paths:
+
+- **Detection path (preferred).** When the agent can read its own model identity from runtime context, emit the canonical form: `Co-Authored-By: <Model Name> <Version> <noreply@anthropic.com>`. Example: `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`.
+- **Fallback path (detection failed).** Ask the human once for the attribution string. Emit `Co-Authored-By: <human-provided string> <noreply@unspecified>` and append a one-line caveat to the commit body: `Note: AI co-author identity provided by human; auto-detection failed.`
+
+v1 is Claude-only — no multi-vendor matrix.
+
+### Related Skills
+
+The `/commit` Skill (`.claude/skills/commit/SKILL.md`) encodes both rules above, plus the suspicious-file blocker, the combined-expand+contract refusal, and the single bundled human approval checkpoint. Run it explicitly as `/commit [issue-or-context]`.

--- a/docs/strategy-project-management.md
+++ b/docs/strategy-project-management.md
@@ -47,6 +47,10 @@ Deliberately disabled:
 
 The rest of GitHub's built-in automations are off.
 
+### Related Skills
+
+`/pr` (`.claude/skills/pr/SKILL.md`) opens PRs (triggering the **PR Linked → In progress** automation when the PR body has `Closes #N`); `/ship` (`.claude/skills/ship/SKILL.md`) merges them (triggering the **PR Merged → Done** automation).
+
 ## Issue conventions
 
 > TODO: document title format, labels we actually use, when to file an issue vs just ship it, how to link PRs to issues, how we use assignees.

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -1,0 +1,96 @@
+{
+  "$comment": "Eval prompt definitions for the three portable AI procedure Skills (/commit, /pr, /ship). Each entry is the realistic user prompt that would invoke the Skill in production, plus an expected_output description of correct behavior. Prompts are taken from docs/plan-portable-ai-procedures.md sections 4.1, 4.2, 4.3. This file is a committed acceptance artifact, not a generated run output.",
+  "skills": [
+    {
+      "skill_name": "commit",
+      "skill_path": ".claude/skills/commit/SKILL.md",
+      "spec_section": "docs/spec-portable-ai-procedures.md §4.1",
+      "evals": [
+        {
+          "id": "commit-1-happy-path",
+          "eval_name": "happy-path-feature-branch-cc-subject",
+          "prompt": "/commit \"fix profile redirect\"",
+          "preconditions": "On a dirty feature branch (not main); a handful of modified files in src/ related to the profile-redirect bug; no .env or generated artifacts in the diff; gh is authenticated.",
+          "expected_output": "Skill stages only the explicit profile-redirect paths (no `git add -A`), runs the suspicious-file blocker (clean), runs `npm test` (pass), drafts a Conventional Commit-style subject like `fix: fix profile redirect` (≤70 chars) with Summary/Why/Behavior/Test Plan body sections and the `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` trailer, shows the bundled approval block (message + staged payload + no devjournal since this is a bugfix), awaits Y/n, then commits and pushes. Reports SHA + tracking info."
+        },
+        {
+          "id": "commit-2-refusal-suspicious-file",
+          "eval_name": "refusal-env-local-in-payload",
+          "prompt": "/commit \"add user endpoint\"",
+          "preconditions": "On a feature branch with a few edits to src/server/api.ts AND a modified `.env.local` in the working tree; no staging done yet.",
+          "expected_output": "Skill identifies `.env.local` as a suspicious-file blocker match (`.env*` rule), refuses to stage it, surfaces the filename, and asks the human for direction (remove from payload, include intentionally, or split). Does NOT proceed to `npm test` or commit. Does NOT use `git add -A`."
+        },
+        {
+          "id": "commit-3-edge-schema-expand-and-combined-refusal",
+          "eval_name": "schema-expand-surface-plus-combined-expand-contract-refusal",
+          "prompt": "/commit #142",
+          "preconditions": "Issue 142 is open and describes a schema change. Two sub-scenarios are evaluated under this id:\n  (a) Payload contains only an expand change to `src/server/schema.ts` and a new `drizzle/0019_add_column.sql`. Expected: Skill correctly identifies the expand phase, surfaces in the approval block that `/ship` will need to run `npm run prod:db:expand` after PR creation (with the `prod-db` maintainer-approval gate) and that the post-deploy `e2e.yml` must pass before merge, then proceeds normally through `npm test` + approval + commit + push.\n  (b) Payload contains an expand change AND a contract change to `src/server/schema.ts` in the same commit (a column added and a different column dropped). Expected: Skill refuses with `Refuse combined expand+contract payloads`, asks the human to split into two commits in deploy order (expand first, contract second).",
+          "expected_output": "(a) Expand-only: schema-expand wait narration appears in the approval block; commit proceeds normally. (b) Combined: hard refusal naming both phases; no commit happens."
+        }
+      ]
+    },
+    {
+      "skill_name": "pr",
+      "skill_path": ".claude/skills/pr/SKILL.md",
+      "spec_section": "docs/spec-portable-ai-procedures.md §4.2",
+      "evals": [
+        {
+          "id": "pr-1-happy-path-existing-pr",
+          "eval_name": "happy-path-existing-pr-comment-on-push",
+          "prompt": "/pr",
+          "preconditions": "On a feature branch that has an open PR; 2 new commits ahead of the last push; working tree clean; gh authenticated; `origin/main` has not advanced (rebase is a no-op).",
+          "expected_output": "Skill runs `gh auth status` (pass), confirms tree clean, `git fetch origin main`, `merge-base --is-ancestor` succeeds (no rebase needed), skips the post-rebase `npm test` re-run (rebase was a no-op), `git push -u origin <branch>`, posts a PR-conversation comment summarizing each new commit (one bullet per commit), does NOT update the PR body (no material scope change), prints the PR URL, stops. Does NOT poll CI checks."
+        },
+        {
+          "id": "pr-2-refusal-branch-mismatch",
+          "eval_name": "refusal-pr-on-different-branch",
+          "prompt": "/pr 145",
+          "preconditions": "Current checkout is on branch `feature-x`. PR 145 is on branch `feature-y`. Tree clean; gh authenticated.",
+          "expected_output": "Skill resolves the argument to PR 145 via `gh pr view 145`, detects the branch mismatch, refuses to switch (per `/pr` policy), names both branches in the refusal, and suggests `/ship 145` for switching. No fetch, no push, no PR-side mutation."
+        },
+        {
+          "id": "pr-3-edge-dirty-tree-delegation",
+          "eval_name": "edge-case-delegation-to-commit-then-create-pr",
+          "prompt": "/pr \"wire up dashboard\"",
+          "preconditions": "On a feature branch with uncommitted changes related to a dashboard wiring task; no existing PR; gh authenticated.",
+          "expected_output": "Skill detects dirty tree at the working-tree pre-flight, delegates to `/commit \"wire up dashboard\"` with the same argument. `/commit` runs its full flow (stage, test, approval, commit, push). On return, `/pr` continues: fetch, no-op rebase, no-op re-test, push (already pushed by `/commit`; idempotent), then drafts a CC-format PR title (e.g., `feat: wire up dashboard`) and structured body for human approval, runs `gh pr create` on approval, prints the URL, stops."
+        },
+        {
+          "id": "pr-4-new-pr-cc-title-breaking-change",
+          "eval_name": "new-pr-cc-title-and-breaking-change-flag",
+          "prompt": "/pr",
+          "preconditions": "On a feature branch with no open PR; tree clean; the branch contains a single commit that removes a public API field (a breaking change); gh authenticated; `origin/main` has not advanced (rebase no-op).",
+          "expected_output": "Skill runs `gh auth status`, confirms tree clean, fetch, no-op rebase, no-op re-test, push, then drafts a CC-format title with the breaking-change flag — e.g., `feat!: remove deprecated profile.legacyId field` (≤70 chars). Body includes the `Summary:` / `Why:` / `Behavior:` / `Test Plan:` sections and a `BREAKING CHANGE:` footer explaining the compatibility impact. Surfaces the breaking-change classification in the approval prompt so the human can confirm before `gh pr create`."
+        }
+      ]
+    },
+    {
+      "skill_name": "ship",
+      "skill_path": ".claude/skills/ship/SKILL.md",
+      "spec_section": "docs/spec-portable-ai-procedures.md §4.3",
+      "evals": [
+        {
+          "id": "ship-1-happy-path-preexisting-pr",
+          "eval_name": "happy-path-preexisting-pr-all-green",
+          "prompt": "/ship",
+          "preconditions": "On a feature branch with a pre-existing open PR (not opened during this run); tree clean; `origin/main` has not advanced; required + visible advisory checks (Lint & Functional Tests, E2E, CodeQL) are all green; no schema expand pending.",
+          "expected_output": "Skill runs `gh auth status` (pass), fetch, `merge-base --is-ancestor` succeeds (no rebase, no re-test), no expand dispatch, `gh pr checks <N> --watch` returns all-green immediately, recognizes the PR pre-existed (no second merge confirmation prompt — narrates the merge in one line), runs `gh pr merge <N> --merge --delete-branch` (no `--squash`, no `--merge-title`, no `--body`), tidies (`git switch main && git pull --ff-only && git branch -d <feature-branch>`), captures merge SHA, runs `gh run list --branch main --commit <sha>`, watches the post-merge runs for up to 5 minutes. On all-green within window: reports merge SHA + Vercel production URL + `main: green.`"
+        },
+        {
+          "id": "ship-2-refusal-pending-advisory-past-wait",
+          "eval_name": "refusal-pending-advisory-past-5min-three-options",
+          "prompt": "/ship",
+          "preconditions": "On a feature branch with a pre-existing open PR; tree clean; required check `Lint & Functional Tests` green within 1 minute; advisory E2E still pending after the 5-minute wait window; no `proceed` option offered.",
+          "expected_output": "Skill enters the wait at step 8, waits 5 minutes for advisories, then presents EXACTLY three options: `wait+5`, `troubleshoot`, `abort`. No `proceed` option is offered or accepted. If the human picks `wait+5`, repeats the wait; if `troubleshoot`, exits the wait and surfaces the still-pending check name + URL; if `abort`, abandons the merge attempt without calling `gh pr merge`."
+        },
+        {
+          "id": "ship-3-edge-docs-only-pr",
+          "eval_name": "edge-docs-only-pr-absent-advisories-expected",
+          "prompt": "/ship",
+          "preconditions": "On a docs-only branch (diff confined to `docs/**` and root `CLAUDE.md`) with a pre-existing open PR; tree clean; `Lint & Functional Tests` posts green within seconds via `dorny/paths-filter` skip; Vercel preview is suppressed per `vercel.json`'s `ignoreCommand` so no preview `deployment_status` event fires and preview `e2e.yml` does not run.",
+          "expected_output": "Skill recognizes the docs-only condition, treats absent advisory checks as expected (per `docs/doc-github.md` docs-only rule), does NOT wait 5 minutes for advisories that the docs-only path skipped by design, proceeds on required-green only, runs `gh pr merge --merge --delete-branch`, tidies, captures merge SHA, runs the post-merge watch on `main`. Production builds still run on `main` (including for docs-only merges), so if a production deploy or production `e2e.yml` run appears in the post-merge run list, the Skill reports its result. Reports merge SHA + post-merge status."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implement the three portable AI procedure Skills (`/commit`, `/pr`,
`/ship`) under `.claude/skills/` per the merged v5 spec (PR #133,
`docs/spec-portable-ai-procedures.md`) and the merged implementation
plan (PR #283, `docs/plan-portable-ai-procedures.md`). This PR was
itself partially self-hosted -- its two commits were produced via the
new `/commit` Skill's bundled-approval flow -- and, on approval, the
final merge will run via `/ship` on this PR itself.

## Why

The team's check-in workflow has so far depended on each teammate's
personal prompting and memory, so execution drifts across teammates
and across tool switches. Encoding the workflow as explicit Claude
Code Skills lets any teammate invoke `/commit`, `/pr`, `/ship` and
get the same behavior: local `npm test` gate, deterministic staging,
bundled human approval, merge-commit-only shipping, post-merge watch
on `main`.

This PR carries the implementation payload of dev-plan Phases 7a, 7b,
and 7c. Phase 8 validation (per-Skill eval self-review + the end-to-
end smoke-test on PR #303, merged 2026-05-27 at `7fbee8e`) is
complete. The Phase 9 self-host -- running `/ship` on this PR to merge
it -- is the integration test that earns the Skills their reputation
by shipping themselves; that step waits for your review approval.

## Behavior

Two commits on this branch:

**1. `feat: add /commit /pr /ship Skills + eval definitions` (Phase 7a + the `.gitignore` adjustment 7c needed)**

- `.claude/skills/commit/SKILL.md` (183 lines, under the spec's 500-line cap) -- Conventional Commit subject draft, suspicious-file blocker, combined expand+contract refusal, single bundled human approval, push.
- `.claude/skills/pr/SKILL.md` (93 lines) -- fetch + freshness rebase + re-run `npm test` if rebase changed anything, push, draft CC-format PR title/body on fresh branches, comment-by-default on existing PRs, refuses branch-switching.
- `.claude/skills/ship/SKILL.md` (122 lines) -- orchestrator; delegates dirty/on-main to `/pr`; schema-expand dispatch with the concrete "while-you-wait" narration the dev plan section 10 implementation note called for (names the `prod-db` approval gate explicitly, gives a minutes-to-hours latency expectation, tells the human where to look while waiting); CI wait with `wait+5`/`troubleshoot`/`abort` options (never "proceed"); `gh pr merge --merge --delete-branch`; post-merge watch on `main`.
- `evals/evals.json` -- committed eval prompt definitions (3 per Skill; 4 for `/pr` per the dev plan's 2026-05-27 CC-title-for-new-PR addition). This is the durable acceptance artifact, not a generated run output, so it stays out of `.gitignore` per dev-plan Phase 7c.2.
- **`.gitignore` -- intentional edit, please review:** the repo previously had a blanket `.claude/` ignore on line 41. Without changing it, the new Skills under `.claude/skills/` would have been silently skipped by git. Replaced with `.claude/*` (excludes contents) + `!.claude/skills/` (re-includes just the Skills directory). This is the only gitignore pattern git honors when re-including a child of an excluded directory -- a flat `!.claude/skills/` after `.claude/` doesn't work because git never descends into the excluded parent. All other `.claude/` contents (settings, history, project caches) remain ignored.

**2. `docs: wire /commit /pr /ship Skills into policy docs + PR template` (Phase 7b)**

- `CLAUDE.md` -- new "AI Skills" section above "Key docs", listing all three Skills with their invocation forms, paths, and a link to the spec.
- `docs/strategy-committing.md` -- "AI-assisted commits" section gets two new subsections (Conventional Commit style; AI co-author trailer protocol) plus a "Related Skills" back-link to `/commit`.
- `docs/strategy-branching.md`, `docs/doc-github.md`, `docs/strategy-project-management.md` -- one-line "Related Skills" back-links.
- `README.md` -- new "Working with AI assistants" section.
- `.github/PULL_REQUEST_TEMPLATE.md` -- NEW FILE (the repo didn't have one before). Includes Summary/Why/Behavior/Test Plan scaffolding plus the smoke-test checklist item the dev plan calls for: "If this PR changes `.claude/skills/**/SKILL.md`, smoke-test the affected Skill on a realistic prompt."

Phase 7c was a no-op for the script -- the existing `scripts/update-main-branch-protection.mjs` already matches the spec exactly (required check name `Lint & Functional Tests`, `strict_required_status_checks_policy: true`, no contradictions). The `.gitignore` adjustment is rolled into commit 1 above.

## Test Plan

- ran `npm run lint` -> Checked 213 files, 0 issues.
- ran `npm run typecheck` -> clean.
- ran `npm run test:functional` (lint + typecheck + dev:db + vitest) -> 21 files, 331 tests passed in ~11s. Full `npm test` (adds Playwright e2e) runs in CI via the Vercel preview deploy.
- self-review against `evals/evals.json` (3 + 4 + 3 = 10 prompts): every prompt maps to specific SKILL.md steps or named subsections.
- Phase 8.2 end-to-end smoke-test: PR #303 (`smoke-test/readme-docs-table` -> main, merged 2026-05-27 at `7fbee8e`) ran the full `/commit -> /pr -> /ship` chain end-to-end via manual execution of the SKILL.md bodies. All 6 pre-merge checks green within ~3 min; CodeQL on main + production E2E both green within the post-merge 5-min window.
- self-hosting validation: both commits on this branch were produced by following the new `/commit` Skill's bundled-approval flow (stage explicit paths, blocker check, run gate, draft CC-format message, present bundled approval block, commit + push). The Skill prescribed the behavior that produced the commits -- first real dogfood pass.
- branch rebased onto `origin/main` after PR #303's smoke-test merge; gate re-ran clean post-rebase before the force-with-lease push.

## Known follow-up (TODO before merging this PR, or fast-follow PR)

The spec section 4.2 Step 9 and the `/pr` SKILL.md body don't include a reviewer-designation step -- they go straight from "draft + approve" to `gh pr create` with no reviewer selection. The right fix is to extend the human approval block in `/pr` Step 9 to ask "and who should I add as reviewers?" and pass `--reviewer @user1,@user2` to `gh pr create`. The spec text either gets a parallel update or the SKILL.md can extend the spec's minimum (the spec doesn't forbid reviewer designation, only fails to mandate it).

This PR's reviewers (@james-baker, @benjifriedman, @oolu4236, @alexisChen9090) were added manually via `gh pr create --reviewer` rather than via the Skill flow. Blake flagged 2026-05-27 that this MUST be resolved quickly. Two paths (team can pick during review):

- **Before merging:** add a third commit to this branch that updates `.claude/skills/pr/SKILL.md` Step 9 with the reviewer-ask language and the `--reviewer` flag passthrough.
- **Fast-follow PR:** ship this PR as-is; open a small follow-up PR immediately that does the same edit. (Lower-risk; doesn't extend this PR's review surface.)

## Next step on approval

The final integration test is the Phase 9 self-host: on review approval, `/ship` runs on this PR to handle the rebase-or-no-op freshness check, CI wait, `gh pr merge --merge --delete-branch`, local tidy, and the 5-minute post-merge watch on `main`. If `/ship` self-host fails for any reason, the spec's clean fallback is manual `gh pr merge --merge --delete-branch` plus a follow-up issue captured for the Skill -- the repo is never at risk of being left in a broken state by the dogfood path.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>