### PR TITLE
feat(welcome): compact agreements and refine onboarding copy

### DIFF
--- a/src/app/welcome/agreements/agreements-content.tsx
+++ b/src/app/welcome/agreements/agreements-content.tsx
@@ -8,8 +8,8 @@
 export const AGREEMENTS_UPDATED_AT = new Date("2026-05-19T00:00:00Z");
 
 const INTENTIONS = [
-  "I intend to notice, name, and welcome what’s “alive” for me internally and relationally.",
   "I intend to be who I want to be and do things I value.",
+  "I intend to notice, name, and welcome what’s “alive” for me internally and relationally.",
   "I intend to contribute to the wellbeing of others around me.",
 ];
 
@@ -106,35 +106,37 @@ export function AgreementsContent() {
         <p className="text-base">
           We also strive to uphold these interaction agreements (v2.0 adopted July 2022) when we are together:
         </p>
-        {INTERACTION_AGREEMENTS.map((group) => (
-          <div key={group.category} className="flex flex-col gap-3">
-            <h2 className="text-lg font-semibold">{group.category}</h2>
-            <ul className="flex flex-col gap-2">
-              {group.items.map((item) => (
-                <li key={item.title}>
-                  <details className="group rounded-xl bg-card">
-                    <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-3 text-sm font-semibold [&::-webkit-details-marker]:hidden">
-                      <span>{item.title}</span>
-                      <svg
-                        viewBox="0 0 12 12"
-                        aria-hidden="true"
-                        className="size-3 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <path d="m3 4.5 3 3 3-3" />
-                      </svg>
-                    </summary>
-                    <p className="px-4 pb-4 text-sm text-muted-foreground">{item.body}</p>
-                  </details>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
+        <ul className="flex flex-col gap-3">
+          {INTERACTION_AGREEMENTS.map((group) => (
+            <li key={group.category}>
+              <details className="group rounded-xl bg-card">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-3 text-lg font-semibold [&::-webkit-details-marker]:hidden">
+                  <span>{group.category}</span>
+                  <svg
+                    viewBox="0 0 12 12"
+                    aria-hidden="true"
+                    className="size-3 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="m3 4.5 3 3 3-3" />
+                  </svg>
+                </summary>
+                <ul className="flex flex-col gap-2 px-4 pb-4 text-sm">
+                  {group.items.map((item) => (
+                    <li key={item.title}>
+                      <span className="font-semibold">{item.title}.</span>{" "}
+                      <span className="text-muted-foreground">{item.body}</span>
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            </li>
+          ))}
+        </ul>
       </section>
 
       <p className="text-center text-sm text-muted-foreground">

--- a/src/app/welcome/agreements/agreements-content.tsx
+++ b/src/app/welcome/agreements/agreements-content.tsx
@@ -83,12 +83,17 @@ const INTERACTION_AGREEMENTS: { category: string; items: { title: string; body: 
   },
 ];
 
-export function AgreementsContent() {
+export function AgreementsContent({ hasProfile }: { hasProfile: boolean }) {
   return (
     <div className="flex w-full max-w-xl flex-col gap-8">
       <div className="flex flex-col items-center gap-3 text-center">
         <h1 className="text-4xl font-bold">Welcome to the Web</h1>
         <p className="text-base text-muted-foreground">First, what we all share: intentions and agreements</p>
+        {hasProfile && (
+          <p className="text-base text-muted-foreground">
+            (You’ve agreed to these before, so this is just a review for you.)
+          </p>
+        )}
       </div>
 
       <section className="flex flex-col gap-3">

--- a/src/app/welcome/agreements/page.tsx
+++ b/src/app/welcome/agreements/page.tsx
@@ -6,11 +6,16 @@ import { AgreementsContent } from "./agreements-content";
 // Step 1 of the welcome flow: a welcome message and the community
 // agreements. "I agree" stamps lastSignedAgreements and advances.
 export default async function WelcomeAgreementsPage() {
-  await requireUser();
+  const me = await requireUser();
+
+  // A non-empty bio means the member has already set up their profile, so
+  // treat this as a returning member reviewing agreements they've signed
+  // before rather than seeing them for the first time.
+  const hasProfile = Boolean(me.profile?.bio);
 
   return (
     <>
-      <AgreementsContent />
+      <AgreementsContent hasProfile={hasProfile} />
       <WelcomeAdvanceButton step="agreements" label="I agree" />
     </>
   );

--- a/src/app/welcome/programs/page.tsx
+++ b/src/app/welcome/programs/page.tsx
@@ -13,8 +13,8 @@ export default async function WelcomeProgramsPage() {
       <div className="flex flex-col items-center gap-3 text-center">
         <h1 className="text-4xl font-bold">Programs</h1>
         <p className="max-w-md text-base text-muted-foreground">
-          These programs are open to new participants — join any that you’d like to sign up for. (We added one for you,
-          opt out if you like.)
+          These programs are open to new participants — join any that you’d like to sign up for. (Note: Weekly Web
+          Updates defaults to on/joined.)
         </p>
       </div>
       <ProgramsList />

--- a/tests/e2e/invites.spec.ts
+++ b/tests/e2e/invites.spec.ts
@@ -11,8 +11,8 @@ import { completeWelcome, resetSeededUsers, signInAs, TIMEOUT_MS } from "./helpe
 //
 // Serial mode: all the authed tests in this file share the regular
 // user, so parallel runs would race on beforeEach resets / invite
-// creation. Local Playwright defaults to workers > 1; CI runs single-
-// worker regardless.
+// creation. playwright.config.ts pins workers to 1 globally; this
+// serial mode is within-file belt-and-braces on top of that.
 test.describe.configure({ mode: "serial" });
 
 test.describe("invites — authed member flow", () => {


### PR DESCRIPTION
Summary: Welcome-flow polish ahead of a user test — collapse the agreements
by section, add a returning-member review note, and clarify the programs
auto-join copy. Also corrects a stale comment in the invites e2e spec.

Why: Preparing for an upcoming user test. The agreements page scrolled too
much with a per-item expando; returning members were unsure why they were
re-seeing agreements they'd already signed; the programs hint didn't name
the auto-joined program; and an e2e comment wrongly claimed local Playwright
runs multiple workers.

Behavior:
- Agreements: the three sections (Safety, Awareness, Engagement) collapse as
  whole units instead of each agreement having its own expando, and items
  render as compact lines. The first two shared intentions are swapped.
- Agreements: members with a non-empty bio see "(You've agreed to these
  before, so this is just a review for you.)" under the subtitle; fresh
  members are unchanged.
- Programs: the auto-join hint now reads "(Note: Weekly Web Updates defaults
  to on/joined.)".
- Tests: invites.spec comment corrected to match playwright.config.ts
  (workers pinned to 1 globally).

Test Plan:
- ran `npm run lint`, `npm run typecheck`, and the functional suite
  (`vitest run`, 340/340) locally — all green
- ran the full Playwright e2e suite locally — 27/27 passed; the welcome.spec
  flow covers the changed agreements and programs pages
- the e2e comment fix is comment-only and was not retested

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
