### PR TITLE
fix(ci): make claude-review post its findings; skip bot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip automated PRs (e.g. Dependabot). claude-code-action refuses bot actors
+    # at its permission gate, and the code-review plugin skips automated PRs on its
+    # own anyway. Skipping here keeps the check neutral instead of red.
+    if: ${{ github.event.pull_request.user.type != 'Bot' }}
 
     runs-on: ubuntu-latest
     permissions:
@@ -36,10 +35,9 @@ jobs:
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          show_full_output: true # TEMP diagnostic — revert after observing the PR #333 review
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## What

Three changes to `.github/workflows/claude-code-review.yml`:

1. **`--comment` added to the prompt** — the real fix. The `code-review` plugin gates posting on a `--comment` argument (`plugins/code-review/commands/code-review.md`, lines 63/65/67). Without it, the workflow ran a full review on every PR, found real issues, and discarded them — which is why no Claude review has ever appeared. Verified via a `show_full_output` transcript: the reviewer found a confirmed high-confidence bug and stopped with *"no --comment argument was provided … stopping here rather than posting."*
2. **Skip automated (Dependabot) PRs** — `if: github.event.pull_request.user.type != 'Bot'`. claude-code-action refuses bot actors at its permission gate (the failure on #328/#329); the plugin skips automated PRs anyway. Keeps the check neutral instead of red.
3. **Remove `show_full_output`** — reverts the temporary diagnostic merged in #335.

## Behavior after this

Every non-bot PR gets one `claude[bot]` comment: inline findings when issues are flagged, or a brief "no issues found" summary on clean PRs. ~$1/PR.

## Note for the merger

This PR's own `claude-review` check will fail — any edit to this workflow file fails the action's token-integrity check (the file must byte-match the default branch). That failure blocks the merge, so it needs an admin bypass. Only required check is **Lint & Functional Tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)