### PR TITLE
fix: de-duplicate keywords on save and render (#219)

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-29 | Benji | Fix duplicate keywords (#219)
+
+De-duplicate keywords on save in `parseEditableProfile` (server-side) and in `KeywordChips` (client-side). Fixes the React duplicate-key warning and prevents visually identical chips from rendering. Added a functional test asserting dedup on PUT /me.
+
 ## 2026-05-28 | Benji | Give Feedback card on homepage
 
 Added a 6th card to the logged-in homepage grid linking to the Google Form feedback survey. Opens in a new tab, styled to match the existing NavCard pattern.

--- a/src/components/keyword-chips.tsx
+++ b/src/components/keyword-chips.tsx
@@ -14,8 +14,8 @@ export function KeywordChips({
   if (unique.length === 0) return null;
   return (
     <div className={className}>
-      {unique.slice(0, max).map((kw, i) => (
-        <span key={`${kw}-${i}`} className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+      {unique.slice(0, max).map((kw) => (
+        <span key={kw} className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
           {kw}
         </span>
       ))}

--- a/src/components/keyword-chips.tsx
+++ b/src/components/keyword-chips.tsx
@@ -10,15 +10,16 @@ export function KeywordChips({
   max?: number;
   className?: string;
 }) {
-  if (keywords.length === 0) return null;
+  const unique = [...new Set(keywords)];
+  if (unique.length === 0) return null;
   return (
     <div className={className}>
-      {keywords.slice(0, max).map((kw) => (
-        <span key={kw} className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+      {unique.slice(0, max).map((kw, i) => (
+        <span key={`${kw}-${i}`} className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
           {kw}
         </span>
       ))}
-      {keywords.length > max && (
+      {unique.length > max && (
         <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">…</span>
       )}
     </div>

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -60,7 +60,7 @@ export const parseEditableProfile = (body: unknown): EditableProfileInput | { er
       if (!isStringArray(value)) {
         return { error: "keywords must be an array of strings" };
       }
-      out.keywords = value;
+      out.keywords = [...new Set(value)];
     } else {
       if (!isNullableString(value)) {
         return { error: `${key} must be a string or null` };

--- a/tests/functional/server/api-me.test.ts
+++ b/tests/functional/server/api-me.test.ts
@@ -143,6 +143,13 @@ describe("GET /api/me", () => {
     expect(res2.status).toBe(400);
   });
 
+  it("PUT /me de-duplicates keywords on save", async () => {
+    const res = await putMe({ keywords: ["running", "running", "yoga", "yoga", "running"] });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { profile: { keywords: string[] } };
+    expect(body.profile.keywords).toEqual(["running", "yoga"]);
+  });
+
   it("PUT /me rejects malformed JSON body", async () => {
     const res = await app.request("/api/me", {
       method: "PUT",


### PR DESCRIPTION
This pull request addresses the issue of duplicate keywords in user profiles by ensuring keywords are de-duplicated both on the server and client sides. It also adds a functional test to verify this behavior and updates the documentation to reflect the change.

**Keyword de-duplication improvements:**

* Server-side: Updated `parseEditableProfile` in `src/server/profiles.ts` to remove duplicate keywords when saving a profile.
* Client-side: Modified `KeywordChips` in `src/components/keyword-chips.tsx` to display only unique keywords and prevent React duplicate-key warnings.

**Testing and documentation:**

* Added a functional test in `tests/functional/server/api-me.test.ts` to assert that duplicate keywords are removed on PUT `/me`.
* Updated `docs/devjournal.md` with an entry describing the fix for duplicate keywords.