### PR TITLE
Breadcrumb back links (closes #274)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { requireUser, serverApiClient } from "@/lib/api-server";
 
 import { AdminHidden } from "./admin-hidden";
@@ -22,9 +23,7 @@ export default async function AdminPage() {
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
       <div className="flex w-full max-w-xl items-center justify-between">
         <h1 className="text-2xl font-bold">Admin</h1>
-        <Link href="/" className="text-base text-muted-foreground hover:text-foreground">
-          ← Back
-        </Link>
+        <BreadcrumbLink fallback="/" />
       </div>
 
       <section className="flex w-full max-w-xl flex-col gap-2">

--- a/src/app/invites/page.tsx
+++ b/src/app/invites/page.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link";
-
+import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { requireUser } from "@/lib/api-server";
 
 import { InvitesPanel } from "./invites-panel";
@@ -9,10 +8,10 @@ export default async function InvitesPage() {
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <h1 className="text-4xl font-bold">Intentional Society</h1>
-      <Link href="/" className="text-base text-muted-foreground underline hover:text-foreground">
-        ← Back to home
-      </Link>
+      <div className="flex w-full max-w-xl items-center justify-between">
+        <h1 className="text-2xl font-bold">Invites</h1>
+        <BreadcrumbLink fallback="/" />
+      </div>
       <InvitesPanel me={me} />
     </main>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { Gudea, Ovo } from "next/font/google";
 
 import { AuthProvider } from "@/components/auth-provider";
+import { NavigationHistory } from "@/components/navigation-history";
 import { QueryProvider } from "@/components/query-provider";
 import { SiteHeader } from "@/components/site-header";
 import { loadMe } from "@/lib/api-server";
@@ -52,6 +53,7 @@ export default async function RootLayout({
       <body className="antialiased">
         <AuthProvider initialUser={user}>
           <QueryProvider>
+            <NavigationHistory />
             <SiteHeader displayName={me?.profile?.displayName ?? null} isAdmin={me?.profile?.isAdmin ?? false} />
             {children}
           </QueryProvider>

--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { Avatar } from "@/components/avatar";
+import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { QueryProvider } from "@/components/query-provider";
 import { requireUser, serverApiClient } from "@/lib/api-server";
 import type { MemberProfile } from "@/lib/api-types";
@@ -29,9 +29,7 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
       <main className="flex min-h-screen flex-col items-center gap-6 p-8">
         <div className="flex w-full max-w-md items-center justify-between">
           <h1 className="text-2xl font-bold">Member not found</h1>
-          <Link href="/members" className="text-base text-muted-foreground hover:text-foreground">
-            ← Directory
-          </Link>
+          <BreadcrumbLink fallback="/members" />
         </div>
         <p className="text-muted-foreground">We couldn&apos;t find a member with that name or ID.</p>
       </main>
@@ -51,9 +49,7 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
             <h1 className="text-2xl font-bold">{profile.displayName ?? "Member"}</h1>
             <p className="text-sm text-muted-foreground">Member since {memberSince}</p>
           </div>
-          <Link href="/members" className="text-base text-muted-foreground hover:text-foreground">
-            ← Directory
-          </Link>
+          <BreadcrumbLink fallback="/members" />
         </div>
 
         <Avatar

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link";
-
+import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { requireUser, serverApiClient } from "@/lib/api-server";
 import type { MemberSummary } from "@/lib/api-types";
 
@@ -16,9 +15,7 @@ export default async function MembersPage() {
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
       <div className="flex w-full max-w-5xl items-center justify-between">
         <h1 className="text-2xl font-bold">Member directory</h1>
-        <Link href="/" className="text-base text-muted-foreground hover:text-foreground">
-          ← Back
-        </Link>
+        <BreadcrumbLink fallback="/" />
       </div>
 
       <MembersList members={members} />

--- a/src/app/myweb/page.tsx
+++ b/src/app/myweb/page.tsx
@@ -1,6 +1,6 @@
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
-import Link from "next/link";
 
+import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { requireUser, serverApiClient } from "@/lib/api-server";
 
 import { MyWeb } from "./my-web";
@@ -36,9 +36,7 @@ export default async function MyWebPage() {
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
       <div className="flex w-full max-w-5xl items-center justify-between">
         <h1 className="text-2xl font-bold">My web</h1>
-        <Link href="/" className="text-base text-muted-foreground hover:text-foreground">
-          ← Back
-        </Link>
+        <BreadcrumbLink fallback="/" />
       </div>
       <HydrationBoundary state={dehydrate(queryClient)}>
         <MyWeb initialLastUpdatedWeb={initialLastUpdatedWeb} />

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link";
-
+import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { requireUser } from "@/lib/api-server";
 import type { Me } from "@/lib/api-types";
 
@@ -19,9 +18,7 @@ export default async function EditProfilePage() {
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
       <div className="flex w-full max-w-md items-center justify-between">
         <h1 className="text-2xl font-bold">Edit profile</h1>
-        <Link href="/profile" className="text-base text-muted-foreground hover:text-foreground">
-          ← Back to profile
-        </Link>
+        <BreadcrumbLink fallback="/profile" />
       </div>
 
       <AvatarUploader name={profile.displayName} initialUrl={profile.avatarUrl} />

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { Avatar } from "@/components/avatar";
+import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { KeywordChips } from "@/components/keyword-chips";
 import { Button } from "@/components/ui/button";
 import { requireUser } from "@/lib/api-server";
@@ -34,9 +35,7 @@ export default async function ProfilePage() {
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
       <div className="flex w-full max-w-md items-center justify-between">
         <h1 className="text-2xl font-bold">My profile</h1>
-        <Link href="/" className="text-base text-muted-foreground hover:text-foreground">
-          ← Back
-        </Link>
+        <BreadcrumbLink fallback="/" />
       </div>
 
       <Avatar

--- a/src/app/programs/[slug]/page.tsx
+++ b/src/app/programs/[slug]/page.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link";
-
+import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { requireUser } from "@/lib/api-server";
 
 import { ProgramSlugDetail } from "./program-slug-detail";
@@ -16,9 +15,7 @@ export default async function ProgramDetailPage({
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
       <div className="flex w-full max-w-3xl items-center justify-between">
         <h1 className="text-2xl font-bold">Program</h1>
-        <Link href="/programs" className="text-base text-muted-foreground hover:text-foreground">
-          ← Programs
-        </Link>
+        <BreadcrumbLink fallback="/programs" />
       </div>
       <ProgramSlugDetail slug={slug} />
     </main>

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link";
-
+import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { requireUser } from "@/lib/api-server";
 
 import { ProgramsList } from "./programs-list";
@@ -11,9 +10,7 @@ export default async function ProgramsPage() {
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
       <div className="flex w-full max-w-5xl items-center justify-between">
         <h1 className="text-2xl font-bold">Programs</h1>
-        <Link href="/" className="text-base text-muted-foreground hover:text-foreground">
-          ← Back
-        </Link>
+        <BreadcrumbLink fallback="/" />
       </div>
       <p className="w-full max-w-5xl text-base text-muted-foreground">
         Browse programs and join the ones that interest you.

--- a/src/components/breadcrumb-link.tsx
+++ b/src/components/breadcrumb-link.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { UrlObject } from "node:url";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { HISTORY_KEY, labelForPath } from "@/lib/route-labels";
+
+type Props = {
+  fallback: string;
+  className?: string;
+};
+
+const DEFAULT_CLASSES = "text-base text-muted-foreground hover:text-foreground";
+
+// History-aware breadcrumb link. On first render (and on the server)
+// it shows the per-page fallback so SSR and hydration agree; a client
+// effect then upgrades it to "← <previous>" when NavigationHistory has
+// an in-app entry recorded for the current pathname. The label for
+// both states comes from labelForPath, so the route → label map is the
+// single source of truth.
+export function BreadcrumbLink({ fallback, className }: Props) {
+  const pathname = usePathname();
+  const [previous, setPrevious] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      const raw = window.sessionStorage.getItem(HISTORY_KEY);
+      if (!raw) {
+        setPrevious(null);
+        return;
+      }
+      const parsed: unknown = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        setPrevious(null);
+        return;
+      }
+      for (let i = parsed.length - 1; i >= 0; i--) {
+        const entry = parsed[i];
+        if (typeof entry === "string" && entry !== pathname) {
+          setPrevious(entry);
+          return;
+        }
+      }
+      setPrevious(null);
+    } catch {
+      setPrevious(null);
+    }
+  }, [pathname]);
+
+  // typedRoutes requires a known route or a UrlObject — the in-app
+  // pathname stack holds arbitrary strings, so we hand Link a UrlObject.
+  const target = previous ?? fallback;
+  const href: UrlObject = { pathname: target };
+  return (
+    <Link href={href} className={className ?? DEFAULT_CLASSES}>
+      ← {labelForPath(target)}
+    </Link>
+  );
+}

--- a/src/components/navigation-history.tsx
+++ b/src/components/navigation-history.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+import { HISTORY_KEY, HISTORY_LIMIT } from "@/lib/route-labels";
+
+// Records each in-app pathname into a sessionStorage-backed stack so
+// BreadcrumbLink can render history-aware "← <previous>" links.
+// Mounted once near the top of the tree in app/layout.tsx.
+export function NavigationHistory() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    try {
+      const raw = window.sessionStorage.getItem(HISTORY_KEY);
+      const parsed: unknown = raw ? JSON.parse(raw) : [];
+      const stack: string[] = Array.isArray(parsed)
+        ? parsed.filter((x): x is string => typeof x === "string")
+        : [];
+      const last = stack[stack.length - 1];
+      if (last === pathname) return;
+      const prev = stack[stack.length - 2];
+      if (prev === pathname) {
+        // Back navigation (breadcrumb click or browser back): pop
+        // rather than push so the stack stays a reverse-chronological
+        // record and clicking "back" from the destination doesn't
+        // bounce us right back to where we just left.
+        stack.pop();
+      } else {
+        stack.push(pathname);
+        while (stack.length > HISTORY_LIMIT) stack.shift();
+      }
+      window.sessionStorage.setItem(HISTORY_KEY, JSON.stringify(stack));
+    } catch {
+      // sessionStorage can be blocked (private browsing, sandboxed
+      // iframes); when it is, BreadcrumbLink quietly falls back to the
+      // per-page default link.
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useAuth } from "@/components/auth-provider";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { clearNavHistory } from "@/lib/route-labels";
 
 export function SiteHeader({ displayName, isAdmin }: { displayName: string | null; isAdmin: boolean }) {
   const { user } = useAuth();
@@ -27,7 +28,7 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
             <SheetClose
               nativeButton={false}
               render={
-                <Link href="/" className="rounded px-2 py-2 hover:bg-muted">
+                <Link href="/" onClick={clearNavHistory} className="rounded px-2 py-2 hover:bg-muted">
                   Home
                 </Link>
               }
@@ -35,7 +36,7 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
             <SheetClose
               nativeButton={false}
               render={
-                <Link href="/programs" className="rounded px-2 py-2 hover:bg-muted">
+                <Link href="/programs" onClick={clearNavHistory} className="rounded px-2 py-2 hover:bg-muted">
                   Programs
                 </Link>
               }
@@ -43,7 +44,7 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
             <SheetClose
               nativeButton={false}
               render={
-                <Link href="/members" className="rounded px-2 py-2 hover:bg-muted">
+                <Link href="/members" onClick={clearNavHistory} className="rounded px-2 py-2 hover:bg-muted">
                   Member directory
                 </Link>
               }
@@ -51,7 +52,7 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
             <SheetClose
               nativeButton={false}
               render={
-                <Link href="/myweb" className="rounded px-2 py-2 hover:bg-muted">
+                <Link href="/myweb" onClick={clearNavHistory} className="rounded px-2 py-2 hover:bg-muted">
                   My web
                 </Link>
               }
@@ -59,7 +60,7 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
             <SheetClose
               nativeButton={false}
               render={
-                <Link href="/profile" className="rounded px-2 py-2 hover:bg-muted">
+                <Link href="/profile" onClick={clearNavHistory} className="rounded px-2 py-2 hover:bg-muted">
                   My profile
                 </Link>
               }
@@ -67,7 +68,7 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
             <SheetClose
               nativeButton={false}
               render={
-                <Link href="/invites" className="rounded px-2 py-2 hover:bg-muted">
+                <Link href="/invites" onClick={clearNavHistory} className="rounded px-2 py-2 hover:bg-muted">
                   Invite a friend
                 </Link>
               }
@@ -84,7 +85,7 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
               <SheetClose
                 nativeButton={false}
                 render={
-                  <Link href="/admin" className="flex items-center gap-2 rounded px-2 py-2 text-green-700 hover:bg-muted">
+                  <Link href="/admin" onClick={clearNavHistory} className="flex items-center gap-2 rounded px-2 py-2 text-green-700 hover:bg-muted">
                     <ShieldCheck className="h-4 w-4 shrink-0" />
                     Admin dashboard
                   </Link>

--- a/src/lib/route-labels.ts
+++ b/src/lib/route-labels.ts
@@ -1,0 +1,51 @@
+// Shared by NavigationHistory (writer), BreadcrumbLink (reader), and
+// clearNavHistory (reset, called from the side-nav menu).
+export const HISTORY_KEY = "isweb-nav-history";
+
+// Short cap: BreadcrumbLink only ever inspects the top of the stack, so
+// a large history adds no value and just bloats sessionStorage.
+export const HISTORY_LIMIT = 10;
+
+// Wipes the recorded in-app history. Called from the side-nav menu
+// links: a menu jump is a "switch sections", not a "drill in", so the
+// new section's BreadcrumbLink should land on its fallback, not point
+// back at the page the user just left.
+export function clearNavHistory(): void {
+  try {
+    window.sessionStorage.removeItem(HISTORY_KEY);
+  } catch {
+    // sessionStorage may be blocked; the breadcrumb already degrades to
+    // its fallback in that case, so there's nothing to clean up.
+  }
+}
+
+// All "← <label>" strings live here. EXACT wins by direct lookup;
+// PREFIX is a fall-through for dynamic detail pages, which use the
+// parent-section label since the entity's display name isn't on hand
+// at render time. PREFIX entries are checked in declaration order, so
+// list longer prefixes first.
+const EXACT_LABELS: Record<string, string> = {
+  "/": "Home",
+  "/members": "Directory",
+  "/myweb": "My web",
+  "/programs": "Programs",
+  "/profile": "Profile",
+  "/profile/edit": "Edit profile",
+  "/invites": "Invites",
+  "/admin": "Admin",
+  "/admin/programs": "Admin programs",
+};
+const PREFIX_LABELS: Record<string, string> = {
+  "/admin/programs/": "Admin programs",
+  "/programs/": "Programs",
+  "/members/": "Member",
+};
+
+export function labelForPath(pathname: string): string {
+  const direct = EXACT_LABELS[pathname];
+  if (direct) return direct;
+  for (const [prefix, label] of Object.entries(PREFIX_LABELS)) {
+    if (pathname.startsWith(prefix)) return label;
+  }
+  return "Back";
+}

--- a/tests/e2e/breadcrumb.spec.ts
+++ b/tests/e2e/breadcrumb.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+import { completeWelcome, resetSeededUsers, signInAs, TIMEOUT_MS } from "./helpers/session";
+
+// Exercises the history-aware breadcrumb back link from #274. /profile
+// is one of the multi-entry pages: reachable from /, /myweb, the nav
+// menu, etc. The back link should follow the user's actual route when
+// an in-app referrer exists, and fall back to the per-page default
+// when it doesn't.
+test.describe.configure({ mode: "serial" });
+
+test.describe("/profile — breadcrumb back link", () => {
+  test.beforeEach(async ({ page, baseURL }) => {
+    if (!baseURL) throw new Error("breadcrumb.spec.ts: baseURL is not configured");
+    await resetSeededUsers(baseURL);
+    // Pre-dismiss the /myweb welcome tour so it doesn't intercept
+    // navigation in the /myweb → /profile flow below.
+    await page.addInitScript(() => {
+      window.sessionStorage.setItem("isweb-welcome-tour-dismissed", "1");
+    });
+  });
+
+  test("/myweb → /profile renders '← My web' and returns there", async ({ page }) => {
+    await signInAs(page, "regular");
+    // Distinct bio per completeWelcome caller — see the #149 probe.
+    await completeWelcome(page, { bio: "e2e bio · breadcrumb.spec · myweb-to-profile" });
+
+    await page.goto("/myweb");
+    await page.waitForURL((u) => u.pathname === "/myweb", { timeout: TIMEOUT_MS });
+    await expect(page.getByRole("heading", { name: "My web" })).toBeVisible();
+
+    await page.goto("/profile");
+    await page.waitForURL((u) => u.pathname === "/profile", { timeout: TIMEOUT_MS });
+    await expect(page.getByRole("heading", { name: "My profile" })).toBeVisible();
+
+    const back = page.getByRole("link", { name: "← My web", exact: true });
+    await expect(back).toHaveAttribute("href", "/myweb");
+    await back.click();
+    await page.waitForURL((u) => u.pathname === "/myweb", { timeout: TIMEOUT_MS });
+  });
+
+  test("direct landing on /profile falls back to '← Home'", async ({ page }) => {
+    await signInAs(page, "regular");
+    // Distinct bio per completeWelcome caller — see the #149 probe.
+    await completeWelcome(page, { bio: "e2e bio · breadcrumb.spec · direct-profile" });
+
+    // Drop the welcome-flow history so this navigation is the user's
+    // only in-app entry, simulating a deep link from outside the app.
+    await page.evaluate(() => window.sessionStorage.removeItem("isweb-nav-history"));
+
+    await page.goto("/profile");
+    await page.waitForURL((u) => u.pathname === "/profile", { timeout: TIMEOUT_MS });
+
+    const back = page.getByRole("link", { name: "← Home", exact: true });
+    await expect(back).toHaveAttribute("href", "/");
+  });
+});


### PR DESCRIPTION
## Summary

- Detail and section pages used to render back links hardcoded to one parent. Now that several are reachable from multiple in-app paths (e.g. `/myweb` → `/profile`), those links could land users somewhere they didn't come from.
- Adds a sessionStorage-backed navigation history tracker mounted in the root layout, plus a `BreadcrumbLink` component that renders `← <previous>` when an in-app referrer exists, or the per-page fallback otherwise.
- Applied to `/members/[id]`, `/profile`, `/profile/edit`, `/myweb`, `/members`, `/invites`, `/programs`, `/programs/[slug]`, `/admin`. The side-nav menu clears the stack on click, so jumping between sections behaves like "go to" not "drill in".
- Reshapes `/invites` to the standard title-on-left, breadcrumb-on-right header.

Issue #274 was originally framed as "browser back button behavior" — the body has been updated in place to reflect the actual breadcrumb framing.

## Test plan

- [x] `npm test` — 21 functional files / 331 tests + 27 e2e tests, all green
- [x] Lint, typecheck, production build clean
- [ ] Manual smoke: `/myweb → /profile` shows "← My web"; direct `/profile` shows "← Home"; same for `/members/[id]`
- [ ] Manual smoke: jump from `/programs` to `/members` via the nav menu — back link on `/members` reads "← Home" (stack was cleared)

🤖 Filed by [Claude Code](https://claude.com/claude-code)