### PR TITLE
fix:Env-aware auth emails (#311)

### DIFF
--- a/docs/design-emails.md
+++ b/docs/design-emails.md
@@ -203,8 +203,29 @@ Supabase substitutes Go-template variables before sending. The ones in use:
 The action-URL pattern both reachable templates use:
 
 ```
-{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=<email|recovery>&next={{ .RedirectTo }}
+{{ .RedirectTo }}&token_hash={{ .TokenHash }}
 ```
+
+`.RedirectTo` is the `emailRedirectTo` URL the form passed; the forms
+build it as the full callback URL with `type` and (for signup) `invite`
+already in the query string:
+
+| Form              | `emailRedirectTo`                                                 |
+| ----------------- | ----------------------------------------------------------------- |
+| `/signin`         | `${origin}/auth/callback?type=email`                              |
+| `/signup`         | `${origin}/auth/callback?type=email&invite=${code}`               |
+| `/forgot-password`| `${origin}/auth/callback?type=recovery`                           |
+
+This is what makes preview-deploy emails work: the action URL's host
+comes from the form's `window.location.origin` (preview / prod /
+localhost), not from `.SiteURL` (which is hardcoded to prod in the
+Supabase project config). Templates contribute only `&token_hash=…`.
+
+Each `emailRedirectTo` must match Supabase's redirect-URL allowlist
+([`doc-supabase.md`](./doc-supabase.md) → "Authentication → URL
+Configuration"). The wildcard entries already cover the `/auth/callback?…`
+path on all three target origins — no allowlist edit is needed when
+the query string changes.
 
 Templates are HTML; Supabase wraps them in a minimal MIME envelope. Email
 clients vary wildly in CSS support — keep styling inline and conservative

--- a/docs/doc-supabase.md
+++ b/docs/doc-supabase.md
@@ -6,7 +6,9 @@ Covers both the hosted production project (configured via the Supabase dashboard
 
 ## Magic-link flow (token-hash + verifyOtp)
 
-The magic-link and password-reset emails embed `{{ .TokenHash }}` directly in a URL pointing at `/auth/callback?token_hash=…&type=…&next=…`. The route calls `supabase.auth.verifyOtp({ token_hash, type })` server-side, so the link works regardless of which browser opens it. The `next` query param carries the `emailRedirectTo` URL the form passed and tells the route where to land the user post-verification.
+The magic-link and password-reset emails embed `{{ .TokenHash }}` directly in a URL pointing at `/auth/callback?type=…&token_hash=…`. The route calls `supabase.auth.verifyOtp({ token_hash, type })` server-side, so the link works regardless of which browser opens it.
+
+The forms pass the full callback URL as `emailRedirectTo`, and templates use `{{ .RedirectTo }}` as the action URL host. That keeps the link env-aware — preview-deploy emails point at the preview origin, not at `.SiteURL` (which is hardcoded to prod). Signup adds `&invite=${code}` to the callback URL; the route reads it directly from its query params.
 
 PKCE is still the configured client `flowType` and still governs session cookies / refresh-token rotation. Only the email-verification step is bypassed by the token-hash flow. See `docs/old-archive/plan-cross-browser-magic-link.md` for the migration rationale.
 
@@ -69,7 +71,7 @@ These settings control where Supabase redirects users after magic-link sign-in. 
 
 Local dev does **not** need entries here — it hits the local Supabase stack, whose allowlist is in `supabase/config.toml`. Only add `localhost` / `127.0.0.1` to this prod allowlist if a developer intentionally points their local frontend at prod Supabase (rare, and sends real magic-link emails).
 
-The bare `/*` covers all three `emailRedirectTo` targets the forms pass: `/` (signin), `/?invite=<code>` (signup), and `/auth/reset-password` (forgot-password). Anything more specific would need a separate entry per target. Without a matching wildcard, Supabase rejects the URL and silently falls back to **Site URL**, stranding the user at `/` with no session.
+The bare `/*` covers the `emailRedirectTo` targets all three forms pass — `/auth/callback?type=email`, `/auth/callback?type=email&invite=<code>`, and `/auth/callback?type=recovery`. Anything more specific would need a separate entry per target. Without a matching wildcard, Supabase rejects the URL and silently falls back to **Site URL**, stranding the user at the prod origin with no session.
 
 ### Auth providers
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -20,19 +20,6 @@ const tryAutoSubscribe = async (userId: string): Promise<void> => {
   }
 };
 
-// Pull the `invite` query param out of the `next` URL the email
-// carried through from `emailRedirectTo`. The value may be a full URL
-// (signup form sends `${origin}/?invite=XYZ`) or a path-only string;
-// `new URL(next, request.url)` handles both.
-const extractInvite = (next: string | null, base: string): string | null => {
-  if (!next) return null;
-  try {
-    return new URL(next, base).searchParams.get("invite");
-  } catch {
-    return null;
-  }
-};
-
 // The two `type` values our templates emit. Supabase's EmailOtpType is
 // wider ("signup" | "invite" | "magiclink" | "email_change" | …) but
 // we don't route any of those, so we narrow at the boundary instead of
@@ -46,7 +33,7 @@ const isAllowedType = (v: string | null): v is AllowedType =>
 export async function GET(request: NextRequest) {
   const tokenHash = request.nextUrl.searchParams.get("token_hash");
   const type = request.nextUrl.searchParams.get("type");
-  const next = request.nextUrl.searchParams.get("next");
+  const invite = request.nextUrl.searchParams.get("invite");
 
   if (!tokenHash || !isAllowedType(type)) {
     return NextResponse.redirect(new URL("/signin?error=missing_token", request.url));
@@ -62,8 +49,6 @@ export async function GET(request: NextRequest) {
   if (type === "recovery") {
     return NextResponse.redirect(new URL("/auth/reset-password", request.url));
   }
-
-  const invite = extractInvite(next, request.url);
 
   // Ordinary sign-in — Phase 1 upsert, referredBy stays null.
   if (!invite) {

--- a/src/app/forgot-password/forgot-password-form.tsx
+++ b/src/app/forgot-password/forgot-password-form.tsx
@@ -19,7 +19,7 @@ export function ForgotPasswordForm() {
     try {
       const supabase = createClient();
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}/auth/reset-password`,
+        redirectTo: `${window.location.origin}/auth/callback?type=recovery`,
       });
       if (error) {
         setErrorMsg(error.message);

--- a/src/app/signin/signin-form.tsx
+++ b/src/app/signin/signin-form.tsx
@@ -36,7 +36,7 @@ function SentView({ email, origin }: { email: string; origin: string }) {
     await supabase.auth.signInWithOtp({
       email,
       options: {
-        emailRedirectTo: `${origin}/`,
+        emailRedirectTo: `${origin}/auth/callback?type=email`,
         shouldCreateUser: false,
       },
     });
@@ -109,7 +109,13 @@ export function SigninForm() {
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
-        emailRedirectTo: `${window.location.origin}/`,
+        // The full callback URL travels as `emailRedirectTo` so the
+        // email's action link points back at the origin the form was
+        // submitted on. Templates use `.RedirectTo` directly as the
+        // action URL host — see docs/design-emails.md. Without this,
+        // preview-deploy emails would always land users on prod (the
+        // Supabase project's `.SiteURL`).
+        emailRedirectTo: `${window.location.origin}/auth/callback?type=email`,
         // Block auto-creation of users via this form. Keeps auth.users
         // from accumulating rows when a bot (or a typo) submits unknown
         // emails, and closes the loophole where a pre-existing row with

--- a/src/app/signup/signup-form.tsx
+++ b/src/app/signup/signup-form.tsx
@@ -74,7 +74,7 @@ export function SignupForm({ initialCode }: { initialCode: string }) {
       const { error } = await supabase.auth.signInWithOtp({
         email,
         options: {
-          emailRedirectTo: `${window.location.origin}/?invite=${code}`,
+          emailRedirectTo: `${window.location.origin}/auth/callback?type=email&invite=${code}`,
           data: { displayName: displayName.trim() || null },
         },
       });

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -163,8 +163,9 @@ site_url = "http://localhost:3000"
 # A list of URLs that auth providers are permitted to redirect to post authentication. Supabase
 # matches these with trailing-`*` wildcard support. Cover both 127.0.0.1 and localhost because
 # window.location.origin on the client depends on which host the dev server was opened with.
-# Bare `/*` covers the three `emailRedirectTo` targets the forms pass: `/` (signin),
-# `/?invite=<code>` (signup), and `/auth/reset-password` (forgot-password).
+# Bare `/*` covers the three `emailRedirectTo` targets the forms pass:
+# `/auth/callback?type=email` (signin), `/auth/callback?type=email&invite=<code>` (signup),
+# and `/auth/callback?type=recovery` (forgot-password).
 additional_redirect_urls = [
   "http://127.0.0.1:3000/*",
   "http://localhost:3000/*",

--- a/supabase/templates/magic-link.html
+++ b/supabase/templates/magic-link.html
@@ -19,11 +19,11 @@
               <p style="margin:0 0 24px;font-size:16px;line-height:1.5;mso-line-height-rule:exactly;color:#1a1a1a;">Use the button below to sign in. This link expires in 1 hour.</p>
               <table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr>
                 <td bgcolor="#1a1a1a" style="border-radius:6px;">
-                  <a href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}" style="display:inline-block;padding:12px 24px;font-size:16px;font-weight:bold;color:#ffffff;text-decoration:none;border-radius:6px;">Sign in</a>
+                  <a href="{{ .RedirectTo }}&token_hash={{ .TokenHash }}" style="display:inline-block;padding:12px 24px;font-size:16px;font-weight:bold;color:#ffffff;text-decoration:none;border-radius:6px;">Sign in</a>
                 </td>
               </tr></table>
               <p style="margin:24px 0 0;font-size:14px;line-height:1.5;mso-line-height-rule:exactly;color:#555;">Or paste this URL into your browser:</p>
-              <p style="margin:4px 0 0;font-size:14px;line-height:1.5;mso-line-height-rule:exactly;color:#555;"><a href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}" style="color:#555;">{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}</a></p>
+              <p style="margin:4px 0 0;font-size:14px;line-height:1.5;mso-line-height-rule:exactly;color:#555;"><a href="{{ .RedirectTo }}&token_hash={{ .TokenHash }}" style="color:#555;">{{ .RedirectTo }}&token_hash={{ .TokenHash }}</a></p>
               <p style="margin:24px 0 0;font-size:14px;line-height:1.5;mso-line-height-rule:exactly;color:#555;">We sent this to {{ .Email }}. If you didn't ask to sign in, you can safely ignore it.</p>
             </td>
           </tr>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -19,11 +19,11 @@
               <p style="margin:0 0 24px;font-size:16px;line-height:1.5;mso-line-height-rule:exactly;color:#1a1a1a;">Use the button below to choose a new password for your Intentional Society Web App account. This link expires in 1 hour.</p>
               <table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr>
                 <td bgcolor="#1a1a1a" style="border-radius:6px;">
-                  <a href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=recovery&next={{ .RedirectTo }}" style="display:inline-block;padding:12px 24px;font-size:16px;font-weight:bold;color:#ffffff;text-decoration:none;border-radius:6px;">Reset password</a>
+                  <a href="{{ .RedirectTo }}&token_hash={{ .TokenHash }}" style="display:inline-block;padding:12px 24px;font-size:16px;font-weight:bold;color:#ffffff;text-decoration:none;border-radius:6px;">Reset password</a>
                 </td>
               </tr></table>
               <p style="margin:24px 0 0;font-size:14px;line-height:1.5;mso-line-height-rule:exactly;color:#555;">Or paste this URL into your browser:</p>
-              <p style="margin:4px 0 0;font-size:14px;line-height:1.5;mso-line-height-rule:exactly;color:#555;"><a href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=recovery&next={{ .RedirectTo }}" style="color:#555;">{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=recovery&next={{ .RedirectTo }}</a></p>
+              <p style="margin:4px 0 0;font-size:14px;line-height:1.5;mso-line-height-rule:exactly;color:#555;"><a href="{{ .RedirectTo }}&token_hash={{ .TokenHash }}" style="color:#555;">{{ .RedirectTo }}&token_hash={{ .TokenHash }}</a></p>
               <p style="margin:24px 0 0;font-size:14px;line-height:1.5;mso-line-height-rule:exactly;color:#555;">We sent this to {{ .Email }}. If you didn't request this, you can safely ignore it — your current password still works.</p>
             </td>
           </tr>

--- a/tests/e2e/password-reset.spec.ts
+++ b/tests/e2e/password-reset.spec.ts
@@ -42,11 +42,12 @@ test("submitting the forgot-password form sends a recovery email and confirms", 
   await page.getByRole("button", { name: "Send reset link" }).click();
 
   await expect(page.getByText("Password reset email sent — check your inbox.")).toBeVisible();
-  // After verifyOtp succeeds on /auth/callback, the recovery branch
-  // redirects here. redirectTo is forwarded as &next= in the email URL,
-  // so the form's value lands the user directly on the set-password
-  // page. (Both paths must be on the Supabase redirect allowlist.)
-  expect(decodeURIComponent(recoverUrl ?? "")).toContain("/auth/reset-password");
+  // The form's `redirectTo` is the full callback URL so the email's
+  // action link points back at this origin (env-aware). The callback's
+  // recovery branch then redirects to /auth/reset-password. The
+  // callback URL — not /auth/reset-password — must be on the Supabase
+  // redirect allowlist.
+  expect(decodeURIComponent(recoverUrl ?? "")).toContain("/auth/callback?type=recovery");
 });
 
 test("reset-password rejects a too-short password", async ({ page }) => {

--- a/tests/functional/server/auth-callback.test.ts
+++ b/tests/functional/server/auth-callback.test.ts
@@ -183,7 +183,7 @@ describe("GET /auth/callback (ordinary sign-in, auto-subscribe to weekly-web-upd
   });
 });
 
-describe("GET /auth/callback (invited sign-in, invite read from next)", () => {
+describe("GET /auth/callback (invited sign-in, invite query param)", () => {
   let inviterId: string;
   let newUserId: string;
   let weeklyProgramId: string;
@@ -205,10 +205,8 @@ describe("GET /auth/callback (invited sign-in, invite read from next)", () => {
     await deleteAuthUser(inviterId);
   });
 
-  const callbackUrl = (inviteCode: string) => {
-    const next = encodeURIComponent(`/?invite=${inviteCode}`);
-    return `/auth/callback?token_hash=hash&type=email&next=${next}`;
-  };
+  const callbackUrl = (inviteCode: string) =>
+    `/auth/callback?token_hash=hash&type=email&invite=${inviteCode}`;
 
   it("redeems a valid invite and stamps referredBy + displayName", async () => {
     const r = await createInvite({


### PR DESCRIPTION
## Summary

Fixes #311.

- Templates collapse to `{{ .RedirectTo }}&token_hash={{ .TokenHash }}`. The action URL host now comes from the form's `window.location.origin` (preview / prod / localhost) instead of Supabase's project-wide `.SiteURL` constant.
- Forms set `emailRedirectTo` to the full callback URL with `type` and (for signup) `invite` already in the query string.
- Callback reads `invite` from its own query params; the `extractInvite`/`next` indirection is removed.

The PR diff in `supabase/templates/` shows snapshot (current prod) vs source files = exactly what's changing for recipients. The committed snapshot is deliberately left at pre-push state per `docs/design-emails.md`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:functional` — 331/331 pass (auth-callback suite rewritten to use `?invite=…` directly)
- [x] `npm run test:e2e` — 27/27 pass (password-reset spec asserts the new `/auth/callback?type=recovery` target)
- [ ] After merge: `npm run update_email_templates` to push the new templates to the hosted Supabase project. Until that runs, the new prod app code is paired with old templates; signin still works (the doubly-wrapped link still resolves to the prod callback), signup briefly loses the invite query param.
- [ ] Manual preview-deploy smoke: request a sign-in link from the preview origin and confirm the email link's host is the preview origin, not `app.intentionalsociety.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)