### PR TITLE
feat(relations): v3 depth vocabulary, dialog instruction, changelog

### DIFF
--- a/docs/design-relations.md
+++ b/docs/design-relations.md
@@ -33,12 +33,12 @@ The MVP visualization is *you, and 1–2 hops out*. Whole-network views are bori
 
 ### One dimension at MVP
 
-A single value from a small set captures both "visible trust" and resonance, with room to add dimensions later. Drafted vocabulary (subject to refinement, worth member testing before committing):
+A single value from a small set captures both "visible trust" and resonance, with room to add dimensions later. At heart it's a 1–4 **depth (of relationship) scale** — how deep the bond runs, whether that depth comes through closeness or through shared work (rungs 3–4 admit both). The descriptions exist to calibrate it: they're phrased *relative to the member's own relationships* ("like others I'm lucky to have", "more than most of my friends", "the rare few") so people with different objective social distributions still map sensibly, while the implied shape — many friends, fewer close, rare kin — gently discourages normalising one's whole web onto the top of the scale:
 
-- `1` — **Acquaintance / Supporter**: I have spent some time with them and feel supportive.
-- `2` — **Friend / Collaborator**: I trust them in most ways and we can work well together.
-- `3` — **Companion / Comrade**: I feel deep resonance and shared purpose with them.
-- `4` — **Kindred / Co-Creator**: a kindred spirit; I hope to partner with them for decades.
+- `1` — **Acquaintance**: I'm glad we've met and wish them well, but we haven't drawn particularly close.
+- `2` — **Friend**: A genuine friend whom I enjoy and make time for, like others I'm lucky to have.
+- `3` — **Close Friend**: I really confide in, count on, or collaborate with them more than most of my friends.
+- `4` — **Kin**: Among the rare few who feel like chosen family or co-founders — soul-level kinship that may last a lifetime.
 
 The absence of a relation is an absence of a row. There is no explicit "0 / no connection of interest" rating — un-rated suggestions simply re-surface in future feeds, and at MVP scale (50–100 members) that's a non-problem. A future "intentional dissonance" value (`-1`) is also deferred — the social cost of publicly logged negative feelings wants more design care than we have lived experience to provide right now.
 

--- a/src/app/myweb/relating-dialog.tsx
+++ b/src/app/myweb/relating-dialog.tsx
@@ -162,14 +162,14 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
                 <Button
                   key={value}
                   variant={isCurrent ? "secondary" : "primary"}
-                  className="h-auto justify-start gap-3 px-3 py-2 text-left"
+                  className="h-auto justify-start gap-3 px-3 py-2 text-left whitespace-normal"
                   disabled={mutation.isPending}
                   onClick={() => relate(value)}
                 >
                   <span className="text-lg font-bold tabular-nums">{value}</span>
-                  <span className="flex flex-col">
+                  <span className="flex min-w-0 flex-col">
                     <span className="font-semibold">{headline}</span>
-                    <span className="text-sm text-muted-foreground">{detail}</span>
+                    <span className="text-sm leading-snug text-muted-foreground">{detail}</span>
                   </span>
                   {isPending && <span className="ml-auto text-sm text-muted-foreground">…</span>}
                 </Button>

--- a/src/app/myweb/relating-dialog.tsx
+++ b/src/app/myweb/relating-dialog.tsx
@@ -126,7 +126,9 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
         <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/20 data-ending-style:opacity-0 data-starting-style:opacity-0 transition-opacity duration-150" />
         <Dialog.Popup
           className="fixed top-1/2 left-1/2 z-50 w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded border border-border bg-popover p-5 text-popover-foreground shadow-lg data-ending-style:opacity-0 data-starting-style:opacity-0 transition-opacity duration-150"
-          aria-describedby={target?.hintAttribution ? "relating-attribution" : undefined}
+          aria-describedby={
+            target?.hintAttribution ? "relating-attribution relating-instruction" : "relating-instruction"
+          }
         >
           <Dialog.Close
             disabled={mutation.isPending}
@@ -140,9 +142,12 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
           </Dialog.Title>
           {target?.hintAttribution && (
             <p id="relating-attribution" className="mt-1 text-sm text-muted-foreground">
-              {target.hintAttribution}
+              ({target.hintAttribution})
             </p>
           )}
+          <p id="relating-instruction" className="mt-1 text-sm text-muted-foreground">
+            On a scale of 1-to-4, please estimate how deep <em className="italic">you</em> feel your relationship is.
+          </p>
 
           <p className="mt-3 text-xs text-muted-foreground">
             Keyboard shortcuts: Number keys 1 through 4, or Esc to cancel
