### PR TITLE
fix(skills): /pr asks for reviewers in its approval block

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -71,13 +71,15 @@ Natural-language phrasings ("open the PR for this branch", "make a PR") are guid
     }
     ```
 
-    Populate on cold cache, in parallel:
+    Populate on cold cache. Steps (1) and (2) run in parallel; step (3) fans out per-login after (1) returns and the bot filter is applied:
 
     1. `gh api 'repos/<owner>/<repo>/collaborators' --paginate --jq '.[].login'` — full collaborator list.
     2. `gh api user --jq '.login'` — the running human's login (stored as `self`).
     3. For each surviving login, `gh api users/<login> --jq '.name // .login'` in parallel — display names. `// .login` returns the login when `.name` is null.
 
     Apply the **bot filter** to (1) before writing the cache: drop `github-advanced-security`, `copilot-pull-request-reviewer`, `claude`, any login starting with `app/`, any login containing `[bot]`. Maintain the list here in the SKILL.md as GitHub adds new advisory bots over time.
+
+    <!-- TODO(PR#305-followup): bot filter is applied at cache-write time, so existing teammate caches don't auto-invalidate when this list changes. Self-heals on the next `gh pr create --reviewer` rejection via the refresh-on-rejection path — at the cost of one wasted prompt cycle. Worth an explicit "force-refresh on filter version bump" if that cycle ever matters in practice. -->
 
     **Refresh triggers** (any one):
     - `refreshedAt` is older than **15 days**.
@@ -97,10 +99,10 @@ Natural-language phrasings ("open the PR for this branch", "make a PR") are guid
 
     **Accept the human's reply** in any of these shapes and resolve to a list of GitHub logins:
 
-    - Numbers (`1 3`, `1,3`, `1, 3`) — positional pick from the rendered order.
+    - Numbers (`1 3`, `1,3`, `1, 3`) — positional pick from the rendered order. If any number is out of range (e.g., `7` when only 5 entries are rendered), surface the invalid index and re-ask rather than partial-resolve.
     - Display names or partial names (`james and benji`, `Alexis`) — match against the cached display-name dictionary. On ambiguity, ask one clarifying question rather than guess.
     - Exact logins (`james-baker, benjifriedman`) — passed through after validating against the cache.
-    - `all` / `everyone` / `whole team` — every collaborator except `self`.
+    - `all` / `everyone` / `whole team` — every collaborator except `self`. If the resulting set is empty (one-person repo where `self` is the only collaborator), treat as `none`.
     - `none` / blank / `skip` — no reviewers.
     - `refresh` — refresh the team cache and re-render the picker.
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -43,7 +43,7 @@ Natural-language phrasings ("open the PR for this branch", "make a PR") are guid
 
 9. **If no open PR for this branch — draft and create.**
 
-    Draft a PR title and body for human approval, then run `gh pr create`.
+    Draft a PR title, body, and reviewer list for human approval, then run `gh pr create`.
 
     **Title:** same Conventional Commit-style headline rule as `/commit`. `<type>[(scope)]: <imperative summary>`, ≤70 chars, including `!` for breaking changes. The title is durable: GitHub uses it verbatim as the merge commit subject (`merge_commit_title: PR_TITLE`).
 
@@ -58,7 +58,66 @@ Natural-language phrasings ("open the PR for this branch", "make a PR") are guid
 
     **Test-plan formatting.** Plain bullets, not Markdown task-list checkboxes. The body becomes the durable merge commit message in this repo (`merge_commit_message: PR_BODY`), and unchecked task-list boxes look like outstanding work. If human-only verification remains, surface it as a pending action or reviewer note, not as completed test evidence. Don't add task-list checkboxes unless they already come from `.github/PULL_REQUEST_TEMPLATE.md`.
 
-    Present the full draft (title + body) for human Y/n approval before `gh pr create`. On approval, run `gh pr create`.
+    **Reviewers — show a one-line picker so the human picks correct logins without spelling them.** The bundled approval block has a third item alongside title and body: a `Reviewers:` picker built from a cached team list. Humans often think in real names ("add Blake") but GitHub needs the login (`NorsemanSpiff`); surfacing the team list eliminates name-to-handle guessing AND catches stale handles (e.g., `alexisChen9090` is a frozen historical handle for `AlexisChen99`).
+
+    **Team cache.** Store at `.claude/skills/pr/.team-cache.json` (per-machine, gitignored):
+
+    ```json
+    {
+      "collaborators": ["<login>", ...],
+      "displayNames": { "<login>": "<name or login>", ... },
+      "self": "<your login>",
+      "refreshedAt": "<ISO timestamp>"
+    }
+    ```
+
+    Populate on cold cache, in parallel:
+
+    1. `gh api 'repos/<owner>/<repo>/collaborators' --paginate --jq '.[].login'` — full collaborator list.
+    2. `gh api user --jq '.login'` — the running human's login (stored as `self`).
+    3. For each surviving login, `gh api users/<login> --jq '.name // .login'` in parallel — display names. `// .login` returns the login when `.name` is null.
+
+    Apply the **bot filter** to (1) before writing the cache: drop `github-advanced-security`, `copilot-pull-request-reviewer`, `claude`, any login starting with `app/`, any login containing `[bot]`. Maintain the list here in the SKILL.md as GitHub adds new advisory bots over time.
+
+    **Refresh triggers** (any one):
+    - `refreshedAt` is older than **15 days**.
+    - `gh pr create --reviewer <list>` rejects a login that exists in the cache (signal: a teammate was removed).
+    - The human types `refresh` in the reviewer prompt (escape hatch for "new teammate joined, refresh now").
+
+    **Render the picker.** Exclude `self` at render time so the same cache works for any teammate running `/pr`. Sort the remaining collaborators alphabetically by display name, case-insensitive. Number them in sort order. Render every collaborator — no truncation:
+
+    ```text
+    Reviewers? Reply with names, logins, numbers, "all", or blank:
+      [1] AlexisChen99    (AlexisChen)
+      [2] benjifriedman   (Benji Friedman)
+      [3] Ceantaur        (Sean)
+      [4] james-baker     (James Baker)
+      [5] oolu4236        (OLA)
+    ```
+
+    **Accept the human's reply** in any of these shapes and resolve to a list of GitHub logins:
+
+    - Numbers (`1 3`, `1,3`, `1, 3`) — positional pick from the rendered order.
+    - Display names or partial names (`james and benji`, `Alexis`) — match against the cached display-name dictionary. On ambiguity, ask one clarifying question rather than guess.
+    - Exact logins (`james-baker, benjifriedman`) — passed through after validating against the cache.
+    - `all` / `everyone` / `whole team` — every collaborator except `self`.
+    - `none` / blank / `skip` — no reviewers.
+    - `refresh` — refresh the team cache and re-render the picker.
+
+    **Echo the resolution** as one line before `gh pr create`, so the human always sees what got resolved:
+
+    ```text
+    → Requesting review from james-baker, benjifriedman. Proceeding.
+    ```
+
+    Pass the resolved list to `gh pr create --reviewer <login1>,<login2>,...` (no `@` prefix, no spaces inside the `--reviewer` value); omit the flag entirely when the list is empty.
+
+    **Failure handling.**
+
+    - If the cache file is missing or unreadable, regenerate it via the cold-cache path above. If regeneration fails (network, rate limit, gh unauthenticated), fall back to a bare `Reviewers (comma-separated logins or blank):` prompt with no picker — the Skill still works, just less ergonomically.
+    - If `gh pr create --reviewer` rejects a login (typo, no longer a collaborator), refresh the cache, surface the exact `gh` error + the refreshed picker, and re-ask. Don't retry blindly.
+
+    Present the full draft (title + body + reviewers) for human Y/n approval before `gh pr create`. On approval, run `gh pr create` with `--reviewer` when the list is non-empty.
 
 10. **If an open PR for this branch exists — comment-by-default, body-update only on material scope change.**
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ test-results/
 # and re-include .claude/skills/ explicitly.
 .claude/*
 !.claude/skills/
+# per-machine Skill state (team-cache, etc.) — never commit
+.claude/skills/**/.team-cache.json
 .vercel
 
 # agent scratch notes — emergent design decisions, working memory

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -61,6 +61,27 @@
           "prompt": "/pr",
           "preconditions": "On a feature branch with no open PR; tree clean; the branch contains a single commit that removes a public API field (a breaking change); gh authenticated; `origin/main` has not advanced (rebase no-op).",
           "expected_output": "Skill runs `gh auth status`, confirms tree clean, fetch, no-op rebase, no-op re-test, push, then drafts a CC-format title with the breaking-change flag — e.g., `feat!: remove deprecated profile.legacyId field` (≤70 chars). Body includes the `Summary:` / `Why:` / `Behavior:` / `Test Plan:` sections and a `BREAKING CHANGE:` footer explaining the compatibility impact. Surfaces the breaking-change classification in the approval prompt so the human can confirm before `gh pr create`."
+        },
+        {
+          "id": "pr-5-reviewer-cold-cache-numeric-pick",
+          "eval_name": "reviewer-cold-cache-numeric-pick-happy-path",
+          "prompt": "/pr",
+          "preconditions": "On a feature branch with a single commit and no open PR; tree clean; `origin/main` not advanced (rebase no-op); gh authenticated; `.claude/skills/pr/.team-cache.json` does not exist (cold cache); the repo has 5 human collaborators after bot-filtering.",
+          "expected_output": "Skill runs Steps 1-8 normally. At Step 9, detects no cache and fires the three cold-cache fetches in parallel: `gh api repos/<owner>/<repo>/collaborators`, `gh api user`, and parallel `gh api users/<login>` for display names. Applies the bot filter to the collaborator list before writing `.claude/skills/pr/.team-cache.json` with `collaborators`, `displayNames`, `self`, `refreshedAt`. Renders the vertical picker sorted alphabetically by display name (case-insensitive), with `self` excluded and entries numbered in sort order. The rendered picker MUST NOT contain `[xN]` count markers, 'Frequent reviewers' or 'Other collaborators' tier headers, or any sort key derived from past review/author activity. Human types `1 3`; Skill resolves to the two corresponding logins, echoes `→ Requesting review from <login1>, <login3>. Proceeding.`, presents the bundled approval block (title + body + resolved reviewers), and on approval runs `gh pr create --reviewer <login1>,<login3>` (no `@`, no spaces inside the value)."
+        },
+        {
+          "id": "pr-6-reviewer-warm-cache-natural-language",
+          "eval_name": "reviewer-warm-cache-natural-language-resolution",
+          "prompt": "/pr",
+          "preconditions": "On a feature branch with a single commit and no open PR; tree clean; `origin/main` not advanced (rebase no-op); gh authenticated; `.claude/skills/pr/.team-cache.json` exists, `refreshedAt` is 3 days old (well within 15-day TTL), `collaborators` includes both `james-baker` (displayName: `James Baker`) and `benjifriedman` (displayName: `Benji Friedman`), `self` is the running human's login.",
+          "expected_output": "Skill reads the cache without firing any `gh api` calls. Renders the vertical picker sorted alphabetically by display name with `self` excluded. The rendered picker MUST NOT contain `[xN]` count markers, 'Frequent reviewers' or 'Other collaborators' tier headers, or any sort key derived from past review/author activity. Human types `james and benji`; Skill matches against the cached `displayNames` dictionary, resolves unambiguously to `[james-baker, benjifriedman]`, asks no clarifying question, echoes `→ Requesting review from james-baker, benjifriedman. Proceeding.`, and on approval runs `gh pr create --reviewer james-baker,benjifriedman`. No cache write occurs during this run."
+        },
+        {
+          "id": "pr-7-reviewer-rejection-refresh-and-reask",
+          "eval_name": "reviewer-gh-rejection-triggers-cache-refresh-and-reask",
+          "prompt": "/pr",
+          "preconditions": "On a feature branch with a single commit and no open PR; tree clean; `origin/main` not advanced (rebase no-op); gh authenticated; `.claude/skills/pr/.team-cache.json` exists with `refreshedAt` 5 days old (within TTL) and contains a login `formerteam` that has since been removed from the repo's collaborator list on GitHub.",
+          "expected_output": "Skill reads the cache, renders the picker including `formerteam`. Human picks the number corresponding to `formerteam`. Skill echoes `→ Requesting review from formerteam. Proceeding.` and calls `gh pr create --reviewer formerteam`. gh returns a reviewer-invalid error. Skill catches the error, surfaces the exact `gh` error text to the human, refreshes the team cache via the same three cold-cache fetches (after which `formerteam` no longer appears in `collaborators`), re-renders the picker with the refreshed list, and re-asks for a reviewer pick. Does NOT retry `gh pr create` with the same input. No PR is created until the re-asked picker resolves to a valid set; on the re-asked pick, `gh pr create --reviewer <valid-login>` runs and the PR opens."
         }
       ]
     },


