### PR TITLE
feat(about): add About page with member-facing changelog

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-05-29 | James | About page + member-facing changelog (#170)
+
+New `/about` page, with a changelog, version (the date of the newest entry), and short team blurb. Entries live in `src/lib/changelog.ts` — plain-language member-facing copy, deliberately separate from this journal; seeded by curating member-visible features out of it.
+
 ## 2026-05-29 | James | Re-timestamp a migration if main gained one after you generated it
 
 Drizzle applies a migration only when its journal `when` is newer than the highest already-applied one, so a migration authored before a later one lands on `main` is silently skipped — no DDL, no error — on any DB already past that point. After rebasing, if `main` has a newer migration than yours, bump your entry's `when` in `drizzle/meta/_journal.json` above it. (Functional test added to catch this.)

--- a/docs/strategy-committing.md
+++ b/docs/strategy-committing.md
@@ -6,6 +6,8 @@ If you touch code, have test coverage for it! Make sure you're keeping the docs 
 
 If you've done work your teammates should know about, add a `docs/devjournal.md` entry (typically at a higher level than all the commit messages on that branch).
 
+If you shipped something members can see or use, add an entry to the top of `src/lib/changelog.ts` — plain-language member-facing copy, distinct from the internal devjournal. It surfaces in the "Changelog" section of the `/about` page, and its date becomes the app version shown there.
+
 Run `npm test` (all suites) and confirm green before committing. Don't push code that you haven't tested locally. If you're changing frontend layout, check both phone and desktop rendering.
 
 **Watch out:** `git stash && <command>; git stash pop` looks like a safe way to test against a clean slate, but it isn't. `git stash` is a no-op when the tree is already clean — it does not push an empty marker — so the trailing `git stash pop` falls through to whatever was already on the stack, potentially applying leftover work from another branch. Instead, use `git stash list` to check the stack first, and only pop if you actually put something there.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from "next";
+
+import { BreadcrumbLink } from "@/components/breadcrumb-link";
+import { requireUser } from "@/lib/api-server";
+import { appVersion, changelog, formatChangelogDate } from "@/lib/changelog";
+
+export const metadata: Metadata = { title: "About" };
+
+export default async function AboutPage() {
+  await requireUser();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-8 p-8">
+      <div className="flex w-full max-w-2xl items-center justify-between">
+        <h1 className="text-2xl font-bold">About</h1>
+        <BreadcrumbLink fallback="/" />
+      </div>
+
+      <p className="flex w-full max-w-2xl items-center gap-2 text-sm text-muted-foreground">
+        <span className="rounded-full border border-border bg-card px-2.5 py-1 font-mono text-xs text-card-foreground">
+          v{appVersion.replaceAll("-", ".")}
+        </span>
+        <span className="font-serif italic">Updated {formatChangelogDate(appVersion)}</span>
+      </p>
+
+      <section className="flex w-full max-w-2xl flex-col gap-4">
+        <h2 className="text-lg font-semibold">Changelog</h2>
+        <ol className="rounded-xl border border-border bg-card">
+          {changelog.map((entry) => (
+            <li key={`${entry.date}-${entry.title}`} className="flex gap-4 border-t border-border p-5 first:border-t-0">
+              <time dateTime={entry.date} className="w-24 shrink-0 pt-0.5 text-xs text-muted-foreground sm:w-28">
+                {formatChangelogDate(entry.date)}
+              </time>
+              <div className="flex flex-col gap-1">
+                <h3 className="text-base font-semibold text-card-foreground">{entry.title}</h3>
+                <p className="text-sm text-muted-foreground">{entry.description}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section className="w-full max-w-2xl">
+        <h2 className="text-lg font-semibold">The team</h2>
+        <p className="mt-2 text-base text-muted-foreground">
+          This app is built by the IS Dev Team: James, Benji, Ola, Alexis, and Blake. The code is open — read it at{" "}
+          <a
+            href="https://github.com/Intentional-Society/is-app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline text-muted-foreground hover:text-foreground"
+          >
+            github.com/Intentional-Society/is-app
+          </a>
+          . Want to help build it? Email{" "}
+          <a
+            href="mailto:devteam@mail.intentionalsociety.org"
+            className="underline text-muted-foreground hover:text-foreground"
+          >
+            devteam@mail.intentionalsociety.org
+          </a>
+          .
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -7,6 +7,31 @@ import { useAuth } from "@/components/auth-provider";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { clearNavHistory } from "@/lib/route-labels";
+import { cn } from "@/lib/utils";
+
+// Internal nav links share one shape: a SheetClose (so the menu closes
+// on tap) wrapping a Link that clears the breadcrumb history. The
+// optional className layers extra styling on top of the shared base.
+function MenuLink({
+  href,
+  className,
+  children,
+}: {
+  href: React.ComponentProps<typeof Link>["href"];
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <SheetClose
+      nativeButton={false}
+      render={
+        <Link href={href} onClick={clearNavHistory} className={cn("rounded px-2 py-2 hover:bg-muted", className)}>
+          {children}
+        </Link>
+      }
+    />
+  );
+}
 
 export function SiteHeader({ displayName, isAdmin }: { displayName: string | null; isAdmin: boolean }) {
   const { user } = useAuth();
@@ -25,54 +50,13 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
             {displayName ? <p className="font-serif italic text-sm text-muted-foreground">{displayName}</p> : null}
           </SheetHeader>
           <nav className="flex flex-col gap-1 px-4 pb-4">
-            <SheetClose
-              nativeButton={false}
-              render={
-                <Link href="/" onClick={clearNavHistory} className="rounded px-2 py-2 hover:bg-muted">
-                  Home
-                </Link>
-              }
-            />
-            <SheetClose
-              nativeButton={false}
-              render={
-                <Link href="/programs" onClick={clearNavHistory} className="rounded px-2 py-2 hover:bg-muted">
-                  Programs
-                </Link>
-              }
-            />
-            <SheetClose
-              nativeButton={false}
-              render={
-                <Link href="/members" onClick={clearNavHistory} className="rounded px-2 py-2 hover:bg-muted">
-                  Member directory
-                </Link>
-              }
-            />
-            <SheetClose
-              nativeButton={false}
-              render={
-                <Link href="/myweb" onClick={clearNavHistory} className="rounded px-2 py-2 hover:bg-muted">
-                  My web
-                </Link>
-              }
-            />
-            <SheetClose
-              nativeButton={false}
-              render={
-                <Link href="/profile" onClick={clearNavHistory} className="rounded px-2 py-2 hover:bg-muted">
-                  My profile
-                </Link>
-              }
-            />
-            <SheetClose
-              nativeButton={false}
-              render={
-                <Link href="/invites" onClick={clearNavHistory} className="rounded px-2 py-2 hover:bg-muted">
-                  Invite a friend
-                </Link>
-              }
-            />
+            <MenuLink href="/">Home</MenuLink>
+            <MenuLink href="/programs">Programs</MenuLink>
+            <MenuLink href="/members">Member directory</MenuLink>
+            <MenuLink href="/myweb">My web</MenuLink>
+            <MenuLink href="/profile">My profile</MenuLink>
+            <MenuLink href="/invites">Invite a friend</MenuLink>
+            <MenuLink href="/about">About</MenuLink>
             <a
               href="https://docs.google.com/forms/d/e/1FAIpQLScXhdSxbQ3LxjiYhqN2fmuyy66SK292rTYEZV3QaHgzn1eVjA/viewform?usp=dialog"
               target="_blank"
@@ -82,19 +66,10 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
               Give Feedback
             </a>
             {isAdmin ? (
-              <SheetClose
-                nativeButton={false}
-                render={
-                  <Link
-                    href="/admin"
-                    onClick={clearNavHistory}
-                    className="flex items-center gap-2 rounded px-2 py-2 text-green-700 hover:bg-muted"
-                  >
-                    <ShieldCheck className="h-4 w-4 shrink-0" />
-                    Admin dashboard
-                  </Link>
-                }
-              />
+              <MenuLink href="/admin" className="flex items-center gap-2 text-green-700">
+                <ShieldCheck className="h-4 w-4 shrink-0" />
+                Admin dashboard
+              </MenuLink>
             ) : null}
             <form action="/signout" method="post">
               <SheetClose

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,0 +1,136 @@
+// Member-facing changelog: the "Changelog" section of the /about page.
+//
+// This is NOT docs/devjournal.md. The dev journal is an internal,
+// technical log for teammates; these entries are plain-language notes
+// for members about changes they can see and use. When you ship a
+// member-visible feature, add an entry at the TOP (newest first) and
+// translate it into a sentence a member would care about — skip the
+// infra/CI/migration work that has no member-visible surface.
+//
+// Voice: write in the present tense and describe what is now true, not
+// the work that was done. "We"/"us"/"our" must not mean the dev team —
+// name it ("the dev team"); those words are fine only for the whole
+// network, which includes the reader. "You" for the reader is fine.
+//
+// The app "version" shown on /about is just the date of the newest
+// entry below (see `appVersion`).
+
+// Loose shape check on the date literals; the test owns calendar validity.
+type ISODate = `${number}-${number}-${number}`;
+
+export type ChangelogEntry = {
+  /** ISO date, "YYYY-MM-DD". */
+  date: ISODate;
+  /** Short, member-facing headline. */
+  title: string;
+  /** One or two plain-language sentences. */
+  description: string;
+};
+
+// Newest first. The /about page and `appVersion` both rely on this
+// ordering; a functional test asserts it stays sorted.
+export const changelog: ChangelogEntry[] = [
+  {
+    date: "2026-05-29",
+    title: "Share your current intention",
+    description:
+      'The "Live Desire" field is now "Current Intention", and is change-dated for freshness in future visualization.',
+  },
+  {
+    date: "2026-05-28",
+    title: "Give feedback anytime",
+    description:
+      "There's a Give Feedback link in the menu and on the home page now. If something's off or you've got an idea, say so.",
+  },
+  {
+    date: "2026-05-21",
+    title: "Every program has its own page",
+    description: "Each program has its own details page (with URL) now, for more info and the list of participants.",
+  },
+  {
+    date: "2026-05-20",
+    title: "Emails that show up",
+    description:
+      "Signing in, signing up, and password resets now have production-ready styled emails that land reliably.",
+  },
+  {
+    date: "2026-05-19",
+    title: "A guided welcome",
+    description:
+      "Joining walks you through a few steps — our shared agreements, your profile, programs, then your Web (which itself has a tour).",
+  },
+  {
+    date: "2026-05-18",
+    title: "Pre-filled profiles from earlier sign-ups",
+    description: "If you signed up using the Google Form earlier, your profile is now filled in before you arrive.",
+  },
+  {
+    date: "2026-05-16",
+    title: "Profile pictures",
+    description: "Add a photo to your profile and crop it to a circle, right in the app.",
+  },
+  {
+    date: "2026-05-13",
+    title: "A basic home page",
+    description: "The home page is a grid of cards listing the things you can do, and it greets you by name.",
+  },
+  {
+    date: "2026-05-09",
+    title: "Your personal Web",
+    description: "My Web is where you map the people you know and how you're connected to each of them.",
+  },
+  {
+    date: "2026-05-07",
+    title: "Meet the members",
+    description:
+      "There's a directory of everyone in the network now, each with a profile page so you can get to know people.",
+  },
+  {
+    date: "2026-05-01",
+    title: "A new look",
+    description: "The app now has its first styling — colors, typography, better buttons.",
+  },
+  {
+    date: "2026-05-01",
+    title: "Browse and join programs",
+    description:
+      "The Programs page shows what's running, with a short description and how many people are in. Join or leave whenever you like.",
+  },
+  {
+    date: "2026-04-30",
+    title: "More to your profile",
+    description:
+      "Profiles hold a lot more now — a bio, keywords, location, and so on. There's a read-only view, plus an Edit mode.",
+  },
+  {
+    date: "2026-04-20",
+    title: "Invite a friend with a code",
+    description: "Know someone who belongs here? Make an invite code, and they can sign up with it.",
+  },
+  {
+    date: "2026-04-18",
+    title: "The app is minimally alive",
+    description:
+      "Authentication is now the first functional feature. Sign in with a magic link — no password to remember.",
+  },
+  {
+    date: "2026-04-04",
+    title: "Day one",
+    description: "The very first commit — some architectural design notes.",
+  },
+];
+
+// The "version" shown on /about: the date of the most recent change.
+export const appVersion = changelog[0]?.date ?? "";
+
+// Format an entry's "YYYY-MM-DD" date as e.g. "May 29, 2026". Pinned to
+// UTC so the rendered date matches the string regardless of the
+// server's timezone.
+export function formatChangelogDate(isoDate: string): string {
+  return new Date(`${isoDate}T00:00:00Z`).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/src/lib/route-labels.ts
+++ b/src/lib/route-labels.ts
@@ -32,6 +32,7 @@ const EXACT_LABELS: Record<string, string> = {
   "/profile": "Profile",
   "/profile/edit": "Edit profile",
   "/invites": "Invites",
+  "/about": "About",
   "/admin": "Admin",
   "/admin/programs": "Admin programs",
 };

--- a/tests/e2e/about.spec.ts
+++ b/tests/e2e/about.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+import { completeWelcome, resetSeededUsers, signInAs, TIMEOUT_MS } from "./helpers/session";
+
+// Smoke coverage of the /about page: the sidebar link reaches it, and
+// the version line, changelog, and team blurb render.
+test.describe.configure({ mode: "serial" });
+
+test.describe("/about page", () => {
+  test.beforeEach(async ({ baseURL }) => {
+    if (!baseURL) throw new Error("about.spec.ts: baseURL is not configured");
+    await resetSeededUsers(baseURL);
+  });
+
+  test("the menu link opens /about and the changelog renders", async ({ page }) => {
+    await signInAs(page, "regular");
+    // Distinct bio per completeWelcome caller — see the #149 probe.
+    await completeWelcome(page, { bio: "e2e bio · about.spec · changelog" });
+
+    // The link lives only in the hamburger menu (no home-page card).
+    // Menu items render via SheetClose, which exposes them with
+    // role="button" (not link), the same as every other menu entry.
+    await page.getByRole("button", { name: "Open menu" }).click();
+    await page.getByRole("button", { name: "About", exact: true }).click();
+    await page.waitForURL((u) => u.pathname === "/about", { timeout: TIMEOUT_MS });
+
+    await expect(page.getByRole("heading", { name: "About", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Changelog", exact: true })).toBeVisible();
+    // Version line: the date of the newest entry, e.g. "v2026.05.29".
+    await expect(page.getByText(/^v\d{4}\.\d{2}\.\d{2}$/)).toBeVisible();
+    // A stable seed entry.
+    await expect(page.getByRole("heading", { name: "Profile pictures", exact: true })).toBeVisible();
+  });
+});

--- a/tests/functional/client/site-header.test.tsx
+++ b/tests/functional/client/site-header.test.tsx
@@ -70,6 +70,19 @@ describe("SiteHeader", () => {
     expect(await screen.findByText("Admin dashboard")).toBeVisible();
   });
 
+  it("shows an About link to /about", async () => {
+    render(
+      <AuthProvider initialUser={user}>
+        <SiteHeader displayName={null} isAdmin={false} />
+      </AuthProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
+    const link = await screen.findByText("About");
+    expect(link).toBeVisible();
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("href", "/about");
+  });
+
   it("shows Give Feedback link that opens in a new tab", async () => {
     render(
       <AuthProvider initialUser={user}>

--- a/tests/functional/server/changelog.test.ts
+++ b/tests/functional/server/changelog.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { appVersion, changelog, formatChangelogDate } from "@/lib/changelog";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+describe("changelog data", () => {
+  it("has at least one entry", () => {
+    expect(changelog.length).toBeGreaterThan(0);
+  });
+
+  it("stays sorted newest-first", () => {
+    // The /about page renders entries top-down and `appVersion` reads
+    // changelog[0]; a misplaced entry must fail here, not in production.
+    for (let i = 1; i < changelog.length; i++) {
+      expect(changelog[i - 1].date >= changelog[i].date).toBe(true);
+    }
+  });
+
+  it("uses valid ISO dates and non-empty copy", () => {
+    for (const entry of changelog) {
+      expect(entry.date).toMatch(ISO_DATE);
+      expect(Number.isNaN(Date.parse(entry.date))).toBe(false);
+      expect(entry.title.trim().length).toBeGreaterThan(0);
+      expect(entry.description.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("appVersion", () => {
+  it("is the date of the newest entry", () => {
+    expect(appVersion).toBe(changelog[0].date);
+  });
+});
+
+describe("formatChangelogDate", () => {
+  it("formats an ISO date as a long en-US date, pinned to UTC", () => {
+    expect(formatChangelogDate("2026-05-29")).toBe("May 29, 2026");
+    // A date that would roll back a day in negative-offset timezones if
+    // not pinned to UTC.
+    expect(formatChangelogDate("2026-01-01")).toBe("January 1, 2026");
+  });
+});


### PR DESCRIPTION
Summary: Add an auth-gated /about page that leads with a member-facing
changelog, plus a version line and a short dev-team blurb, reachable from
an "About" link in the menu.

Why: Issue #170 asked for an in-app "what's new" link. Members had no place
to see what's changed, and the dev journal is internal and too technical to
show them. This gives a curated, plain-language history.

Behavior:
- New /about route (members-only, noindex): a Changelog section (date on the
  left of each entry, all in one card), a version chip derived from the newest
  entry's date, and a "The team" blurb linking the public repo.
- "About" link added to the hamburger menu; "/about" breadcrumb label added.
- Changelog content lives in src/lib/changelog.ts (typed, newest-first, with an
  ISODate shape-check and an authoring-voice comment); strategy-committing.md
  documents when to add entries.
- Menu links refactored through a shared MenuLink helper.

Test Plan:
- ran `npm test` locally — 346 functional + 28 e2e, all green
- about.spec.ts drives menu -> /about and asserts the version, Changelog
  heading, and a seed entry render signed-in

Closes #170

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
