### PR TITLE
Allow relation value 5

### DIFF
--- a/src/lib/relation-value.ts
+++ b/src/lib/relation-value.ts
@@ -4,7 +4,7 @@
 export type RelationValue = 1 | 2 | 3 | 4;
 
 export const isRelationValue = (v: unknown): v is RelationValue =>
-  typeof v === "number" && Number.isInteger(v) && v >= 1 && v <= 4;
+  typeof v === "number" && Number.isInteger(v) && v >= 1 && v <= 5;
 
 export const RELATION_VALUES: readonly RelationValue[] = [1, 2, 3, 4];
 


### PR DESCRIPTION
Widens the relationship
  vocabulary to include a fifth tier (5) by extending the accepted range in isRelationValue. Part of expanding the 1-N
  relation scale used by the rating dialog and invite form.