### PR TITLE
fix(drizzle): keep generate clean of stray auth-schema DDL

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-03 | James | Guard drizzle generate against stray auth-schema DDL
+
+An attempt to stop `drizzle-kit generate` re-emitting `CREATE/ALTER/DROP TABLE "auth"` for the `pgSchema("auth")` reference (`schemaFilter`/`tablesFilter` gate only `pull`; tables have no `.existing()` yet — drizzle-orm #1305): `auth.users` is now tracked in the `0013` snapshot baseline, with a functional guard rejecting auth-schema DDL as the backstop.
+
 ## 2026-05-30 | Ola | Deactivate account (member self-serve, #185)
 
 Members can deactivate their own account from the edit-profile page (`POST /me/deactivate`). Deactivated profiles are filtered from the directory, member lookups, relation suggestions, and the web graph — same `IS NULL` guard pattern as `profiles.hidden`. Members can reactivate themselves at any time via the same page (`POST /me/reactivate`); no admin action needed. `deactivated_at` is exposed in `GET /me` so the UI can show state. Functional tests cover deactivate, reactivate, and the self-shape assertion. (#301)

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -680,6 +680,31 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": true
+    },
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     }
   },
   "enums": {},

--- a/tests/functional/server/migration-journal.test.ts
+++ b/tests/functional/server/migration-journal.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 // Drizzle applies a migration only when its journal `when` exceeds the highest
@@ -29,5 +29,31 @@ describe("migration journal (drizzle/meta/_journal.json)", () => {
     }
 
     expect(violations).toEqual([]);
+  });
+});
+
+// `drizzle-kit generate` emits DDL for the pgSchema("auth") reference in
+// schema.ts: `schemaFilter`/`tablesFilter` only gate `pull` introspection, not
+// `generate`, and there is no table-level `.existing()` marker yet (drizzle-orm
+// #1305). auth.users is Supabase-managed, so any CREATE/ALTER/DROP against the
+// auth schema would break or corrupt prod. The snapshot baseline tracks
+// auth.users to keep `generate` clean; this guards a regenerate from
+// re-introducing auth-schema DDL. See devjournal 2026-06-03.
+describe("migration SQL (drizzle/*.sql)", () => {
+  // The FK in 0000 is `ALTER TABLE "profiles" ... REFERENCES "auth"."users"`,
+  // which targets "profiles" — not "auth" — so it won't false-positive.
+  const authDdl = /(?:CREATE|ALTER|DROP) TABLE (?:IF (?:NOT )?EXISTS )?"auth"\./i;
+
+  it("never emits DDL against the auth schema", () => {
+    const offenders = readdirSync("drizzle")
+      .filter((f) => f.endsWith(".sql"))
+      .filter((f) => authDdl.test(readFileSync(`drizzle/${f}`, "utf8")))
+      .map(
+        (f) =>
+          `${f} emits CREATE/ALTER/DROP TABLE against the "auth" schema — it is Supabase-managed. ` +
+          `Strip the stray statement; the snapshot baseline already tracks auth.users.`,
+      );
+
+    expect(offenders).toEqual([]);
   });
 });


### PR DESCRIPTION
Summary: track the Supabase-managed auth.users table in the 0013 snapshot
baseline and add a functional guard rejecting auth-schema DDL in migrations.

Why: `drizzle-kit generate` emits CREATE/ALTER/DROP TABLE "auth"."users" for the
pgSchema("auth") reference in schema.ts — schemaFilter/tablesFilter only gate
`pull` introspection, not `generate`, and there is no table-level `.existing()`
yet (drizzle-orm #1305). Our snapshots never tracked auth.users, so any
`generate` re-proposes that DDL; applied to prod it fails (auth.users exists).

Behavior: with auth.users in the 0013 snapshot baseline, `generate` reports "No
schema changes" — no migration is produced, and none is needed (the table
already exists; migrate ignores snapshots). The guard test fails any
drizzle/*.sql containing (CREATE|ALTER|DROP) TABLE "auth".

Test Plan:
- lint, typecheck, functional (360/360) green via `npm test`
- e2e 28/28 (clean re-run after a transient dev-server startup crash first time)
- guard verified: fails on planted ALTER and DROP auth.users migrations, passes on current tree

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
