### PR TITLE
Grant write perms so Claude workflows can post comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write # post the review via `gh pr comment`
       issues: read
       id-token: write
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # reply on PRs / PR review threads
+      issues: write # reply on issues
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Problem

The Claude Code Review action runs but never posts a comment (e.g. PR #312). The run concludes `success` — the review executes in full (29 turns, \$1.38) — but no comment appears, and the log shows `permission_denials_count: 1`.

Root cause: the `code-review@claude-code-plugins` plugin posts its review with `gh pr comment`, which requires the `GITHUB_TOKEN` to have **`pull-requests: write`**. Both Claude workflows granted only `pull-requests: read`, so posting was impossible. Repo-wide there has never been a `claude[bot]` comment, confirming it's systemic config, not a per-PR "no issues found".

The `directory mismatch … tsconfig.json` line ([#1266](https://github.com/anthropics/claude-code-action/issues/1266)) is a red herring here: it prints *after* a successful result and does not fail the job.

## Fix

- `claude-code-review.yml`: `pull-requests: read` → `write` (post the review).
- `claude.yml`: `pull-requests: read` → `write` and `issues: read` → `write` (so `@claude` can reply on PRs and issues).

Per-workflow escalation works despite the org's greyed-out read-only default — that's only the *default* when no `permissions:` block is present, not a ceiling. Proven in this repo by `codeql.yml`, which escalates to `security-events: write` and runs green.

`contents` is left at `read` on `claude.yml` (reply-only; `@claude` can't push commits). Bump to `write` if we want it to implement fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)