### PR DESCRIPTION
## Summary

Adds reviewer designation to `/pr` Step 9 via a cached one-line picker, closing the gap §4.2 Step 9 of the spec left open.

## Why

Without a reviewer step, `/pr` would run `gh pr create` with no reviewers requested, and humans would add reviewers manually with `gh pr edit --add-reviewer` after the PR opened — defeating the automation. Two real failure modes shaped the design:

1. **Real-name-to-handle confusion** — asking for "blake" without knowing the GitHub login is `NorsemanSpiff`.
2. **Stale-handle confusion** — typing a historical handle (`alexisChen9090`) instead of the current one (`AlexisChen99`); both belong to the same person, but the old handle is frozen in some git commit metadata.

Surfacing a vetted team list at the moment of reviewer selection eliminates both. The picker is deliberately unranked — alphabetical by display name, no review/author counts, no "frequent" tier, no ordering by past activity. Reviewer assignment is a deliberate choice, not a popularity signal.

## Behavior

`/pr` Step 9 shows a one-line prompt + vertical numbered picker, backed by a per-machine cache:

```text
Reviewers? Reply with names, logins, numbers, "all", or blank:
  [1] AlexisChen99    (AlexisChen)
  [2] benjifriedman   (Benji Friedman)
  [3] Ceantaur        (Sean)
  [4] james-baker     (James Baker)
  [5] oolu4236        (OLA)
```

