### PR TITLE
chore(biome): self-tracking $schema + config rationale doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,5 +89,6 @@ Design and rationale: [docs/spec-portable-ai-procedures.md](docs/spec-portable-a
 - `docs/doc-github.md` — GitHub settings and CI workflows
 - `docs/doc-sentry.md` — Sentry error tracking and performance monitoring
 - `docs/doc-axiom.md` — Axiom logging and Web Vitals
+- `docs/doc-biome.md` — Biome lint/format config rationale and the version-bump policy
 - `docs/setup-dev-machine.md` — system prerequisites (Node.js, Docker, etc.)
 - `docs/devjournal.md` — development decision log (most recent first)

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/docs/doc-biome.md
+++ b/docs/doc-biome.md
@@ -1,0 +1,36 @@
+# Biome Configuration
+
+Biome is the linter + formatter. `npm run lint` runs `biome ci .`, and CI gates
+it on every PR. Config lives in `biome.json`; this doc holds the rationale the
+JSON itself can't carry.
+
+## Updating Biome
+
+`$schema` points at the locally installed copy
+(`./node_modules/@biomejs/biome/configuration_schema.json`), so editor
+validation tracks whatever version is installed — bumping `@biomejs/biome`
+(e.g. via Dependabot) needs no edit to `biome.json`. This is deliberate: a
+pinned `schemas/<version>/schema.json` URL silently drifts whenever the package
+bumps but the URL doesn't, which CI flags as *"configuration schema version
+does not match"*.
+
+After a bump, run `npm run lint` once to surface any renamed or newly
+recommended rules.
+
+## Notable config
+
+- **App code can't import `@/server/*`** — the `noRestrictedImports` override on
+  `src/app/**` and `src/components/**` forces app code through the Hono API
+  (`apiClient` / `serverApiClient`) instead of reaching into server modules
+  directly. See `architecture-appstack.md`.
+- **Import order** — `organizeImports` groups node/package builtins, then `@/`
+  aliases, then relative paths, with blank lines between each group.
+- **shadcn UI a11y opt-outs** — `src/components/ui/**` disables
+  `useSemanticElements` and `useKeyWithClickEvents`; those are generated
+  components we don't hand-edit.
+- **`noNonNullAssertion`** — an error in app code, relaxed to off under `tests/`
+  and `scripts/`.
+- **Excluded paths** — the `files.includes` negations skip generated or vendored
+  trees Biome shouldn't touch: `.next`, `next-env.d.ts`, Supabase email
+  templates, `docs/_temp-*`, `drizzle/meta`, and the functional-test
+  `__data__` fixtures.


### PR DESCRIPTION
## What

Switches `biome.json`'s `$schema` from a version-pinned URL to the locally installed copy (`./node_modules/@biomejs/biome/configuration_schema.json`), so editor validation always tracks whatever Biome version is installed.

A pinned `schemas/<version>/schema.json` URL silently drifts whenever Dependabot bumps the package but not the URL — exactly what happened on the 2.4.15 → 2.4.16 bump (#329), surfacing as the CI annotation *"configuration schema version does not match the CLI version 2.4.16."* The node_modules path has no embedded version, so there's nothing to drift.

Also adds `docs/doc-biome.md` — the rationale the JSON can't carry: the version-bump policy plus why the non-obvious rules exist (the Hono-API import guard, shadcn a11y opt-outs, per-tree `noNonNullAssertion`, excluded paths). Linked from CLAUDE.md's Key docs.

## Testing

- `npm run lint` clean locally on the updated config — and the *"schema version does not match"* annotation is gone.
- Functional tests run in CI's required **Lint & Functional Tests** gate. Not run locally: the change is an editor-only `$schema` string plus markdown, which can't affect them.
- E2E is temporarily out of commission; disregard that check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
