### PR TITLE
fix: harden onboarding error handling and relating-dialog contrast

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -132,7 +132,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     let result: { created: boolean };
     try {
       result = await upsertProfile(data.user);
-    } catch {
+    } catch (err) {
+      Sentry.captureException(err);
       return NextResponse.redirect(new URL("/signin?error=profile_error", request.url), 303);
     }
     if (result.created) {
@@ -216,6 +217,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       await supabase.auth.signOut();
       return NextResponse.redirect(new URL("/signin?error=invite_invalid", request.url), 303);
     }
+    // Anything other than InviteInvalid (the routine "code already
+    // redeemed/expired" path) is a real Postgres/transaction failure —
+    // capture it instead of swallowing it behind the generic redirect.
+    Sentry.captureException(err);
     return NextResponse.redirect(new URL("/signin?error=profile_error", request.url), 303);
   }
 

--- a/src/app/myweb/relating-dialog.tsx
+++ b/src/app/myweb/relating-dialog.tsx
@@ -14,6 +14,7 @@ import {
   RELATION_VALUES,
   type RelationValue,
 } from "@/lib/relation-value";
+import { cn } from "@/lib/utils";
 
 import { RELATION_CANDIDATES_QUERY_KEY, RELATION_SUBGRAPH_QUERY_KEY, relationValueQueryKey } from "./query-keys";
 
@@ -174,7 +175,17 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
                   <span className="text-lg font-bold tabular-nums">{value}</span>
                   <span className="flex min-w-0 flex-col">
                     <span className="font-semibold">{headline}</span>
-                    <span className="text-sm leading-snug text-muted-foreground">{detail}</span>
+                    {/* The selected value renders as `secondary` (dark teal
+                        fill), where muted-foreground gray is unreadable; switch
+                        the detail line to the light on-fill color in that state. */}
+                    <span
+                      className={cn(
+                        "text-sm leading-snug",
+                        isCurrent ? "text-primary-foreground/80" : "text-muted-foreground",
+                      )}
+                    >
+                      {detail}
+                    </span>
                   </span>
                   {isPending && <span className="ml-auto text-sm text-muted-foreground">…</span>}
                 </Button>

--- a/src/app/welcome/profile/welcome-form.tsx
+++ b/src/app/welcome/profile/welcome-form.tsx
@@ -22,11 +22,23 @@ export function WelcomeForm({ initial }: { initial: ProfileFormValues }) {
 
     if (password.length > 0) {
       const supabase = createClient();
-      const { error } = await supabase.auth.updateUser({ password });
-      if (error) {
+      try {
+        const { error } = await supabase.auth.updateUser({ password });
+        if (error) {
+          setStatus({
+            kind: "error",
+            message: `Profile saved, but password update failed: ${error.message}`,
+          });
+          return;
+        }
+      } catch (err) {
+        // updateUser can reject outright (network drop, CORS) instead of
+        // returning { error }. Without this catch the rejection is unhandled
+        // and the form dead-ends after a successful profile save — no error
+        // surfaced, no navigation.
         setStatus({
           kind: "error",
-          message: `Profile saved, but password update failed: ${error.message}`,
+          message: `Profile saved, but password update failed: ${err instanceof Error ? err.message : "network error"}`,
         });
         return;
       }


### PR DESCRIPTION
Summary: Capture previously-swallowed auth-callback failures to Sentry, guard the welcome form's password update against thrown rejections, and fix unreadable detail text on the selected relationship-depth value.

Why: Pre-soft-launch hardening ahead of the 40+ member rollout.
- #255: profile-upsert and invite-redemption failures redirected to a generic error with no telemetry, leaving broken onboarding invisible.
- #211: supabase.auth.updateUser can reject outright rather than returning { error }, dead-ending the welcome form with no feedback after a successful profile save.
- #342: the selected depth value renders as the dark-teal `secondary` variant, where the muted-gray detail line is near-invisible.

Behavior:
- Auth-callback ordinary and invited paths now capture real failures to Sentry; the routine InviteInvalid path stays unreported.
- Welcome-form password step surfaces an error and stops instead of an unhandled rejection.
- Selected depth value's detail text switches to the light on-fill color; all other states are unchanged.

Test Plan:
- ran `npm test` locally — lint, typecheck, 360 functional, 28 e2e all green.

Closes #255
Closes #211
Closes #342

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