- **Cache:** `.claude/skills/pr/.team-cache.json` (per-machine, gitignored). Holds collaborator list, display-name dictionary, self login, and `refreshedAt`.
- **Refresh triggers** (any one): cache age > 15 days, `gh pr create --reviewer` rejects a cached login (signal: teammate removed), or the human types `refresh` in the picker.
- **Input shapes:** numbers (`1 3`), exact logins, display names / partial names (`james and benji`), `all`, `none`/blank, or `refresh`. Natural-language shapes resolve against the cached display-name dictionary. Ambiguity gets one clarifying question, not a guess.
- **Echo:** Skill prints `→ Requesting review from <list>. Proceeding.` before `gh pr create` so the human always sees what got resolved.
- **Sort:** alphabetical by display name, case-insensitive.
- **Selection:** all collaborators minus bots, minus self at render time. No truncation.
- **Cost:** cold cache fires ~2s of parallel `gh api` calls, once per machine per 15 days. Warm cache: zero API calls, sub-second render.

## Eval coverage

Three new evals appended to `evals/evals.json` under the `pr` skill:

- **pr-5-reviewer-cold-cache-numeric-pick** (happy path) — cold cache → three parallel fetches → write cache → sorted picker → numeric pick → echo → `gh pr create --reviewer`.
- **pr-6-reviewer-warm-cache-natural-language** (edge) — fresh cache → zero API calls → `james and benji` → unambiguous resolution → echo → create.
- **pr-7-reviewer-rejection-refresh-and-reask** (refusal-flavored) — cached login no longer a collaborator → gh rejects → cache refresh → re-render → re-ask. No blind retry.

Each new eval includes an explicit negative assertion against ranked-hint shapes (`MUST NOT contain [xN] count markers, 'Frequent reviewers' or 'Other collaborators' tier headers, or any sort key derived from past review/author activity`), so the no-leaderboard constraint is test-pinned, not just convention.

## Test Plan

- `git check-ignore -v .claude/skills/pr/.team-cache.json` → `.gitignore:48` matches; cache path correctly excluded.
- `npm run lint` → Checked 213 files, 0 issues (covers SKILL.md + evals.json).
- `npm run typecheck` → types generated successfully.
- `evals/evals.json` parses; `pr` skill has 7 evals in order (pr-1..pr-7).
- Mental rehearsal of pr-5/6/7 against the Step 9 text — each expected_output traces directly to SKILL.md instructions. The eval-viewer tooling referenced in the spec is not yet built in this repo; eval validation is rehearsal against SKILL.md text — matches the rehearsal mode used for PR #304's original SKILL.md drafts.
- Content-only change; full `npm test` deferred to CI.

## Notes

Builds on the portable AI procedure framework introduced in PR #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)