### PR TITLE
Allowlist /** for multi-segment paths

### DIFF
--- a/docs/doc-supabase.md
+++ b/docs/doc-supabase.md
@@ -66,12 +66,12 @@ These settings control where Supabase redirects users after magic-link sign-in. 
 
 - **Site URL:** `https://app.intentionalsociety.org`
 - **Redirect URLs** (allowlist):
-  - `https://app.intentionalsociety.org/*` — production
-  - `https://is-app-vercel-*-intentional-society-vercel.vercel.app/*` — Vercel preview deploys (wildcard)
+  - `https://app.intentionalsociety.org/**` — production
+  - `https://is-app-vercel-*-intentional-society-vercel.vercel.app/**` — Vercel preview deploys (wildcard host)
 
 Local dev does **not** need entries here — it hits the local Supabase stack, whose allowlist is in `supabase/config.toml`. Only add `localhost` / `127.0.0.1` to this prod allowlist if a developer intentionally points their local frontend at prod Supabase (rare, and sends real magic-link emails).
 
-The bare `/*` covers the `emailRedirectTo` targets all three forms pass — `/auth/callback?type=email`, `/auth/callback?type=email&invite=<code>`, and `/auth/callback?type=recovery`. Anything more specific would need a separate entry per target. Without a matching wildcard, Supabase rejects the URL and silently falls back to **Site URL**, stranding the user at the prod origin with no session.
+The `/**` wildcard covers the `emailRedirectTo` targets all three forms pass — `/auth/callback?type=email` (signin), `/auth/callback?type=email&invite=<code>` (signup), and `/auth/callback?type=recovery` (forgot-password). Supabase's `*` wildcard matches non-separator characters only, with `/` and `.` counted as separators, so `/**` is required for the multi-segment `/auth/callback` path — `/*` would only match a single segment. The host wildcard `is-app-vercel-*-…vercel.app` uses single-star because Vercel preview subdomains are one DNS segment. See the [Supabase redirect URL docs](https://supabase.com/docs/guides/auth/redirect-urls) for the full wildcard table.
 
 ### Auth providers
 
@@ -148,7 +148,7 @@ The local Supabase stack (spun up by `supabase start`, wrapped by `npm run dev:d
 Same silent-fallback semantics as prod: if `emailRedirectTo` from the client isn't in the allowlist, Supabase falls back to `site_url`.
 
 - **`site_url`** — `http://127.0.0.1:3000`
-- **`additional_redirect_urls`** — bare `/*` for both `127.0.0.1:3000` and `localhost:3000`, since `window.location.origin` depends on which host the dev server was opened with and the wildcard covers all three form redirect targets.
+- **`additional_redirect_urls`** — `/**` for both `127.0.0.1:3000` and `localhost:3000`, since `window.location.origin` depends on which host the dev server was opened with and the wildcard covers all three form redirect targets (see the prod URL Configuration section above for why `/**` rather than `/*`).
 
 ### Inbucket (local email catcher)
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -160,15 +160,16 @@ enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
 site_url = "http://localhost:3000"
-# A list of URLs that auth providers are permitted to redirect to post authentication. Supabase
-# matches these with trailing-`*` wildcard support. Cover both 127.0.0.1 and localhost because
-# window.location.origin on the client depends on which host the dev server was opened with.
-# Bare `/*` covers the three `emailRedirectTo` targets the forms pass:
-# `/auth/callback?type=email` (signin), `/auth/callback?type=email&invite=<code>` (signup),
-# and `/auth/callback?type=recovery` (forgot-password).
+# A list of URLs that auth providers are permitted to redirect to post authentication. Cover both
+# 127.0.0.1 and localhost because window.location.origin on the client depends on which host the
+# dev server was opened with. The `/**` wildcard matches multi-segment paths (Supabase's `*` only
+# matches non-separator characters, with `/` counted as a separator), so it covers the three
+# `emailRedirectTo` targets the forms pass: `/auth/callback?type=email` (signin),
+# `/auth/callback?type=email&invite=<code>` (signup), and `/auth/callback?type=recovery`
+# (forgot-password). See https://supabase.com/docs/guides/auth/redirect-urls for wildcard rules.
 additional_redirect_urls = [
-  "http://127.0.0.1:3000/*",
-  "http://localhost:3000/*",
+  "http://127.0.0.1:3000/**",
+  "http://localhost:3000/**",
 ]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600


### PR DESCRIPTION
## Summary

Follow-up to #311 / #312. Supabase's `*` wildcard matches non-separator characters only — `/` and `.` count as separators — so `/*` allowlist entries cover only single-segment paths. The forms now pass multi-segment `/auth/callback?type=email` targets, so the allowlist needs `/**`.

Prod dashboard already updated. This PR mirrors the change into local config and docs:

- `supabase/config.toml`: `127.0.0.1:3000/*` and `localhost:3000/*` → `/**`.
- `docs/doc-supabase.md`: prod and preview allowlist entries documented as `/**`; brief callout of the wildcard rule with a link to Supabase's redirect URL docs.

Doc-only / config-only — no source changes, no functional tests affected.

## Test plan

- [x] `npm run lint` — clean
- [ ] Local stack smoke after `npm run dev:db:stop && npm run dev`: send a magic link from `/signin`, confirm the Inbucket link host is the local origin with the full `/auth/callback?type=email` path preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)