@@ -179,8 +184,8 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
           )}
 
           <p className="mt-3 text-xs text-muted-foreground">
-            Notes: Yes, these become visible to them and others. It&apos;s okay to pick a different relation value than
-            they do for you! Everyone will have their own slightly unique interpretation.
+            Notes: Yes, these become visible to them and others. It&apos;s okay to pick a different relationship depth
+            estimate than they do for you! Everyone will have their own slightly unique interpretation.
           </p>
         </Dialog.Popup>
       </Dialog.Portal>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -31,6 +31,12 @@ export type ChangelogEntry = {
 // ordering; a functional test asserts it stays sorted.
 export const changelog: ChangelogEntry[] = [
   {
+    date: "2026-06-04",
+    title: "Clearer relationship labels",
+    description:
+      "The labels and wording for relationship depth are simpler and clearer now, refined once more for understandability.",
+  },
+  {
     date: "2026-05-29",
     title: "Share your current intention",
     description:

--- a/src/lib/relation-value.ts
+++ b/src/lib/relation-value.ts
@@ -11,8 +11,21 @@ export const RELATION_VALUES: readonly RelationValue[] = [1, 2, 3, 4];
 // Mirror of the vocabulary in design-relations.md. Shared by every UI
 // that lets a member pick a 1..4 value (rating dialog, invite form).
 export const RELATION_VALUE_LABELS: Record<RelationValue, { headline: string; detail: string }> = {
-  1: { headline: "Acquaintance / Supporter", detail: "I have spent some time with them and feel supportive." },
-  2: { headline: "Friend / Collaborator", detail: "I trust them in most ways and we can work well together." },
-  3: { headline: "Companion / Comrade", detail: "I feel deep resonance and shared purpose with them." },
-  4: { headline: "Kindred / Co-Creator", detail: "A kindred spirit; I hope to partner with them for decades." },
+  1: {
+    headline: "Acquaintance",
+    detail: "I'm glad we've met and wish them well, but we haven't drawn particularly close.",
+  },
+  2: {
+    headline: "Friend",
+    detail: "A genuine friend whom I enjoy and make time for, like others I'm lucky to have.",
+  },
+  3: {
+    headline: "Close Friend",
+    detail: "I really confide in, count on, or collaborate with them more than most of my friends.",
+  },
+  4: {
+    headline: "Kin",
+    detail:
+      "Among the rare few who feel like chosen family or co-founders — soul-level kinship that may last a lifetime.",
+  },
 };

--- a/tests/functional/client/member-relation-control.test.tsx
+++ b/tests/functional/client/member-relation-control.test.tsx
@@ -43,7 +43,7 @@ describe("MemberRelationControl", () => {
 
     // Regression guard: the label must render the headline string, not the
     // RELATION_VALUE_LABELS object (which stringifies to "[object Object]").
-    expect(await screen.findByText("Connected · Friend / Collaborator")).toBeVisible();
+    expect(await screen.findByText("Connected · Friend")).toBeVisible();
     expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
   });
 


### PR DESCRIPTION
## What

Third pass on the relationship-depth vocabulary — now a clean 1–4 depth scale — plus dialog copy and a member-facing changelog entry.

**Vocabulary** (`src/lib/relation-value.ts`, `docs/design-relations.md`)
- `1` Acquaintance · `2` Friend · `3` Close Friend · `4` Kin
- Descriptions are phrased relative to the member's own relationships, so different objective social distributions still map sensibly. Rungs 3–4 admit depth via shared work (collaborate / co-founders) as well as closeness.

**Relating dialog** (`src/app/myweb/relating-dialog.tsx`)
- New instruction subtitle under the title: "On a scale of 1-to-4, please estimate how deep you feel your relationship is."
- Hint attribution is parenthesized and sits above the instruction; `aria-describedby` points at both.
- Notes line reworded: "relation value" → "relationship depth estimate".

**Changelog** (`src/lib/changelog.ts`) — member-facing entry; bumps the /about version to `v2026.06.04`.

**Test** — updated the value-2 headline assertion to match the new label.

## Testing
- Lint ✅, typecheck ✅, functional Vitest 358/360 locally — the 2 failures are avatar/storage tests, artifacts of a broken local Supabase stack (a `supabase start` 404 rollback after a hard crash on this machine), unrelated to this diff.
- The authoritative functional + e2e runs are CI's, against the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)