### PR TITLE
Myweb tutorial and graph polish

### DIFF
--- a/docs/design-relations.md
+++ b/docs/design-relations.md
@@ -35,10 +35,10 @@ The MVP visualization is *you, and 1–2 hops out*. Whole-network views are bori
 
 A single value from a small set captures both "visible trust" and resonance, with room to add dimensions later. Drafted vocabulary (subject to refinement, worth member testing before committing):
 
-- `1` — we've met in group settings and know of each other.
-- `2` — we've spent some time talking 1-on-1 enjoyably.
-- `3` — friend.
-- `4` — deep trust and knowing.
+- `1` — **Acquaintance / Supporter**: I have spent some time with them and feel supportive.
+- `2` — **Friend / Collaborator**: I trust them in most ways and we can work well together.
+- `3` — **Companion / Comrade**: I feel deep resonance and shared purpose with them.
+- `4` — **Kindred / Co-Creator**: a kindred spirit; I hope to partner with them for decades.
 
 The absence of a relation is an absence of a row. There is no explicit "0 / no connection of interest" rating — un-rated suggestions simply re-surface in future feeds, and at MVP scale (50–100 members) that's a non-problem. A future "intentional dissonance" value (`-1`) is also deferred — the social cost of publicly logged negative feelings wants more design care than we have lived experience to provide right now.
 

