### PR TITLE
UX: require typing DEACTIVATE to confirm account deactivation (#320)

### DIFF
--- a/src/app/profile/deactivate-account-form.tsx
+++ b/src/app/profile/deactivate-account-form.tsx
@@ -4,13 +4,17 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { apiClient } from "@/lib/api";
+
+const CONFIRM_WORD = "DEACTIVATE";
 
 type Props = { isDeactivated: boolean };
 
 export function DeactivateAccountForm({ isDeactivated }: Props) {
   const router = useRouter();
   const [confirming, setConfirming] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -73,12 +77,32 @@ export function DeactivateAccountForm({ isDeactivated }: Props) {
   return (
     <div className="flex flex-col gap-3">
       <p className="text-sm text-muted-foreground">Are you sure? You can reactivate your account here at any time.</p>
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="deactivate-confirm" className="text-sm text-muted-foreground">
+          Type <span className="font-mono font-semibold text-foreground">{CONFIRM_WORD}</span> to confirm
+        </label>
+        <Input
+          id="deactivate-confirm"
+          value={confirmText}
+          onChange={(e) => setConfirmText(e.target.value)}
+          disabled={busy}
+          placeholder={CONFIRM_WORD}
+          autoComplete="off"
+        />
+      </div>
       {error && <p className="text-sm text-destructive">{error}</p>}
       <div className="flex gap-3">
-        <Button variant="destructive" disabled={busy} onClick={handleDeactivate}>
+        <Button variant="destructive" disabled={busy || confirmText !== CONFIRM_WORD} onClick={handleDeactivate}>
           {busy ? "Deactivating…" : "Yes, deactivate my account"}
         </Button>
-        <Button variant="ghost" disabled={busy} onClick={() => setConfirming(false)}>
+        <Button
+          variant="ghost"
+          disabled={busy}
+          onClick={() => {
+            setConfirming(false);
+            setConfirmText("");
+          }}
+        >
           Cancel
         </Button>
       </div>


### PR DESCRIPTION
## Summary

Adds a typed confirmation step to the deactivate account flow. After clicking "Deactivate account", the user must type **DEACTIVATE** exactly into a text input before the confirm button becomes enabled — preventing accidental deactivation from a mis-click.

Cancelling clears the input so it resets cleanly if the user reopens the confirmation.

UI-only change — no backend, schema, or API changes.

Closes #320

## Test plan

- [ ] Click "Deactivate account" — confirm button should be disabled
- [ ] Type anything other than DEACTIVATE — button stays disabled
- [ ] Type DEACTIVATE exactly — button enables
- [ ] Click Cancel — reopening confirmation shows empty input

🤖 Generated with [Claude Code](https://claude.com/claude-code)