### PR TITLE
fix: reword latest changelog entry, add intro line

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -24,7 +24,12 @@ export default async function AboutPage() {
       </p>
 
       <section className="flex w-full max-w-2xl flex-col gap-4">
-        <h2 className="text-lg font-semibold">Changelog</h2>
+        <div className="flex flex-col gap-1">
+          <h2 className="text-lg font-semibold">Changelog</h2>
+          <p className="text-sm text-muted-foreground">
+            This is a running list, newest first, of significant updates made to this app.
+          </p>
+        </div>
         <ol className="rounded-xl border border-border bg-card">
           {changelog.map((entry) => (
             <li key={`${entry.date}-${entry.title}`} className="flex gap-4 border-t border-border p-5 first:border-t-0">

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -34,7 +34,7 @@ export const changelog: ChangelogEntry[] = [
     date: "2026-05-29",
     title: "Share your current intention",
     description:
-      'The "Live Desire" field is now "Current Intention", and is change-dated for freshness in future visualization.',
+      'The "Live Desire" field is now "Current Intention", and there\'s now a basic visualization/browsing feature.',
   },
   {
     date: "2026-05-28",


### PR DESCRIPTION
Summary: Reword the newest changelog entry's second clause and add a one-line description of the changelog under its heading on /about.

Why: The May 29 entry teased "freshness in future visualization"; that visualization/browsing now exists, so the copy should describe what's live rather than what's coming. The new intro line tells members what the changelog is.

Behavior: On /about, the latest entry (May 29, 2026) now ends "...and there's now a basic visualization/browsing feature." A new muted line under the "Changelog" heading reads "This is a running list, newest first, of significant updates made to this app."

Test Plan:
- Lint + typecheck + Vitest: green (359/359 functional).
- Playwright: 27/28 first run; the lone failure (welcome.spec.ts end-to-end, a 30s timeout unrelated to this change) passed on isolated re-run. about.spec.ts, which renders this page, passed both times.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>