### PR TITLE
feat(invites): improve the invite-a-friend page

### DIFF
--- a/src/app/invites/invites-panel.tsx
+++ b/src/app/invites/invites-panel.tsx
@@ -4,11 +4,17 @@ import { useCallback, useEffect, useState } from "react";
 
 import { MemberChip, MemberTypeahead } from "@/components/member-typeahead";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
 import { apiClient } from "@/lib/api";
 import type { Me, MemberSummary } from "@/lib/api-types";
-import { RELATION_VALUE_LABELS, RELATION_VALUES, type RelationValue } from "@/lib/relation-value";
+import { HINTS_PER_INVITE_LIMIT, MIN_NOTE_LENGTH } from "@/lib/invite-limits";
+import {
+  RELATION_VALUE_LABELS,
+  RELATION_VALUE_VISIBILITY_NOTE,
+  RELATION_VALUES,
+  type RelationValue,
+} from "@/lib/relation-value";
 
 type InviteRow = {
   code: string;
@@ -21,8 +27,6 @@ type InviteRow = {
 };
 
 type PanelState = { kind: "idle" } | { kind: "creating" } | { kind: "error"; message: string };
-
-const HINT_LIMIT = 10;
 
 type HintMember = Pick<MemberSummary, "id" | "displayName">;
 
@@ -58,10 +62,10 @@ export function InvitesPanel({ me }: { me: Me }) {
   const create = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const trimmed = note.trim();
-    if (trimmed.length < 10) {
+    if (trimmed.length < MIN_NOTE_LENGTH) {
       setState({
         kind: "error",
-        message: "Note must be at least 10 characters.",
+        message: `Please write at least ${MIN_NOTE_LENGTH} characters about who you're inviting.`,
       });
       return;
     }
@@ -134,7 +138,7 @@ export function InvitesPanel({ me }: { me: Me }) {
   };
 
   const addHint = (m: MemberSummary) => {
-    if (hints.length >= HINT_LIMIT) return;
+    if (hints.length >= HINTS_PER_INVITE_LIMIT) return;
     if (hints.some((h) => h.id === m.id)) return;
     setHints((prev) => [...prev, { id: m.id, displayName: m.displayName }]);
   };
@@ -152,16 +156,19 @@ export function InvitesPanel({ me }: { me: Me }) {
       className="flex w-full max-w-xl flex-col gap-4 rounded border border-border p-4"
     >
       <h2 id="invites-heading" className="text-lg font-semibold">
-        Invite a member
+        Invite a new member
       </h2>
+      <p className="text-base text-muted-foreground">
+        You can bring others into the IS Web — ideally people <em>already</em> woven into our larger network of
+        relationships. If you're their only connection here, make it a strong one.
+      </p>
       <form onSubmit={create} className="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
-          <Label htmlFor="invite-note">Note (for your records and theirs — who are you inviting?)</Label>
-          <Textarea
+          <Label htmlFor="invite-note">Who are you inviting? (We'll use this to greet them initially.)</Label>
+          <Input
             id="invite-note"
             required
-            minLength={10}
-            rows={2}
+            minLength={MIN_NOTE_LENGTH}
             value={note}
             onChange={(event) => setNote(event.target.value)}
             disabled={submitting}
@@ -172,12 +179,12 @@ export function InvitesPanel({ me }: { me: Me }) {
 
         <div className="flex flex-col gap-2">
           <MemberTypeahead
-            label="Hints (optional) — people you think they'll want to know"
-            triggerLabel="Add a hint…"
+            label="Recommendations: Who in this Web do you think they already know?"
+            triggerLabel="Add a connection recommendation…"
             selectedIds={hints.map((h) => h.id)}
             excludeIds={excludeFromHints}
             onSelect={addHint}
-            disabled={submitting || hints.length >= HINT_LIMIT}
+            disabled={submitting || hints.length >= HINTS_PER_INVITE_LIMIT}
           />
           {hints.length > 0 && (
             <div className="flex flex-wrap gap-1">
@@ -186,8 +193,8 @@ export function InvitesPanel({ me }: { me: Me }) {
               ))}
             </div>
           )}
-          {hints.length >= HINT_LIMIT && (
-            <p className="text-sm text-muted-foreground">Up to {HINT_LIMIT} hints per invite.</p>
+          {hints.length >= HINTS_PER_INVITE_LIMIT && (
+            <p className="text-sm text-muted-foreground">Up to {HINTS_PER_INVITE_LIMIT} hints per invite.</p>
           )}
         </div>
 
@@ -202,7 +209,7 @@ export function InvitesPanel({ me }: { me: Me }) {
       </form>
 
       <div>
-        <h3 className="mb-2 text-base font-semibold uppercase tracking-wide text-muted-foreground">My invites</h3>
+        <h3 className="mb-2 text-base font-semibold text-muted-foreground">My Invites</h3>
         {rows === null ? (
           <p className="text-base text-muted-foreground">Loading…</p>
         ) : rows.length === 0 ? (
@@ -210,23 +217,33 @@ export function InvitesPanel({ me }: { me: Me }) {
         ) : (
           <ul className="flex flex-col gap-2">
             {rows.map((row) => (
-              <li key={row.code} className="flex flex-col gap-1 rounded border border-border p-3 text-base">
-                <div className="flex items-center gap-3">
-                  <code className="font-mono text-base">{row.code}</code>
-                  <StatusBadge status={row.status} />
+              <li
+                key={row.code}
+                className="flex items-start justify-between gap-3 rounded-xl bg-popover p-3 text-base ring-1 ring-foreground/10"
+              >
+                <div className="flex min-w-0 flex-col gap-1">
+                  <p className="text-foreground">{row.note}</p>
+                  <div className="flex items-center gap-3">
+                    <StatusBadge status={row.status} />
+                    <span className="text-sm text-muted-foreground">Expires {formatDate(row.expiresAt)}</span>
+                  </div>
+                </div>
+                <div className="flex flex-col items-end gap-2">
+                  <div className="whitespace-nowrap text-base">
+                    <span className="text-muted-foreground">Code: </span>
+                    <code className="font-mono">{row.code}</code>
+                  </div>
                   {row.status === "active" && (
-                    <>
-                      <Button size="xs" className="ml-auto" onClick={() => copy(row.code)}>
-                        {copiedCode === row.code ? "Copied" : "Copy"}
+                    <div className="flex gap-2">
+                      <Button size="xs" onClick={() => copy(row.code)}>
+                        {copiedCode === row.code ? "Copied" : "Copy invite link"}
                       </Button>
                       <Button variant="destructive" size="xs" onClick={() => revoke(row.code)}>
                         Revoke
                       </Button>
-                    </>
+                    </div>
                   )}
                 </div>
-                <p className="text-foreground">{row.note}</p>
-                <p className="text-sm text-muted-foreground">Expires {formatDate(row.expiresAt)}</p>
               </li>
             ))}
           </ul>
@@ -246,36 +263,45 @@ function RelationValuePicker({
   disabled?: boolean;
 }) {
   return (
-    <fieldset className="flex flex-col gap-2" disabled={disabled}>
-      <legend className="text-base font-medium">Your relationship to them (optional)</legend>
-      <div className="flex flex-col gap-2">
-        {RELATION_VALUES.map((v) => {
-          const { headline, detail } = RELATION_VALUE_LABELS[v];
-          const selected = value === v;
-          return (
-            <Button
-              key={v}
-              type="button"
-              variant={selected ? "secondary" : "primary"}
-              className="h-auto justify-start gap-3 px-3 py-2 text-left"
-              onClick={() => onChange(selected ? null : v)}
-              aria-pressed={selected}
-            >
-              <span className="text-lg font-bold tabular-nums">{v}</span>
-              <span className="flex flex-col">
-                <span className="font-semibold">{headline}</span>
-                <span className="text-sm text-muted-foreground">{detail}</span>
-              </span>
-            </Button>
-          );
-        })}
-      </div>
-      {value === 1 && (
-        <p className="text-sm text-muted-foreground">
-          Inviting people you've only met in group settings tends to lead to weak fit. Is this the right time?
-        </p>
-      )}
-    </fieldset>
+    <div className="flex flex-col gap-2">
+      <p id="relation-value-heading" className="text-base font-medium leading-none">
+        What's your relationship to them?
+      </p>
+      <fieldset
+        className="flex flex-col gap-2 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10"
+        disabled={disabled}
+        aria-labelledby="relation-value-heading"
+      >
+        <div className="flex flex-col gap-2">
+          {RELATION_VALUES.map((v) => {
+            const { headline, detail } = RELATION_VALUE_LABELS[v];
+            const selected = value === v;
+            return (
+              <Button
+                key={v}
+                type="button"
+                variant={selected ? "secondary" : "primary"}
+                className="h-auto justify-start gap-3 whitespace-normal px-3 py-2 text-left"
+                onClick={() => onChange(selected ? null : v)}
+                aria-pressed={selected}
+              >
+                <span className="text-lg font-bold tabular-nums">{v}</span>
+                <span className="flex min-w-0 flex-col">
+                  <span className="font-semibold">{headline}</span>
+                  <span className="text-sm text-muted-foreground">{detail}</span>
+                </span>
+              </Button>
+            );
+          })}
+        </div>
+        {value === 1 && (
+          <p className="text-sm text-muted-foreground">
+            Inviting people you've only met in group settings tends to lead to weak fit. Is this the right time?
+          </p>
+        )}
+        <p className="text-xs text-muted-foreground">Notes: {RELATION_VALUE_VISIBILITY_NOTE}</p>
+      </fieldset>
+    </div>
   );
 }
 

--- a/src/app/myweb/relating-dialog.tsx
+++ b/src/app/myweb/relating-dialog.tsx
@@ -8,7 +8,12 @@ import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api";
 import type { RelationCandidatesFeed } from "@/lib/api-types";
-import { RELATION_VALUE_LABELS, RELATION_VALUES, type RelationValue } from "@/lib/relation-value";
+import {
+  RELATION_VALUE_LABELS,
+  RELATION_VALUE_VISIBILITY_NOTE,
+  RELATION_VALUES,
+  type RelationValue,
+} from "@/lib/relation-value";
 
 import { RELATION_CANDIDATES_QUERY_KEY, RELATION_SUBGRAPH_QUERY_KEY, relationValueQueryKey } from "./query-keys";
 
@@ -183,10 +188,7 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
             </p>
           )}
 
-          <p className="mt-3 text-xs text-muted-foreground">
-            Notes: Yes, these become visible to them and others. It&apos;s okay to pick a different relationship depth
-            estimate than they do for you! Everyone will have their own slightly unique interpretation.
-          </p>
+          <p className="mt-3 text-xs text-muted-foreground">Notes: {RELATION_VALUE_VISIBILITY_NOTE}</p>
         </Dialog.Popup>
       </Dialog.Portal>
     </Dialog.Root>

--- a/src/lib/invite-limits.ts
+++ b/src/lib/invite-limits.ts
@@ -1,0 +1,8 @@
+// Invite form limits, shared between the server-side validator and the
+// client UI so the two stay in lockstep. Keep this file dependency-free
+// (no db, no node APIs) so the client bundle can import it. The server
+// remains the real gatekeeper — these constants only keep the client's
+// pre-submit hints honest.
+
+export const MIN_NOTE_LENGTH = 5;
+export const HINTS_PER_INVITE_LIMIT = 20;

--- a/src/lib/relation-value.ts
+++ b/src/lib/relation-value.ts
@@ -29,3 +29,8 @@ export const RELATION_VALUE_LABELS: Record<RelationValue, { headline: string; de
       "Among the rare few who feel like chosen family or co-founders — soul-level kinship that may last a lifetime.",
   },
 };
+
+// Reassurance shown wherever a member picks a 1..4 value — the rating
+// dialog and the invite form. One definition so the two never drift.
+export const RELATION_VALUE_VISIBILITY_NOTE =
+  "Yes, these become visible to them and others. It's okay to pick a different relationship depth estimate than they do for you! Everyone will have their own slightly unique interpretation.";

--- a/src/server/invites.ts
+++ b/src/server/invites.ts
@@ -1,6 +1,7 @@
 import { randomInt } from "node:crypto";
 import { and, count, desc, eq, gt, isNull, sql } from "drizzle-orm";
 
+import { MIN_NOTE_LENGTH } from "@/lib/invite-limits";
 import { isRelationValue, type RelationValue } from "@/lib/relation-value";
 
 import { db } from "./db";
@@ -16,7 +17,6 @@ const CODE_LENGTH = 10;
 
 const MAX_ACTIVE_INVITES_PER_USER = 50;
 const INVITE_LIFETIME_DAYS = 30;
-const MIN_NOTE_LENGTH = 10;
 
 export type InviteStatus = "active" | "redeemed" | "revoked" | "expired";
 

--- a/src/server/relations.ts
+++ b/src/server/relations.ts
@@ -13,6 +13,7 @@ import {
 } from "drizzle-orm";
 import type { PgTransaction } from "drizzle-orm/pg-core";
 
+import { HINTS_PER_INVITE_LIMIT } from "@/lib/invite-limits";
 import { isRelationValue, type RelationValue } from "@/lib/relation-value";
 
 import { isUuid } from "./auth-middleware";
@@ -591,8 +592,6 @@ export const deleteRelationHint = async (params: {
   if (result.length === 0) return { error: "not_found" };
   return { ok: true };
 };
-
-export const HINTS_PER_INVITE_LIMIT = 10;
 
 export type ValidateHintsResult =
   | { ok: true; ids: string[] }

--- a/tests/e2e/invites.spec.ts
+++ b/tests/e2e/invites.spec.ts
@@ -31,9 +31,9 @@ test.describe("invites — authed member flow", () => {
   test("create an invite, see it listed, revoke it", async ({ page }) => {
     await page.getByRole("link", { name: "Invite a friend" }).click();
     await page.waitForURL((u) => u.pathname === "/invites", { timeout: TIMEOUT_MS });
-    await expect(page.getByRole("heading", { name: "Invite a member" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Invite a new member" })).toBeVisible();
 
-    await page.getByLabel(/Note \(for your records/).fill("bringing a friend from the meditation group");
+    await page.getByLabel("Who are you inviting?").fill("bringing a friend from the meditation group");
     await page.getByRole("button", { name: "Create invite" }).click();
 
     const codeLocator = page.locator("code").first();
@@ -51,7 +51,7 @@ test.describe("invites — authed member flow", () => {
     await page.getByRole("link", { name: "Invite a friend" }).click();
     await page.waitForURL((u) => u.pathname === "/invites", { timeout: TIMEOUT_MS });
     // Stub POST /api/invites to return 429 — we don't want to seed
-    // ten real invites per test run, and we only need to verify the
+    // fifty real invites per test run, and we only need to verify the
     // UI's error branch for the cap case.
     await page.route("**/api/invites", async (route) => {
       if (route.request().method() === "POST") {
@@ -60,7 +60,7 @@ test.describe("invites — authed member flow", () => {
           contentType: "application/json",
           body: JSON.stringify({
             error: "too_many_active_invites",
-            limit: 10,
+            limit: 50,
           }),
         });
         return;
@@ -68,10 +68,10 @@ test.describe("invites — authed member flow", () => {
       await route.continue();
     });
 
-    await page.getByLabel(/Note \(for your records/).fill("this should trigger the cap message");
+    await page.getByLabel("Who are you inviting?").fill("this should trigger the cap message");
     await page.getByRole("button", { name: "Create invite" }).click();
 
-    await expect(page.getByText(/You already have 10 active invites/)).toBeVisible();
+    await expect(page.getByText(/You already have 50 active invites/)).toBeVisible();
   });
 });
 
@@ -99,7 +99,7 @@ test.describe("/signup — unauthed invite flow", () => {
       });
       await memberPage.getByRole("link", { name: "Invite a friend" }).click();
       await memberPage.waitForURL((u) => u.pathname === "/invites", { timeout: TIMEOUT_MS });
-      await memberPage.getByLabel(/Note \(for your records/).fill("e2e signup-flow invite — come on in");
+      await memberPage.getByLabel("Who are you inviting?").fill("e2e signup-flow invite — come on in");
       await memberPage.getByRole("button", { name: "Create invite" }).click();
       const codeLocator = memberPage.locator("code").first();
       await expect(codeLocator).toHaveText(/^[A-HJ-NP-Z2-9]{10}$/);

--- a/tests/functional/server/invites.test.ts
+++ b/tests/functional/server/invites.test.ts
@@ -310,11 +310,11 @@ describe("POST /api/invites", () => {
     expect(typeof body.expiresAt).toBe("string");
   });
 
-  it("rejects a note shorter than 10 chars", async () => {
-    const res = await post({ note: "too short" });
+  it("rejects a note shorter than 5 chars", async () => {
+    const res = await post({ note: "hi" });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toMatch(/at least 10/);
+    expect(body.error).toMatch(/at least 5/);
   });
 
   it("rejects a malformed JSON body", async () => {


### PR DESCRIPTION
Summary: Polishes the invite-a-friend page (#343) and unifies the note-length and hint-count limits into a single client/server source.

Why: #343 asked for clearer copy, a single-line invitee field, a self-contained relationship-depth card, and tidier invite rows. Relaxing the note minimum and hint cap surfaced constants duplicated across client and server, plus a reassurance note copied verbatim from the relating dialog.

Behavior:
- Intro paragraph under "Invite a new member"; the invitee field is now a single-line "Who are you inviting?" input.
- Relationship-depth picker is a dialog-style card (bg-popover + ring) holding the depth buttons, the level-1 caution, and the shared visibility note; long depth-button text wraps inside the card.
- "Recommendations" label and "Add a connection recommendation…" trigger replace the old "Hints" wording.
- Invite rows: note leads, "Code:" sits top-right above the buttons, "Copy invite link", "My Invites" (no longer all-caps), dialog-white card backgrounds.
- Note minimum 10 → 5 and hint cap 10 → 20, defined once in src/lib/invite-limits.ts and imported by client and server.
- Relationship visibility note moved to relation-value.ts, shared by the invite card and the relating dialog.

A pre-existing typeahead scroll bug surfaced during this work and is tracked separately in #346 (out of scope here).

Test Plan:
- ran the full suite locally: vitest 360/360, playwright e2e 28/28 green.
- James verified the rendered page (card, copy, invite rows) on the local dev server.

Closes #343

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
