### PR TITLE
test: verify claude-review posts (DO NOT MERGE)

### DIFF
--- a/src/lib/relation-value.ts
+++ b/src/lib/relation-value.ts
@@ -4,7 +4,7 @@
 export type RelationValue = 1 | 2 | 3 | 4;
 
 export const isRelationValue = (v: unknown): v is RelationValue =>
-  typeof v === "number" && Number.isInteger(v) && v >= 1 && v <= 4;
+  typeof v === "number" && Number.isInteger(v) && v >= 1 && v <= 5;
 
 export const RELATION_VALUES: readonly RelationValue[] = [1, 2, 3, 4];
 


### PR DESCRIPTION
Positive control to confirm the `claude-review` workflow actually posts a review.

Injects one deliberate high-confidence bug (`isRelationValue` accepts `5`, which has no label in `RELATION_VALUE_LABELS` and contradicts the file's "1..4" comment) and enables `show_full_output` on this throwaway branch only.

**Do not merge** — this will be closed and the branch deleted as soon as the `claude-review` run is observed.

🤖 Filed by Claude Code