### PR TITLE
ci: TEMP enable show_full_output on claude-review (diagnostic)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true # TEMP diagnostic — revert after observing the PR #333 review
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
Temporary diagnostic. Surfaces the claude-review transcript so we can see why it posts nothing on PRs. Reverted immediately after observing one PR review. Required check: Lint & Functional Tests (workflow-only change, unaffected).