### PR TITLE
feat: add Give Feedback card to logged-in homepage

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -12,6 +12,10 @@ Added a callout to `docs/strategy-committing.md` warning against `git stash && X
 
 Mirrors program memberships into Buttondown subscriber tags via a daily cron plus inline hooks on join/leave/admin-remove, replacing the Apps Script pipeline. Per-program opt-in via `programs.buttondown_tag`; ships in dry-run, then `scripts/buttondown-bootstrap.ts` reconciles the existing audience and `BUTTONDOWN_SYNC_WRITE=1` flips writes on. Design: `docs/design-buttondown.md`. (#280)
 
+## 2026-05-28 | Benji | Give Feedback card on homepage
+
+Added a 6th card to the logged-in homepage grid linking to the Google Form feedback survey. Opens in a new tab, styled to match the existing NavCard pattern.
+
 ## 2026-05-24 | Benji | Custom 404 page
 
 Added a `not-found.tsx` at the app root so unmatched routes show a styled 404 page consistent with the app's aesthetic — serif italic subtitle, centered layout, and a "Go home" button.

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-28 | Benji | Give Feedback card on homepage
+
+Added a 6th card to the logged-in homepage grid linking to the Google Form feedback survey. Opens in a new tab, styled to match the existing NavCard pattern.
+
 ## 2026-05-26 | Blake | Stash-pop antipattern callout in committing strategy
 
 Added a callout to `docs/strategy-committing.md` warning against `git stash && X; git stash pop` as a clean-slate verification idiom — instead, use `git stash list` to check the stack first, and only pop if you actually put something there. Surfaced from RCA #284 (Gap 4); resolves #287.
@@ -11,10 +15,6 @@ Added a callout to `docs/strategy-committing.md` warning against `git stash && X
 ## 2026-05-25 | James | Buttondown sync
 
 Mirrors program memberships into Buttondown subscriber tags via a daily cron plus inline hooks on join/leave/admin-remove, replacing the Apps Script pipeline. Per-program opt-in via `programs.buttondown_tag`; ships in dry-run, then `scripts/buttondown-bootstrap.ts` reconciles the existing audience and `BUTTONDOWN_SYNC_WRITE=1` flips writes on. Design: `docs/design-buttondown.md`. (#280)
-
-## 2026-05-28 | Benji | Give Feedback card on homepage
-
-Added a 6th card to the logged-in homepage grid linking to the Google Form feedback survey. Opens in a new tab, styled to match the existing NavCard pattern.
 
 ## 2026-05-24 | Benji | Custom 404 page
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -89,6 +89,15 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
         <NavCard href="/myweb" title="My web" description="Build your relational map by adding connections!" />
         <NavCard href="/profile" title="My profile" description="View and edit your profile information." />
         <NavCard href="/invites" title="Invite a friend" description="Generate an invite code to bring someone into the network." />
+        <a
+          href="https://docs.google.com/forms/d/e/1FAIpQLScXhdSxbQ3LxjiYhqN2fmuyy66SK292rTYEZV3QaHgzn1eVjA/viewform?usp=dialog"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-5 transition-all hover:border-primary/40 hover:bg-accent hover:shadow-sm"
+        >
+          <h2 className="text-lg font-semibold text-card-foreground group-hover:text-accent-foreground">Give Feedback</h2>
+          <p className="text-sm text-muted-foreground">Share your thoughts, suggestions, or report issues with the app.</p>
+        </a>
       </div>
     </main>
   );


### PR DESCRIPTION
This pull request adds a new "Give Feedback" card to the logged-in homepage, allowing users to easily access a Google Form for feedback. The card is styled to match the existing navigation cards and opens the survey in a new tab. Documentation has also been updated to reflect this addition.

**Homepage UI Updates:**
* Added a sixth card to the homepage grid in `src/app/page.tsx` that links to a Google Form feedback survey, styled consistently with other `NavCard` components and opening in a new tab.

**Documentation:**
* Updated the changelog in `docs/devjournal.md` to record the addition of the "Give Feedback" card on the homepage.