--- a/src/app/myweb/my-web.tsx
+++ b/src/app/myweb/my-web.tsx
@@ -52,24 +52,33 @@ export function MyWeb({ initialLastUpdatedWeb }: { initialLastUpdatedWeb: Date |
   // Bumped on replay so Joyride fully unmounts/remounts — toggling
   // `run` alone doesn't reliably reset stepIndex back to 0.
   const [tourKey, setTourKey] = useState(0);
+  // Bumped after a successful relation so the tour advances past the
+  // "click anyone here" step automatically.
+  const [tourAdvanceToken, setTourAdvanceToken] = useState(0);
   useEffect(() => {
     if (initialLastUpdatedWeb !== null) return;
     if (window.sessionStorage.getItem(TOUR_DISMISSED_KEY) === "1") return;
     setTourRun(true);
   }, [initialLastUpdatedWeb]);
   const markDone = useMarkDone(() => setMode("view"));
-  // If a user clicks the highlighted Done button mid-tour, hide the
-  // tour rather than leaving the tooltip floating over View mode.
-  useEffect(() => {
-    if (markDone.isSuccess) setTourRun(false);
-  }, [markDone.isSuccess]);
 
   const dismissTour = () => {
     setTourRun(false);
     window.sessionStorage.setItem(TOUR_DISMISSED_KEY, "1");
   };
 
+  // Done is the tour's intended finisher — close the tour synchronously
+  // on click so the tooltip doesn't linger while the mutation runs.
+  const handleDoneClick = () => {
+    dismissTour();
+    markDone.mutate();
+  };
+
   const replayTour = () => {
+    // The tour spotlights edit-mode UI (the suggestion feed, the Done
+    // button); ensure we're in edit mode before it starts, otherwise
+    // those targets don't exist on the page.
+    setMode("edit");
     window.sessionStorage.removeItem(TOUR_DISMISSED_KEY);
     setTourKey((k) => k + 1);
     setTourRun(true);
@@ -89,7 +98,7 @@ export function MyWeb({ initialLastUpdatedWeb }: { initialLastUpdatedWeb: Date |
               variant="secondary"
               data-tour="done-button"
               disabled={markDone.isPending}
-              onClick={() => markDone.mutate()}
+              onClick={handleDoneClick}
             >
               {markDone.isPending ? "Saving…" : "Done"}
             </Button>
@@ -110,8 +119,14 @@ export function MyWeb({ initialLastUpdatedWeb }: { initialLastUpdatedWeb: Date |
         )}
       </div>
 
-      <RelatingDialog target={relatingTarget} onClose={() => setRelatingTarget(null)} />
-      <WelcomeTour key={tourKey} run={tourRun} onClose={dismissTour} />
+      <RelatingDialog
+        target={relatingTarget}
+        onClose={() => setRelatingTarget(null)}
+        onRelated={() => {
+          if (tourRun) setTourAdvanceToken((t) => t + 1);
+        }}
+      />
+      <WelcomeTour key={tourKey} run={tourRun} advanceToken={tourAdvanceToken} onClose={dismissTour} />
     </div>
   );
 }

--- a/src/app/myweb/my-web.tsx
+++ b/src/app/myweb/my-web.tsx
@@ -43,27 +43,41 @@ export function MyWeb({ initialLastUpdatedWeb }: { initialLastUpdatedWeb: Date |
   // Lifted to MyWeb so both the suggestion feed (WebBuilder) and the
   // graph (WebGraph) can request a rating dialog from a single source.
   const [relatingTarget, setRelatingTarget] = useState<RelatingTarget | null>(null);
-  // Tour dismissed for the rest of this tab session (sessionStorage),
-  // for this navigation (markDone success), or for this state (parent
-  // setTourDismissed). The sessionStorage check makes e2e tests trivial
-  // to set up: addInitScript with the flag and the tour stays off.
-  const [tourDismissed, setTourDismissed] = useState(false);
+  // Controlled tour state so a "Replay guided tour" action can re-fire
+  // it for returning members. The initial-run decision (first visit,
+  // not already dismissed this session) runs in an effect so SSR markup
+  // matches the hydrated tree. The sessionStorage check still makes
+  // e2e tests trivial: addInitScript with the flag and the tour stays off.
+  const [tourRun, setTourRun] = useState(false);
+  // Bumped on replay so Joyride fully unmounts/remounts — toggling
+  // `run` alone doesn't reliably reset stepIndex back to 0.
+  const [tourKey, setTourKey] = useState(0);
   useEffect(() => {
-    if (window.sessionStorage.getItem(TOUR_DISMISSED_KEY) === "1") {
-      setTourDismissed(true);
-    }
-  }, []);
+    if (initialLastUpdatedWeb !== null) return;
+    if (window.sessionStorage.getItem(TOUR_DISMISSED_KEY) === "1") return;
+    setTourRun(true);
+  }, [initialLastUpdatedWeb]);
   const markDone = useMarkDone(() => setMode("view"));
-  const tourRun = initialLastUpdatedWeb === null && !tourDismissed && !markDone.isSuccess;
+  // If a user clicks the highlighted Done button mid-tour, hide the
+  // tour rather than leaving the tooltip floating over View mode.
+  useEffect(() => {
+    if (markDone.isSuccess) setTourRun(false);
+  }, [markDone.isSuccess]);
 
   const dismissTour = () => {
-    setTourDismissed(true);
+    setTourRun(false);
     window.sessionStorage.setItem(TOUR_DISMISSED_KEY, "1");
+  };
+
+  const replayTour = () => {
+    window.sessionStorage.removeItem(TOUR_DISMISSED_KEY);
+    setTourKey((k) => k + 1);
+    setTourRun(true);
   };
 
   return (
     <div className="flex w-full max-w-5xl flex-col items-center gap-6">
-      <WebGraph onOpenRelating={setRelatingTarget} />
+      <WebGraph onOpenRelating={setRelatingTarget} onReplayTour={replayTour} />
 
       {/* Toggle floats in the right gutter so it doesn't claim its own
        * row. Edit and Done sit at the same coordinates across modes —
@@ -97,7 +111,7 @@ export function MyWeb({ initialLastUpdatedWeb }: { initialLastUpdatedWeb: Date |
       </div>
 
       <RelatingDialog target={relatingTarget} onClose={() => setRelatingTarget(null)} />
-      <WelcomeTour run={tourRun} onClose={dismissTour} />
+      <WelcomeTour key={tourKey} run={tourRun} onClose={dismissTour} />
     </div>
   );
 }

--- a/src/app/myweb/relating-dialog.tsx
+++ b/src/app/myweb/relating-dialog.tsx
@@ -21,9 +21,13 @@ export type RelatingTarget = {
 type Props = {
   target: RelatingTarget | null;
   onClose: () => void;
+  // Fires only after a relation is successfully committed. Used by
+  // /myweb to advance the welcome tour once the user completes the
+  // "add people" step's action.
+  onRelated?: () => void;
 };
 
-export function RelatingDialog({ target, onClose }: Props) {
+export function RelatingDialog({ target, onClose, onRelated }: Props) {
   const queryClient = useQueryClient();
   const [pendingValue, setPendingValue] = useState<RelationValue | null>(null);
 
@@ -78,6 +82,7 @@ export function RelatingDialog({ target, onClose }: Props) {
         onSuccess: () => {
           setPendingValue(null);
           onClose();
+          onRelated?.();
         },
         onError: () => {
           setPendingValue(null);

--- a/src/app/myweb/relating-dialog.tsx
+++ b/src/app/myweb/relating-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { Dialog } from "@base-ui/react/dialog";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { X } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -127,8 +128,15 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
           className="fixed top-1/2 left-1/2 z-50 w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded border border-border bg-popover p-5 text-popover-foreground shadow-lg data-ending-style:opacity-0 data-starting-style:opacity-0 transition-opacity duration-150"
           aria-describedby={target?.hintAttribution ? "relating-attribution" : undefined}
         >
-          <Dialog.Title className="font-heading text-base font-medium">
-            Describe your relationship with {target?.displayName ?? "this member"}
+          <Dialog.Close
+            disabled={mutation.isPending}
+            aria-label="Close"
+            className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+          >
+            <X className="h-4 w-4" />
+          </Dialog.Close>
+          <Dialog.Title className="pr-8 font-heading text-base font-medium">
+            Who is <span className="font-semibold">{target?.displayName ?? "this member"}</span> to you?
           </Dialog.Title>
           {target?.hintAttribution && (
             <p id="relating-attribution" className="mt-1 text-sm text-muted-foreground">
@@ -136,7 +144,9 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
             </p>
           )}
 
-          <div className="mt-4 flex flex-col gap-2">
+          <p className="mt-3 text-xs text-muted-foreground">Keyboard shortcuts: Number keys 1 through 4, or Esc to cancel</p>
+
+          <div className="mt-2 flex flex-col gap-2">
             {RELATION_VALUES.map((value) => {
               const { headline, detail } = RELATION_VALUE_LABELS[value];
               const isCurrent = target?.currentValue === value;
@@ -167,7 +177,8 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
           )}
 
           <p className="mt-3 text-xs text-muted-foreground">
-            Click outside or press 1–4 to choose. Closing without choosing leaves the suggestion as-is.
+            Notes: Yes, these become visible to them and others. It&apos;s okay to pick a different relation value than they
+            do for you! Everyone will have their own slightly unique interpretation.
           </p>
         </Dialog.Popup>
       </Dialog.Portal>

--- a/src/app/myweb/web-builder.tsx
+++ b/src/app/myweb/web-builder.tsx
@@ -15,21 +15,32 @@ const fetchCandidates = async (): Promise<RelationCandidatesFeed> => {
   return res.json();
 };
 
-const targetFromCandidate = (candidate: RelationCandidate): RelatingTarget => {
-  // Hint cards reveal the hinter's name in the dialog so the member
-  // sees who suggested them. addedYou cards intentionally omit the
-  // value (soft-hide) — the API never sends it, so there's nothing
-  // to omit here either.
-  const hintAttribution =
-    candidate.reason.type === "hint"
-      ? `${candidate.reason.hintedBy?.displayName ?? "Someone"} suggested you know each other`
-      : null;
-  return {
-    id: candidate.id,
-    displayName: candidate.displayName,
-    hintAttribution,
-  };
+const buildHintAttribution = (candidate: RelationCandidate): string | null => {
+  const reason = candidate.reason;
+  switch (reason.type) {
+    case "hint": {
+      const name = reason.hintedBy?.displayName ?? "Someone";
+      return `${name} suggested that you know each other.`;
+    }
+    case "viaInviter": {
+      const name = reason.inviter.displayName ?? "Your inviter";
+      return `${name} suggested that you know each other.`;
+    }
+    case "addedYou": {
+      return `They have added you to their relational web.`;
+    }
+    case "recentlyActive":
+      return "They've been active here recently.";
+    case "member":
+      return null;
+  }
 };
+
+const targetFromCandidate = (candidate: RelationCandidate): RelatingTarget => ({
+  id: candidate.id,
+  displayName: candidate.displayName,
+  hintAttribution: buildHintAttribution(candidate),
+});
 
 export function WebBuilder({ onOpenRelating }: { onOpenRelating: (target: RelatingTarget) => void }) {
   const { data, isPending, isError } = useQuery({

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -429,7 +429,10 @@ export function WebGraph({
   }
 
   return (
-    <div className="h-[500px] w-full overflow-hidden rounded border border-border bg-canvas [--xy-background-color:var(--color-canvas)]">
+    <div
+      data-tour="graph"
+      className="h-[500px] w-full overflow-hidden rounded border border-border bg-canvas [--xy-background-color:var(--color-canvas)]"
+    >
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -504,7 +507,10 @@ export function WebGraph({
               </ul>
               <button
                 type="button"
-                onClick={onReplayTour}
+                onClick={() => {
+                  setHintOpen(false);
+                  onReplayTour();
+                }}
                 className="self-start text-foreground underline underline-offset-2 hover:text-primary"
               >
                 Replay guided tour

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -167,7 +167,13 @@ function parseStoredView(raw: string | null): SubgraphViewOptions | null {
   return null;
 }
 
-export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: RelatingTarget) => void }) {
+export function WebGraph({
+  onOpenRelating,
+  onReplayTour,
+}: {
+  onOpenRelating: (target: RelatingTarget) => void;
+  onReplayTour: () => void;
+}) {
   const router = useRouter();
   const [view, setView] = useState<SubgraphViewOptions>(DEFAULT_SUBGRAPH_VIEW);
   const [hintOpen, setHintOpen] = useState(false);
@@ -483,18 +489,27 @@ export function WebGraph({ onOpenRelating }: { onOpenRelating: (target: Relating
             ?
           </Button>
           {hintOpen && (
-            <ul
+            <div
               id="web-graph-hints"
-              className="flex max-w-[18rem] flex-col gap-1 rounded border border-border bg-background/90 p-2 text-sm text-muted-foreground"
+              className="flex max-w-[18rem] flex-col gap-2 rounded border border-border bg-background/90 p-2 text-sm text-muted-foreground"
             >
-              <li>Drag the background to pan.</li>
-              <li>Scroll or pinch to zoom.</li>
-              <li>Single-click a node to center the view on it.</li>
-              <li>Double-click a node to open their profile.</li>
-              <li>
-                <span className="font-medium text-foreground">2 hops</span> adds friends of friends.
-              </li>
-            </ul>
+              <ul className="flex flex-col gap-1">
+                <li>Drag the background to pan.</li>
+                <li>Scroll or pinch to zoom.</li>
+                <li>Single-click a node to center the view on it.</li>
+                <li>Double-click a node to open their profile.</li>
+                <li>
+                  <span className="font-medium text-foreground">2 hops</span> adds friends of friends.
+                </li>
+              </ul>
+              <button
+                type="button"
+                onClick={onReplayTour}
+                className="self-start text-foreground underline underline-offset-2 hover:text-primary"
+              >
+                Replay guided tour
+              </button>
+            </div>
           )}
         </Panel>
         <Panel

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -4,6 +4,7 @@ import "@xyflow/react/dist/style.css";
 
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
+  applyNodeChanges,
   BaseEdge,
   Controls,
   type Edge,
@@ -12,6 +13,7 @@ import {
   getStraightPath,
   Handle,
   type Node,
+  type NodeChange,
   type NodeProps,
   Panel,
   Position,
@@ -20,7 +22,7 @@ import {
 } from "@xyflow/react";
 import { forceCollide, forceLink, forceManyBody, forceSimulation, type Simulation } from "d3-force";
 import { useRouter } from "next/navigation";
-import { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import { Avatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
@@ -240,6 +242,13 @@ export function WebGraph({
   // mount, so a settling simulation would otherwise overflow whatever
   // scale the initial random positions happened to produce.
   const flowRef = useRef<ReactFlowInstance<Node<MemberNodeData>, Edge<EdgeData>> | null>(null);
+  // Shared between the d3-force sim and the drag handlers: drag needs
+  // to mutate fx/fy on the sim node directly, and drag-induced sim
+  // position changes shouldn't re-derive the render-coords scale (the
+  // dragged node would drift under your cursor as the bbox shifts).
+  const simNodesByIdRef = useRef<Map<string, SimNode>>(new Map());
+  const normRef = useRef<{ cx: number; cy: number; scale: number } | null>(null);
+  const draggedNodeIdRef = useRef<string | null>(null);
 
   // Edges never change after the subgraph loads — derive instead of
   // duplicating into React state.
@@ -288,8 +297,11 @@ export function WebGraph({
       };
     });
     // Lookup map kept around for paintFromSim — avoids an O(n²) .find
-    // scan on every tick.
+    // scan on every tick. Also exposed via simNodesByIdRef so the
+    // node-drag handlers (outside this effect) can mutate fx/fy on
+    // the dragged node.
     const simNodeById = new Map(simNodes.map((n) => [n.id, n]));
+    simNodesByIdRef.current = simNodeById;
     const simEdges: SimEdge[] = data.edges.map((e) => ({
       source: e.relatorId,
       target: e.relateeId,
@@ -304,7 +316,10 @@ export function WebGraph({
           type: "member",
           position: { x: sn?.x ?? 0, y: sn?.y ?? 0 },
           data: { ...n, isCenter: n.id === centerId },
-          draggable: true,
+          // Center node is fx/fy-pinned at the origin; letting the user
+          // drag it would either fight the pin or move "yourself" on
+          // your own web, neither of which is the intent.
+          draggable: n.id !== centerId,
           // Override ReactFlow's default ".react-flow__node{pointer-events: all}"
           // so only the Avatar (pointer-events-auto + clip-path:circle) is a
           // click target. The corners around the round avatar no longer count
@@ -386,22 +401,33 @@ export function WebGraph({
     // the rendered graph fill the viewport regardless of node count.
     function paintFromSim() {
       if (simNodes.length === 0) return;
-      const TARGET = 600;
-      let minX = simNodes[0].x;
-      let maxX = minX;
-      let minY = simNodes[0].y;
-      let maxY = minY;
-      for (let i = 1; i < simNodes.length; i++) {
-        const sn = simNodes[i];
-        if (sn.x < minX) minX = sn.x;
-        else if (sn.x > maxX) maxX = sn.x;
-        if (sn.y < minY) minY = sn.y;
-        else if (sn.y > maxY) maxY = sn.y;
+      // During a drag, freeze the normalization. Recomputing it would
+      // shift cx/cy/scale based on the moving bbox, which makes the
+      // dragged node visually drift away from the cursor.
+      let cx: number;
+      let cy: number;
+      let scale: number;
+      if (draggedNodeIdRef.current && normRef.current) {
+        ({ cx, cy, scale } = normRef.current);
+      } else {
+        const TARGET = 600;
+        let minX = simNodes[0].x;
+        let maxX = minX;
+        let minY = simNodes[0].y;
+        let maxY = minY;
+        for (let i = 1; i < simNodes.length; i++) {
+          const sn = simNodes[i];
+          if (sn.x < minX) minX = sn.x;
+          else if (sn.x > maxX) maxX = sn.x;
+          if (sn.y < minY) minY = sn.y;
+          else if (sn.y > maxY) maxY = sn.y;
+        }
+        const longer = Math.max(maxX - minX, maxY - minY);
+        scale = longer > 1 ? TARGET / longer : 1;
+        cx = (maxX + minX) / 2;
+        cy = (maxY + minY) / 2;
+        normRef.current = { cx, cy, scale };
       }
-      const longer = Math.max(maxX - minX, maxY - minY);
-      const scale = longer > 1 ? TARGET / longer : 1;
-      const cx = (maxX + minX) / 2;
-      const cy = (maxY + minY) / 2;
 
       setNodes((prev) => {
         let changed = false;
@@ -421,6 +447,9 @@ export function WebGraph({
         return changed ? next : prev;
       });
 
+      // Skip auto-refit during drag — the user is steering the layout,
+      // shifting the viewport under them mid-drag is disorienting.
+      if (draggedNodeIdRef.current) return;
       const now = performance.now();
       if (now - lastFit >= FIT_MS) {
         lastFit = now;
@@ -437,6 +466,59 @@ export function WebGraph({
       sim.stop();
     };
   }, [data]);
+
+  // Required for ReactFlow's drag to actually update positions in our
+  // controlled `nodes` state; without it, drag fires events that go
+  // nowhere and the node visually doesn't move.
+  const onNodesChange = useCallback((changes: NodeChange<Node<MemberNodeData>>[]) => {
+    setNodes((nds) => applyNodeChanges(changes, nds));
+  }, []);
+
+  // Drag handlers integrate the user with the d3-force sim: pinning
+  // the dragged node via fx/fy lets the rest of the graph relax
+  // around the new position. On release, fx/fy is cleared so the node
+  // re-enters the sim's normal physics.
+  const flowPositionToSim = useCallback((flow: { x: number; y: number }) => {
+    const norm = normRef.current;
+    if (!norm) return null;
+    return { x: flow.x / norm.scale + norm.cx, y: flow.y / norm.scale + norm.cy };
+  }, []);
+  const onNodeDragStart = useCallback(
+    (_event: React.MouseEvent, node: Node<MemberNodeData>) => {
+      const simNode = simNodesByIdRef.current.get(node.id);
+      const sim = flowPositionToSim(node.position);
+      if (!simNode || !sim) return;
+      draggedNodeIdRef.current = node.id;
+      simNode.fx = sim.x;
+      simNode.fy = sim.y;
+      // alphaTarget keeps the sim warm for the duration of the drag —
+      // without it, alpha decays past alphaMin (~5s on defaults) and
+      // ticks stop firing, freezing the layout mid-pull. alpha(0.3)
+      // gives an immediate burst, alphaTarget(0.3) keeps it there.
+      simRef.current?.alphaTarget(0.3).alpha(0.3).restart();
+    },
+    [flowPositionToSim],
+  );
+  const onNodeDrag = useCallback(
+    (_event: React.MouseEvent, node: Node<MemberNodeData>) => {
+      const simNode = simNodesByIdRef.current.get(node.id);
+      const sim = flowPositionToSim(node.position);
+      if (!simNode || !sim) return;
+      simNode.fx = sim.x;
+      simNode.fy = sim.y;
+    },
+    [flowPositionToSim],
+  );
+  const onNodeDragStop = useCallback((_event: React.MouseEvent, node: Node<MemberNodeData>) => {
+    const simNode = simNodesByIdRef.current.get(node.id);
+    if (simNode) {
+      simNode.fx = null;
+      simNode.fy = null;
+    }
+    // Release the alpha target so the sim cools normally back to rest.
+    simRef.current?.alphaTarget(0);
+    draggedNodeIdRef.current = null;
+  }, []);
 
   const empty = !data || data.nodes.length === 0;
 
@@ -474,6 +556,10 @@ export function WebGraph({
           onInit={(instance) => {
             flowRef.current = instance;
           }}
+          onNodesChange={onNodesChange}
+          onNodeDragStart={onNodeDragStart}
+          onNodeDrag={onNodeDrag}
+          onNodeDragStop={onNodeDragStop}
           nodesConnectable={false}
           elementsSelectable={false}
           proOptions={{ hideAttribution: true }}

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -97,17 +97,23 @@ const HANDLE_STYLE = { opacity: 0, top: "50%", pointerEvents: "none" as const };
 
 function MemberNode({ data }: NodeProps<Node<MemberNodeData>>) {
   return (
-    <div className="flex cursor-pointer flex-col items-center gap-1" title={data.displayName ?? undefined}>
+    // pointer-events-none on the wrapper + the !pointer-events-none
+    // override on .react-flow__node (set per-node above) means only the
+    // Avatar (pointer-events-auto + clip-path:circle) is a click
+    // target. The name renders in flow below the avatar so the wrapper
+    // bounding box covers the full visible node, but its
+    // pointer-events-none keeps clicks on the name inert.
+    <div className="pointer-events-none flex flex-col items-center gap-1">
       <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
       <Handle type="source" position={Position.Top} style={HANDLE_STYLE} />
       <Avatar
         name={data.displayName}
         url={data.avatarUrl}
-        className={`flex items-center justify-center overflow-hidden rounded-full border-2 ${
+        className={`pointer-events-auto flex cursor-pointer items-center justify-center overflow-hidden rounded-full border-2 [clip-path:circle()] transition-transform duration-150 hover:scale-110 ${
           data.isCenter ? "h-16 w-16 border-primary" : "h-12 w-12 border-border"
         } bg-muted text-base font-semibold text-muted-foreground`}
       />
-      <div className="max-w-[8rem] truncate text-sm font-medium">{data.displayName ?? "—"}</div>
+      <div className="pointer-events-none max-w-[8rem] truncate text-sm font-medium">{data.displayName ?? "—"}</div>
     </div>
   );
 }
@@ -253,7 +259,6 @@ export function WebGraph({
           stroke: "var(--color-canvas-foreground)",
           strokeOpacity: edgeStrokeOpacity(e.value),
           strokeWidth: edgeStrokeWidth(e.value),
-          cursor: isOutgoing ? "pointer" : "default",
         },
         data: {
           isOutgoing,
@@ -300,6 +305,11 @@ export function WebGraph({
           position: { x: sn?.x ?? 0, y: sn?.y ?? 0 },
           data: { ...n, isCenter: n.id === centerId },
           draggable: true,
+          // Override ReactFlow's default ".react-flow__node{pointer-events: all}"
+          // so only the Avatar (pointer-events-auto + clip-path:circle) is a
+          // click target. The corners around the round avatar no longer count
+          // as the node, so clicking outside the circle doesn't fire onNodeClick.
+          className: "!pointer-events-none",
         };
       }),
     );
@@ -479,18 +489,6 @@ export function WebGraph({
           onNodeDoubleClick={(_event, node) => {
             const slug = node.data.slug ?? node.data.id;
             router.push(`/members/${slug}`);
-          }}
-          onEdgeClick={(_event, edge) => {
-            // Re-rate is only available on edges I authored. Incoming-only
-            // edges (someone else rated me, I haven't reciprocated) route
-            // through the suggestion feed instead.
-            const data = edge.data as EdgeData | undefined;
-            if (!data?.isOutgoing) return;
-            onOpenRelating({
-              id: data.relateeId,
-              displayName: data.relateeName,
-              currentValue: isRelationValue(data.value) ? data.value : null,
-            });
           }}
         >
           {/* Built-in +/-/fit-view buttons for users who can't or don't

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -20,7 +20,7 @@ import {
 } from "@xyflow/react";
 import { forceCollide, forceLink, forceManyBody, forceSimulation, type Simulation } from "d3-force";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import { Avatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
@@ -114,28 +114,53 @@ function MemberNode({ data }: NodeProps<Node<MemberNodeData>>) {
 
 const nodeTypes = { member: MemberNode };
 
+// Lets the edge label pop the relating dialog without threading a
+// callback through the edge data object (which would defeat the edges
+// useMemo). NumberedEdge is registered via ReactFlow's edgeTypes prop;
+// the Provider wraps ReactFlow so context still propagates to it.
+const EdgeRelatingContext = createContext<((target: RelatingTarget) => void) | null>(null);
+
 // Straight-line edge with an HTML circle label at the geometric midpoint
 // of the line between source and target. ReactFlow's default bezier
 // edges arc upward (both ends are Position.Top), so their parametric
 // midpoint sits above the visual line — using a straight edge keeps the
 // label on the line, and HTML labels (via EdgeLabelRenderer) give us a
 // real circular pill that an SVG <rect> can't.
+
 function NumberedEdge({ id, sourceX, sourceY, targetX, targetY, style, data }: EdgeProps<Edge<EdgeData>>) {
   const [edgePath, labelX, labelY] = getStraightPath({ sourceX, sourceY, targetX, targetY });
+  const openRelating = useContext(EdgeRelatingContext);
+  const isClickable = data?.isOutgoing === true && openRelating !== null;
+  const handleClick = isClickable
+    ? () =>
+        openRelating?.({
+          id: data.relateeId,
+          displayName: data.relateeName,
+          currentValue: isRelationValue(data.value) ? data.value : null,
+        })
+    : undefined;
   return (
     <>
       <BaseEdge id={id} path={edgePath} style={style} />
       <EdgeLabelRenderer>
-        <div
+        <button
+          type="button"
+          onClick={handleClick}
+          disabled={!isClickable}
+          aria-label={isClickable ? "Adjust your rating" : undefined}
           style={{
             position: "absolute",
             transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-            pointerEvents: "none",
+            // Restore pointer events so the label catches clicks; the
+            // SVG edge path underneath only covers a few px of the line.
+            pointerEvents: "auto",
           }}
-          className="flex h-5 w-5 items-center justify-center rounded-full bg-canvas/60 text-xs font-semibold text-canvas-foreground"
+          className={`flex h-5 w-5 items-center justify-center rounded-full bg-canvas/60 text-xs font-semibold text-canvas-foreground ${
+            isClickable ? "cursor-pointer hover:bg-canvas/90" : "cursor-default"
+          }`}
         >
           {data?.value}
-        </div>
+        </button>
       </EdgeLabelRenderer>
     </>
   );
@@ -153,12 +178,7 @@ function parseStoredView(raw: string | null): SubgraphViewOptions | null {
   if (!raw) return null;
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      "hops" in parsed &&
-      (parsed.hops === 1 || parsed.hops === 2)
-    ) {
+    if (typeof parsed === "object" && parsed !== null && "hops" in parsed && (parsed.hops === 1 || parsed.hops === 2)) {
       return { hops: parsed.hops };
     }
   } catch {
@@ -433,105 +453,107 @@ export function WebGraph({
       data-tour="graph"
       className="h-[500px] w-full overflow-hidden rounded border border-border bg-canvas [--xy-background-color:var(--color-canvas)]"
     >
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        fitView
-        fitViewOptions={{ padding: 0.15 }}
-        onInit={(instance) => {
-          flowRef.current = instance;
-        }}
-        nodesConnectable={false}
-        elementsSelectable={false}
-        proOptions={{ hideAttribution: true }}
-        onNodeClick={(_event, node) => {
-          // Re-center the viewport on the clicked node so members can
-          // explore the graph without navigating away. Double-click
-          // navigates to the member's profile page.
-          flowRef.current?.setCenter(node.position.x, node.position.y, {
-            zoom: flowRef.current.getZoom(),
-            duration: 400,
-          });
-        }}
-        onNodeDoubleClick={(_event, node) => {
-          const slug = node.data.slug ?? node.data.id;
-          router.push(`/members/${slug}`);
-        }}
-        onEdgeClick={(_event, edge) => {
-          // Re-rate is only available on edges I authored. Incoming-only
-          // edges (someone else rated me, I haven't reciprocated) route
-          // through the suggestion feed instead.
-          const data = edge.data as EdgeData | undefined;
-          if (!data?.isOutgoing) return;
-          onOpenRelating({
-            id: data.relateeId,
-            displayName: data.relateeName,
-            currentValue: isRelationValue(data.value) ? data.value : null,
-          });
-        }}
-      >
-        {/* Built-in +/-/fit-view buttons for users who can't or don't
-         * want to scroll-zoom (trackpad pinch, mouse wheel). Lock toggle
-         * is hidden — selection and connection are already disabled. */}
-        <Controls position="top-left" showInteractive={false} />
-        <Panel position="bottom-right" className="flex flex-row-reverse items-end gap-2">
-          {/* Click-to-toggle (not hover) so the hints stay reachable on
-           * touch devices where hover doesn't exist. */}
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            aria-label={hintOpen ? "Hide canvas tips" : "Show canvas tips"}
-            aria-expanded={hintOpen}
-            aria-controls="web-graph-hints"
-            onClick={() => setHintOpen((h) => !h)}
-            className="rounded-full border border-border bg-background/90 font-bold"
-          >
-            ?
-          </Button>
-          {hintOpen && (
-            <div
-              id="web-graph-hints"
-              className="flex max-w-[18rem] flex-col gap-2 rounded border border-border bg-background/90 p-2 text-sm text-muted-foreground"
-            >
-              <ul className="flex flex-col gap-1">
-                <li>Drag the background to pan.</li>
-                <li>Scroll or pinch to zoom.</li>
-                <li>Single-click a node to center the view on it.</li>
-                <li>Double-click a node to open their profile.</li>
-                <li>
-                  <span className="font-medium text-foreground">2 hops</span> adds friends of friends.
-                </li>
-              </ul>
-              <button
-                type="button"
-                onClick={() => {
-                  setHintOpen(false);
-                  onReplayTour();
-                }}
-                className="self-start text-foreground underline underline-offset-2 hover:text-primary"
-              >
-                Replay guided tour
-              </button>
-            </div>
-          )}
-        </Panel>
-        <Panel
-          position="top-right"
-          className="flex flex-col gap-1 rounded border border-border bg-background/90 p-2 text-sm"
+      <EdgeRelatingContext.Provider value={onOpenRelating}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.15 }}
+          onInit={(instance) => {
+            flowRef.current = instance;
+          }}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          proOptions={{ hideAttribution: true }}
+          onNodeClick={(_event, node) => {
+            // Re-center the viewport on the clicked node so members can
+            // explore the graph without navigating away. Double-click
+            // navigates to the member's profile page.
+            flowRef.current?.setCenter(node.position.x, node.position.y, {
+              zoom: flowRef.current.getZoom(),
+              duration: 400,
+            });
+          }}
+          onNodeDoubleClick={(_event, node) => {
+            const slug = node.data.slug ?? node.data.id;
+            router.push(`/members/${slug}`);
+          }}
+          onEdgeClick={(_event, edge) => {
+            // Re-rate is only available on edges I authored. Incoming-only
+            // edges (someone else rated me, I haven't reciprocated) route
+            // through the suggestion feed instead.
+            const data = edge.data as EdgeData | undefined;
+            if (!data?.isOutgoing) return;
+            onOpenRelating({
+              id: data.relateeId,
+              displayName: data.relateeName,
+              currentValue: isRelationValue(data.value) ? data.value : null,
+            });
+          }}
         >
-          <label className="flex cursor-pointer items-center gap-2">
-            <input
-              type="checkbox"
-              checked={view.hops === 2}
-              onChange={(e) => setView((v) => ({ ...v, hops: e.target.checked ? 2 : 1 }))}
-            />
-            2 hops
-          </label>
-        </Panel>
-      </ReactFlow>
+          {/* Built-in +/-/fit-view buttons for users who can't or don't
+           * want to scroll-zoom (trackpad pinch, mouse wheel). Lock toggle
+           * is hidden — selection and connection are already disabled. */}
+          <Controls position="top-left" showInteractive={false} />
+          <Panel position="bottom-right" className="flex flex-row-reverse items-end gap-2">
+            {/* Click-to-toggle (not hover) so the hints stay reachable on
+             * touch devices where hover doesn't exist. */}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label={hintOpen ? "Hide canvas tips" : "Show canvas tips"}
+              aria-expanded={hintOpen}
+              aria-controls="web-graph-hints"
+              onClick={() => setHintOpen((h) => !h)}
+              className="rounded-full border border-border bg-background/90 font-bold"
+            >
+              ?
+            </Button>
+            {hintOpen && (
+              <div
+                id="web-graph-hints"
+                className="flex max-w-[18rem] flex-col gap-2 rounded border border-border bg-background/90 p-2 text-sm text-muted-foreground"
+              >
+                <ul className="flex flex-col gap-1">
+                  <li>Drag the background to pan.</li>
+                  <li>Scroll or pinch to zoom.</li>
+                  <li>Single-click a node to center the view on it.</li>
+                  <li>Double-click a node to open their profile.</li>
+                  <li>
+                    <span className="font-medium text-foreground">2 hops</span> adds friends of friends.
+                  </li>
+                </ul>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setHintOpen(false);
+                    onReplayTour();
+                  }}
+                  className="self-start text-foreground underline underline-offset-2 hover:text-primary"
+                >
+                  Replay guided tour
+                </button>
+              </div>
+            )}
+          </Panel>
+          <Panel
+            position="top-right"
+            className="flex flex-col gap-1 rounded border border-border bg-background/90 p-2 text-sm"
+          >
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={view.hops === 2}
+                onChange={(e) => setView((v) => ({ ...v, hops: e.target.checked ? 2 : 1 }))}
+              />
+              2 hops
+            </label>
+          </Panel>
+        </ReactFlow>
+      </EdgeRelatingContext.Provider>
     </div>
   );
 }

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -249,6 +249,9 @@ export function WebGraph({
   const simNodesByIdRef = useRef<Map<string, SimNode>>(new Map());
   const normRef = useRef<{ cx: number; cy: number; scale: number } | null>(null);
   const draggedNodeIdRef = useRef<string | null>(null);
+  // True once the user pans/zooms — auto-fitView during sim ticks
+  // would otherwise yank the viewport back every ~250ms.
+  const userMovedViewportRef = useRef(false);
 
   // Edges never change after the subgraph loads — derive instead of
   // duplicating into React state.
@@ -335,10 +338,7 @@ export function WebGraph({
     // Without this throttle a dev build can render-storm so hard the
     // browser never paints between frames and the simulation looks blank.
     const FRAME_MS = 50;
-    // fitView is not free; throttle to ~4×/sec instead of every paint.
-    const FIT_MS = 250;
     let lastUpdate = 0;
-    let lastFit = 0;
     // No forceCenter — the viewing member is already pinned at the
     // origin via fx/fy, so forceCenter would only pull the other nodes
     // toward the pinned center, fighting the link-distance equilibrium
@@ -393,7 +393,16 @@ export function WebGraph({
         lastUpdate = now;
         paintFromSim();
       })
-      .on("end", () => paintFromSim());
+      .on("end", () => {
+        paintFromSim();
+        // One-shot refit once the layout has fully relaxed, unless the
+        // user has already taken over the viewport.
+        if (!userMovedViewportRef.current) {
+          requestAnimationFrame(() => {
+            flowRef.current?.fitView({ padding: 0.15, duration: 200 });
+          });
+        }
+      });
 
     // Paints React node positions from the live simNodes, normalized so
     // the layout's longer axis spans TARGET sim units and is centered
@@ -447,16 +456,12 @@ export function WebGraph({
         return changed ? next : prev;
       });
 
-      // Skip auto-refit during drag — the user is steering the layout,
-      // shifting the viewport under them mid-drag is disorienting.
-      if (draggedNodeIdRef.current) return;
-      const now = performance.now();
-      if (now - lastFit >= FIT_MS) {
-        lastFit = now;
-        requestAnimationFrame(() => {
-          flowRef.current?.fitView({ padding: 0.15, duration: 0 });
-        });
-      }
+      // No periodic fitView here. ReactFlow's `fitView` prop fits on
+      // mount, and the normalization above keeps the layout at a stable
+      // ~TARGET sim units throughout settling — so a one-time fit
+      // covers it. The sim's "end" handler does one more fit when the
+      // layout has fully relaxed, in case the user hasn't taken over
+      // the viewport in the meantime.
     }
 
     simRef.current?.stop();
@@ -555,6 +560,11 @@ export function WebGraph({
           fitViewOptions={{ padding: 0.15 }}
           onInit={(instance) => {
             flowRef.current = instance;
+          }}
+          onMove={(event) => {
+            // Programmatic fitView calls pass event=null; only flip the
+            // flag on user gestures (MouseEvent / TouchEvent / Wheel).
+            if (event !== null) userMovedViewportRef.current = true;
           }}
           onNodesChange={onNodesChange}
           onNodeDragStart={onNodeDragStart}

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -252,6 +252,11 @@ export function WebGraph({
   // True once the user pans/zooms — auto-fitView during sim ticks
   // would otherwise yank the viewport back every ~250ms.
   const userMovedViewportRef = useRef(false);
+  // True once paintFromSim has run a one-shot fit against the
+  // normalized layout. ReactFlow's `fitView` prop fires too early
+  // (before the first paint) and would otherwise leave the viewport
+  // sized for the unnormalized random positions.
+  const initialPaintFittedRef = useRef(false);
 
   // Edges never change after the subgraph loads — derive instead of
   // duplicating into React state.
@@ -378,6 +383,12 @@ export function WebGraph({
     };
 
     const sim = forceSimulation(simNodes)
+      // Default alphaMin is 0.001, which combined with the default
+      // alphaDecay drags the sim out to ~5s with the last ~3.2s being
+      // sub-pixel motion no one can see. Bumping alphaMin cuts the
+      // trailing tail off (~1.8s end) without speeding up the
+      // perceptible early settling.
+      .alphaMin(0.08)
       .force("charge", forceManyBody().strength(-800))
       .force(
         "link",
@@ -456,12 +467,20 @@ export function WebGraph({
         return changed ? next : prev;
       });
 
-      // No periodic fitView here. ReactFlow's `fitView` prop fits on
-      // mount, and the normalization above keeps the layout at a stable
-      // ~TARGET sim units throughout settling — so a one-time fit
-      // covers it. The sim's "end" handler does one more fit when the
-      // layout has fully relaxed, in case the user hasn't taken over
-      // the viewport in the meantime.
+      // One-shot fit on the first normalized paint — ReactFlow's
+      // `fitView` prop fires before this runs, against the unnormalized
+      // 200-unit random layout, so without this the viewport stays
+      // zoomed in for the entire settling phase. After this initial
+      // fit, no periodic refits during settling (the normalization
+      // keeps the layout at a stable ~TARGET sim units). The sim's
+      // "end" handler does one more fit when the layout has fully
+      // relaxed.
+      if (!initialPaintFittedRef.current && !userMovedViewportRef.current) {
+        initialPaintFittedRef.current = true;
+        requestAnimationFrame(() => {
+          flowRef.current?.fitView({ padding: 0.15, duration: 0 });
+        });
+      }
     }
 
     simRef.current?.stop();
@@ -613,11 +632,12 @@ export function WebGraph({
               >
                 <ul className="flex flex-col gap-1">
                   <li>Drag the background to pan.</li>
+                  <li>Drag a circle to reposition it.</li>
                   <li>Scroll or pinch to zoom.</li>
-                  <li>Single-click a node to center the view on it.</li>
-                  <li>Double-click a node to open their profile.</li>
+                  <li>Single-click a circle to center the view on it.</li>
+                  <li>Double-click a circle to open their profile.</li>
                   <li>
-                    <span className="font-medium text-foreground">2 hops</span> adds friends of friends.
+                    <span className="font-medium text-foreground">2 hops</span> adds friends-of-friends.
                   </li>
                 </ul>
                 <button

--- a/src/app/myweb/welcome-tour.tsx
+++ b/src/app/myweb/welcome-tour.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import type { EventData, Step } from "react-joyride";
+import { useEffect, useRef } from "react";
+import type { Controls, EventData, Step } from "react-joyride";
 
 // react-joyride v3 reads `window` at module load, which would crash the
 // SSR of any client component that imports it. dynamic + ssr:false keeps
@@ -12,20 +13,29 @@ const STEPS: Step[] = [
   {
     target: "body",
     placement: "center",
-    title: "Welcome to your relational web",
-    content: "This page is yours. Add a few people you know to bring it to life — we'll show you how.",
+    title: "Mapping your relational web",
+    content: "A network is made of connections — mapping them is hopefully fun and useful! We'll show you how...",
   },
   {
     target: "[data-tour='add-people']",
-    title: "Add people you know",
-    content: "Click anyone here to set how you know them. Each rating draws a new edge on your web.",
+    title: "Adding people you know",
+    content: "Click anyone here, and say how well you know them. Go ahead and try one now!",
     placement: "top",
   },
   {
+    target: "[data-tour='graph']",
+    title: "Seeing your web",
+    content: "Your connections show up here. The ? in the corner has more navigation tips.",
+    placement: "bottom",
+  },
+  {
     target: "[data-tour='done-button']",
-    title: "Click Done when you're ready",
-    content: "Done marks you as recently active and switches to view mode. You can come back and edit anytime.",
+    title: "Finish by clicking Done",
+    content: "No notifications are sent, but your relations become hints for others. Click Done now! (You can add more anytime.)",
     placement: "left",
+    // No primary button on the final step — the spotlighted Done
+    // button on the page is the only finisher.
+    buttons: ["back", "skip"],
   },
 ];
 
@@ -35,8 +45,30 @@ const STEPS: Step[] = [
 // away mid-tour), which would otherwise poison sessionStorage and hide
 // the tour from that tab forever. Pairing tour:end with action verbs
 // (skip / close / next-on-last-step) leaves passive teardowns alone.
-export function WelcomeTour({ run, onClose }: { run: boolean; onClose: () => void }) {
-  const handleEvent = (data: EventData) => {
+export function WelcomeTour({
+  run,
+  advanceToken,
+  onClose,
+}: {
+  run: boolean;
+  // Increment from the parent to programmatically advance the tour by
+  // one step (e.g. after the user completes the step's action). The
+  // ref-vs-prop comparison below ignores the initial value, so a fresh
+  // mount (replay path) doesn't auto-advance.
+  advanceToken: number;
+  onClose: () => void;
+}) {
+  const controlsRef = useRef<Controls | null>(null);
+  const lastAdvanceTokenRef = useRef(advanceToken);
+
+  useEffect(() => {
+    if (advanceToken === lastAdvanceTokenRef.current) return;
+    lastAdvanceTokenRef.current = advanceToken;
+    controlsRef.current?.next();
+  }, [advanceToken]);
+
+  const handleEvent = (data: EventData, controls: Controls) => {
+    controlsRef.current = controls;
     if (data.type === "tour:end" && (data.action === "skip" || data.action === "close" || data.action === "next")) {
       onClose();
     }
@@ -47,6 +79,9 @@ export function WelcomeTour({ run, onClose }: { run: boolean; onClose: () => voi
       steps={STEPS}
       run={run}
       onEvent={handleEvent}
+      // continuous=true makes the primary button advance through steps
+      continuous
+      locale={{ skip: "Dismiss tour" }}
       options={{
         // skipBeacon means the tooltip appears immediately instead of
         // showing the pulse beacon first — better for a guided welcome.
@@ -55,6 +90,10 @@ export function WelcomeTour({ run, onClose }: { run: boolean; onClose: () => voi
         // Default buttons drop 'skip'; we want a one-click out for users
         // who'd rather poke around themselves.
         buttons: ["back", "skip", "primary"],
+        // Default is "close"; users reported losing the tour to errant
+        // background clicks. Dismiss is now an intentional act via the
+        // Dismiss tour button.
+        overlayClickAction: false,
         // Project teal, matches the rest of the palette closely enough.
         primaryColor: "#4a7c7a",
         zIndex: 10000,

--- a/src/lib/relation-value.ts
+++ b/src/lib/relation-value.ts
@@ -11,8 +11,8 @@ export const RELATION_VALUES: readonly RelationValue[] = [1, 2, 3, 4];
 // Mirror of the vocabulary in design-relations.md. Shared by every UI
 // that lets a member pick a 1..4 value (rating dialog, invite form).
 export const RELATION_VALUE_LABELS: Record<RelationValue, { headline: string; detail: string }> = {
-  1: { headline: "Met in a group", detail: "We've met in group settings and know of each other." },
-  2: { headline: "Talked 1-on-1", detail: "We've spent some time talking 1-on-1 enjoyably." },
-  3: { headline: "Friend", detail: "Friend." },
-  4: { headline: "Deep trust", detail: "Deep trust and knowing." },
+  1: { headline: "Acquaintance / Supporter", detail: "I have spent some time with them and feel supportive." },
+  2: { headline: "Friend / Collaborator", detail: "I trust them in most ways and we can work well together." },
+  3: { headline: "Companion / Comrade", detail: "I feel deep resonance and shared purpose with them." },
+  4: { headline: "Kindred / Co-Creator", detail: "A kindred spirit; I hope to partner with them for decades." },
 };

--- a/tests/e2e/myweb.spec.ts
+++ b/tests/e2e/myweb.spec.ts
@@ -61,8 +61,8 @@ test.describe("/myweb — first-time welcome tour", () => {
     await page.getByRole("link", { name: "My web" }).click();
     await page.waitForURL((u) => u.pathname === "/myweb", { timeout: TIMEOUT_MS });
 
-    await expect(page.getByText("Welcome to your relational web")).toBeVisible({ timeout: 5_000 });
-    await page.getByRole("button", { name: /^Skip$/ }).click();
-    await expect(page.getByText("Welcome to your relational web")).toBeHidden();
+    await expect(page.getByText("Mapping your relational web")).toBeVisible({ timeout: 5_000 });
+    await page.getByRole("button", { name: /^Dismiss tour$/ }).click();
+    await expect(page.getByText("Mapping your relational web")).toBeHidden();
   });
 });

--- a/tests/functional/client/member-relation-control.test.tsx
+++ b/tests/functional/client/member-relation-control.test.tsx
@@ -43,7 +43,7 @@ describe("MemberRelationControl", () => {
 
     // Regression guard: the label must render the headline string, not the
     // RELATION_VALUE_LABELS object (which stringifies to "[object Object]").
-    expect(await screen.findByText("Connected · Talked 1-on-1")).toBeVisible();
+    expect(await screen.findByText("Connected · Friend / Collaborator")).toBeVisible();
     expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
- Tour polish: rewritten copy, "Replay guided tour" action in the /myweb help popover, smoother step transitions.
- Relating dialog opens from the numbered edge label; relation-value vocabulary refreshed.
- Graph polish: nodes are draggable and integrated with the force sim; avatar-only node hitboxes and label-only edge hitboxes; fixed initial zoom, stopped refitting viewport every tick, shortened sim tail.

## Test plan
- [x] `npm test` (lint + typecheck + 331 vitest + 25 playwright) all green locally
- [ ] Manually replay tour from help popover on a fresh account
- [ ] Drag nodes around; confirm sim settles quickly and viewport stays put
- [ ] Click a numbered edge label and confirm the relating dialog opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)