### PR TITLE
fix(auth): verify magic links on POST, not GET (link-scanner safe)

### DIFF
--- a/docs/doc-supabase.md
+++ b/docs/doc-supabase.md
@@ -6,9 +6,11 @@ Covers both the hosted production project (configured via the Supabase dashboard
 
 ## Magic-link flow (token-hash + verifyOtp)
 
-The magic-link and password-reset emails embed `{{ .TokenHash }}` directly in a URL pointing at `/auth/callback?type=…&token_hash=…`. The route calls `supabase.auth.verifyOtp({ token_hash, type })` server-side, so the link works regardless of which browser opens it.
+The magic-link and password-reset emails embed `{{ .TokenHash }}` directly in a URL pointing at `/auth/callback?type=…&token_hash=…`. The route verifies the token via `supabase.auth.verifyOtp({ token_hash, type })` server-side, so the link works regardless of which browser opens it.
 
-The forms pass the full callback URL as `emailRedirectTo`, and templates use `{{ .RedirectTo }}` as the action URL host. That keeps the link env-aware — preview-deploy emails point at the preview origin, not at `.SiteURL` (which is hardcoded to prod). Signup adds `&invite=${code}` to the callback URL; the route reads it directly from its query params.
+**Two-step GET → POST (anti-prefetch).** The clicked link is a `GET`, but verification runs on a `POST`. The `GET` only renders a tiny "Signing you in…" page whose form auto-submits (inline script; `<noscript>` degrades to a Continue button) back to `/auth/callback` as a `POST`, and only that `POST` calls `verifyOtp`. This exists because email link scanners — Microsoft Defender Safe Links most notably — prefetch the link with a bare `GET` to vet it, which would otherwise consume the single-use token before the member's real click ever lands (surfacing as `otp_expired`; see issue #325). Scanners don't execute scripts or submit forms, so the token survives the prefetch. The `POST` redirects with 303 so the browser follows it with a `GET`.
+
+The forms pass the full callback URL as `emailRedirectTo`, and templates use `{{ .RedirectTo }}` as the action URL host. That keeps the link env-aware — preview-deploy emails point at the preview origin, not at `.SiteURL` (which is hardcoded to prod). Signup adds `&invite=${code}` to the callback URL; the `GET` reads it from the query string and carries it through the transit form into the `POST`.
 
 PKCE is still the configured client `flowType` and still governs session cookies / refresh-token rotation. Only the email-verification step is bypassed by the token-hash flow. See `docs/old-archive/plan-cross-browser-magic-link.md` for the migration rationale.
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -30,7 +30,64 @@ type AllowedType = (typeof ALLOWED_TYPES)[number];
 const isAllowedType = (v: string | null): v is AllowedType =>
   v !== null && (ALLOWED_TYPES as readonly string[]).includes(v);
 
-export async function GET(request: NextRequest) {
+// `token_hash` and `invite` arrive verbatim from the query string and
+// get reflected into the auto-submit form, so they must be neutralized
+// to keep this page free of reflected HTML/script injection.
+const escapeHtml = (s: string): string =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+
+// Interstitial that immediately POSTs back to this route to run the
+// actual verification. Email link scanners (Microsoft Safe Links and
+// friends) prefetch the link with a bare GET; verifying on GET would let
+// that scan consume the single-use token before the member's real click
+// lands, surfacing as `otp_expired` (issue #325). Scanners don't execute
+// scripts or submit forms, so rendering this on GET and verifying only on
+// POST keeps the token intact for the navigation that matters. <noscript>
+// degrades to a manual Continue button for the rare JS-off client.
+const transitPage = (params: { tokenHash: string; type: AllowedType; invite: string | null }): NextResponse => {
+  const fields = [
+    `<input type="hidden" name="token_hash" value="${escapeHtml(params.tokenHash)}">`,
+    `<input type="hidden" name="type" value="${params.type}">`,
+    params.invite ? `<input type="hidden" name="invite" value="${escapeHtml(params.invite)}">` : "",
+  ].join("");
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Signing you in…</title>
+</head>
+<body style="margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background:Canvas;color:CanvasText;">
+  <main style="min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;padding:24px;text-align:center;">
+    <p style="font-size:18px;margin:0;">Signing you in…</p>
+    <form id="verify" method="POST" action="/auth/callback">
+      ${fields}
+      <noscript>
+        <p style="font-size:14px;color:GrayText;margin:0 0 12px;">JavaScript is off — tap to continue.</p>
+        <button type="submit" style="padding:12px 24px;font-size:16px;font-weight:bold;color:ButtonText;background:ButtonFace;border:1px solid ButtonBorder;border-radius:6px;cursor:pointer;">Continue</button>
+      </noscript>
+    </form>
+    <script>document.getElementById("verify").submit();</script>
+  </main>
+</body>
+</html>`;
+
+  return new NextResponse(html, {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      // Holds the one-time token — never let an intermediary cache it.
+      "cache-control": "no-store",
+    },
+  });
+};
+
+// GET is the link target. It only renders the transit page; the token is
+// never spent here (see transitPage). Missing/invalid params still bounce
+// to /signin so a stray prefetch of a malformed link is harmless.
+export function GET(request: NextRequest): NextResponse {
   const tokenHash = request.nextUrl.searchParams.get("token_hash");
   const type = request.nextUrl.searchParams.get("type");
   const invite = request.nextUrl.searchParams.get("invite");
@@ -39,15 +96,35 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL("/signin?error=missing_token", request.url));
   }
 
+  return transitPage({ tokenHash, type, invite });
+}
+
+// POST carries the verification. It runs only from the transit form's
+// auto-submit (or the <noscript> button) — a real navigation, not a
+// scanner's prefetch. Redirects use 303 so the browser follows them with
+// a GET rather than re-POSTing to the destination.
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const form = await request.formData();
+  const tokenHashRaw = form.get("token_hash");
+  const typeRaw = form.get("type");
+  const inviteRaw = form.get("invite");
+
+  const tokenHash = typeof tokenHashRaw === "string" ? tokenHashRaw : null;
+  const type = typeof typeRaw === "string" ? typeRaw : null;
+  if (!tokenHash || !isAllowedType(type)) {
+    return NextResponse.redirect(new URL("/signin?error=missing_token", request.url), 303);
+  }
+  const invite = typeof inviteRaw === "string" && inviteRaw.length > 0 ? inviteRaw : null;
+
   const supabase = await createClient();
   const { data, error } = await supabase.auth.verifyOtp({ token_hash: tokenHash, type });
   if (error || !data.user) {
-    return NextResponse.redirect(new URL("/signin?error=verify_failed", request.url));
+    return NextResponse.redirect(new URL("/signin?error=verify_failed", request.url), 303);
   }
 
   // Password reset — skip profile upsert, redirect to set-password page.
   if (type === "recovery") {
-    return NextResponse.redirect(new URL("/auth/reset-password", request.url));
+    return NextResponse.redirect(new URL("/auth/reset-password", request.url), 303);
   }
 
   // Ordinary sign-in — Phase 1 upsert, referredBy stays null.
@@ -56,12 +133,12 @@ export async function GET(request: NextRequest) {
     try {
       result = await upsertProfile(data.user);
     } catch {
-      return NextResponse.redirect(new URL("/signin?error=profile_error", request.url));
+      return NextResponse.redirect(new URL("/signin?error=profile_error", request.url), 303);
     }
     if (result.created) {
       await tryAutoSubscribe(data.user.id);
     }
-    return NextResponse.redirect(new URL("/", request.url));
+    return NextResponse.redirect(new URL("/", request.url), 303);
   }
 
   // Invited sign-in. Profile insert + invite redemption must land
@@ -137,13 +214,13 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     if (err instanceof InviteInvalid) {
       await supabase.auth.signOut();
-      return NextResponse.redirect(new URL("/signin?error=invite_invalid", request.url));
+      return NextResponse.redirect(new URL("/signin?error=invite_invalid", request.url), 303);
     }
-    return NextResponse.redirect(new URL("/signin?error=profile_error", request.url));
+    return NextResponse.redirect(new URL("/signin?error=profile_error", request.url), 303);
   }
 
   if (!result) {
-    return NextResponse.redirect(new URL("/signin?error=profile_error", request.url));
+    return NextResponse.redirect(new URL("/signin?error=profile_error", request.url), 303);
   }
 
   // Auto-subscribe runs outside the redemption transaction: it is
@@ -153,7 +230,7 @@ export async function GET(request: NextRequest) {
     await tryAutoSubscribe(userId);
   }
 
-  return NextResponse.redirect(new URL("/", request.url));
+  return NextResponse.redirect(new URL("/", request.url), 303);
 }
 
 class InviteInvalid extends Error {}

--- a/tests/functional/server/auth-callback.test.ts
+++ b/tests/functional/server/auth-callback.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(),
 }));
 
-import { GET } from "@/app/auth/callback/route";
+import { GET, POST } from "@/app/auth/callback/route";
 import { createClient } from "@/lib/supabase/server";
 import { db } from "@/server/db";
 import { createInvite } from "@/server/invites";
@@ -15,7 +15,16 @@ import { invites, profilePrograms, profiles, programs } from "@/server/schema";
 
 const mockCreateClient = vi.mocked(createClient);
 
-const makeRequest = (path: string) => new NextRequest(new URL(path, "http://testfake.local"));
+const makeGet = (path: string) => new NextRequest(new URL(path, "http://testfake.local"));
+
+// The transit form auto-submits a urlencoded POST back to the route;
+// these requests stand in for that submission.
+const makePost = (fields: Record<string, string>) =>
+  new NextRequest(new URL("/auth/callback", "http://testfake.local"), {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(fields).toString(),
+  });
 
 const mockSupabase = (user: { id: string; email: string } | null) => {
   const signOut = vi.fn().mockResolvedValue({ error: null });
@@ -73,34 +82,84 @@ const ensureWeeklyProgram = async (): Promise<string> => {
   return row.id;
 };
 
-describe("GET /auth/callback", () => {
+describe("GET /auth/callback (renders the transit page, never verifies)", () => {
   beforeEach(() => {
     mockCreateClient.mockReset();
   });
 
-  it("redirects to /signin?error=missing_token when the token_hash query param is absent", async () => {
-    const res = await GET(makeRequest("/auth/callback?type=email"));
+  it("redirects to /signin?error=missing_token when the token_hash query param is absent", () => {
+    const res = GET(makeGet("/auth/callback?type=email"));
 
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toBe("http://testfake.local/signin?error=missing_token");
     expect(mockCreateClient).not.toHaveBeenCalled();
   });
 
-  it("redirects to /signin?error=missing_token when the type query param is absent", async () => {
-    const res = await GET(makeRequest("/auth/callback?token_hash=abc"));
+  it("redirects to /signin?error=missing_token when the type query param is absent", () => {
+    const res = GET(makeGet("/auth/callback?token_hash=abc"));
 
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toBe("http://testfake.local/signin?error=missing_token");
     expect(mockCreateClient).not.toHaveBeenCalled();
   });
 
-  it("redirects to /signin?error=missing_token when type is not one we handle", async () => {
+  it("redirects to /signin?error=missing_token when type is not one we handle", () => {
     // `signup` is a valid EmailOtpType in the Supabase SDK but our
     // templates never emit it — the runtime guard rejects it before we
-    // ever call verifyOtp.
-    const res = await GET(makeRequest("/auth/callback?token_hash=abc&type=signup"));
+    // ever render a verifiable form.
+    const res = GET(makeGet("/auth/callback?token_hash=abc&type=signup"));
 
     expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("http://testfake.local/signin?error=missing_token");
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("renders an auto-submit form on a valid GET without consuming the token", async () => {
+    // The defining property of the fix (issue #325): a bare GET — which
+    // is all an email link scanner does — must NOT call verifyOtp, so the
+    // single-use token survives for the member's real click.
+    const res = GET(makeGet("/auth/callback?token_hash=tok123&type=email"));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(res.headers.get("cache-control")).toBe("no-store");
+
+    const html = await res.text();
+    expect(html).toContain('method="POST"');
+    expect(html).toContain('action="/auth/callback"');
+    expect(html).toContain('name="token_hash"');
+    expect(html).toContain('value="tok123"');
+    expect(html).toContain('name="type"');
+
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("carries the invite code into the transit form", async () => {
+    const res = GET(makeGet("/auth/callback?token_hash=tok123&type=email&invite=ABCDEFGHIJ"));
+    const html = await res.text();
+
+    expect(html).toContain('name="invite"');
+    expect(html).toContain('value="ABCDEFGHIJ"');
+  });
+
+  it("escapes untrusted query values reflected into the form", async () => {
+    const res = GET(makeGet(`/auth/callback?token_hash=${encodeURIComponent('"><script>x()</script>')}&type=email`));
+    const html = await res.text();
+
+    expect(html).not.toContain("<script>x()</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("POST /auth/callback (verifies the token)", () => {
+  beforeEach(() => {
+    mockCreateClient.mockReset();
+  });
+
+  it("redirects to /signin?error=missing_token when params are absent", async () => {
+    const res = await POST(makePost({ type: "email" }));
+
+    expect(res.status).toBe(303);
     expect(res.headers.get("location")).toBe("http://testfake.local/signin?error=missing_token");
     expect(mockCreateClient).not.toHaveBeenCalled();
   });
@@ -108,9 +167,9 @@ describe("GET /auth/callback", () => {
   it("redirects to /signin?error=verify_failed when verifyOtp errors", async () => {
     mockSupabase(null);
 
-    const res = await GET(makeRequest("/auth/callback?token_hash=bad&type=email"));
+    const res = await POST(makePost({ token_hash: "bad", type: "email" }));
 
-    expect(res.status).toBe(307);
+    expect(res.status).toBe(303);
     expect(res.headers.get("location")).toBe("http://testfake.local/signin?error=verify_failed");
   });
 
@@ -120,9 +179,9 @@ describe("GET /auth/callback", () => {
     mockSupabase({ id: userId, email: `${userId}@testfake.local` });
 
     try {
-      const res = await GET(makeRequest("/auth/callback?token_hash=hash&type=recovery"));
+      const res = await POST(makePost({ token_hash: "hash", type: "recovery" }));
 
-      expect(res.status).toBe(307);
+      expect(res.status).toBe(303);
       expect(res.headers.get("location")).toBe("http://testfake.local/auth/reset-password");
 
       // No profile row created — recovery branch skips that step.
@@ -134,7 +193,7 @@ describe("GET /auth/callback", () => {
   });
 });
 
-describe("GET /auth/callback (ordinary sign-in, auto-subscribe to weekly-web-updates)", () => {
+describe("POST /auth/callback (ordinary sign-in, auto-subscribe to weekly-web-updates)", () => {
   let userId: string;
   let weeklyProgramId: string;
 
@@ -153,9 +212,9 @@ describe("GET /auth/callback (ordinary sign-in, auto-subscribe to weekly-web-upd
   it("auto-subscribes the new member to weekly-web-updates", async () => {
     mockSupabase({ id: userId, email: "newbie@testfake.local" });
 
-    const res = await GET(makeRequest("/auth/callback?token_hash=hash&type=email"));
+    const res = await POST(makePost({ token_hash: "hash", type: "email" }));
 
-    expect(res.status).toBe(307);
+    expect(res.status).toBe(303);
     expect(res.headers.get("location")).toBe("http://testfake.local/");
 
     const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, userId));
@@ -170,9 +229,9 @@ describe("GET /auth/callback (ordinary sign-in, auto-subscribe to weekly-web-upd
 
     mockSupabase({ id: userId, email: "returning@testfake.local" });
 
-    const res = await GET(makeRequest("/auth/callback?token_hash=hash&type=email"));
+    const res = await POST(makePost({ token_hash: "hash", type: "email" }));
 
-    expect(res.status).toBe(307);
+    expect(res.status).toBe(303);
     expect(res.headers.get("location")).toBe("http://testfake.local/");
 
     const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, userId));
@@ -180,7 +239,7 @@ describe("GET /auth/callback (ordinary sign-in, auto-subscribe to weekly-web-upd
   });
 });
 
-describe("GET /auth/callback (invited sign-in, invite query param)", () => {
+describe("POST /auth/callback (invited sign-in, invite field)", () => {
   let inviterId: string;
   let newUserId: string;
   let weeklyProgramId: string;
@@ -202,7 +261,7 @@ describe("GET /auth/callback (invited sign-in, invite query param)", () => {
     await deleteAuthUser(inviterId);
   });
 
-  const callbackUrl = (inviteCode: string) => `/auth/callback?token_hash=hash&type=email&invite=${inviteCode}`;
+  const invitePost = (inviteCode: string) => makePost({ token_hash: "hash", type: "email", invite: inviteCode });
 
   it("redeems a valid invite and stamps referredBy + displayName", async () => {
     const r = await createInvite({
@@ -212,9 +271,9 @@ describe("GET /auth/callback (invited sign-in, invite query param)", () => {
     if ("error" in r) throw new Error("seed failed");
     mockSupabase({ id: newUserId, email: "newbie@testfake.local" });
 
-    const res = await GET(makeRequest(callbackUrl(r.code)));
+    const res = await POST(invitePost(r.code));
 
-    expect(res.status).toBe(307);
+    expect(res.status).toBe(303);
     expect(res.headers.get("location")).toBe("http://testfake.local/");
 
     const [profile] = await db.select().from(profiles).where(eq(profiles.id, newUserId));
@@ -240,9 +299,9 @@ describe("GET /auth/callback (invited sign-in, invite query param)", () => {
       email: "newbie@testfake.local",
     });
 
-    const res = await GET(makeRequest(callbackUrl(r.code)));
+    const res = await POST(invitePost(r.code));
 
-    expect(res.status).toBe(307);
+    expect(res.status).toBe(303);
     expect(res.headers.get("location")).toBe("http://testfake.local/signin?error=invite_invalid");
     expect(signOut).toHaveBeenCalledOnce();
 
@@ -257,9 +316,9 @@ describe("GET /auth/callback (invited sign-in, invite query param)", () => {
       email: "newbie@testfake.local",
     });
 
-    const res = await GET(makeRequest(callbackUrl("ZZZZZZZZZZ")));
+    const res = await POST(invitePost("ZZZZZZZZZZ"));
 
-    expect(res.status).toBe(307);
+    expect(res.status).toBe(303);
     expect(res.headers.get("location")).toBe("http://testfake.local/signin?error=invite_invalid");
     expect(signOut).toHaveBeenCalledOnce();
   });
@@ -272,9 +331,9 @@ describe("GET /auth/callback (invited sign-in, invite query param)", () => {
     if ("error" in r) throw new Error("seed failed");
     mockSupabase({ id: newUserId, email: "newbie@testfake.local" });
 
-    const res = await GET(makeRequest(callbackUrl(r.code)));
+    const res = await POST(invitePost(r.code));
 
-    expect(res.status).toBe(307);
+    expect(res.status).toBe(303);
     expect(res.headers.get("location")).toBe("http://testfake.local/");
 
     const rows = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, newUserId));


### PR DESCRIPTION
Summary: /auth/callback now renders an auto-submitting "Signing you in…"
page on GET and only verifies the OTP on the POST it submits.

Why: Email link scanners (Microsoft Defender Safe Links) prefetch the
magic link with a bare GET to vet it, consuming the single-use token
before the member's click lands — surfacing as otp_expired (#325).
Scanners don't run scripts or submit forms, so deferring verifyOtp to a
POST keeps the token intact for the real navigation.

Behavior: members see a brief "Signing you in…" transit screen, then land
signed in as before. POST redirects use 303 (PRG). The page uses the
Canvas/CanvasText system colors, so it tracks light/dark and never drifts
from the theme. Email templates and the /auth/callback link target are
unchanged.

Test Plan:
- ran `npm test` locally — lint, typecheck, functional 350/350, e2e 28/28
- functional tests assert GET renders the form without calling verifyOtp
  (the anti-prefetch property), and that POST performs verification

Closes #325

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
