### PR TITLE
fix(relations): simplify the Acquaintance description

### DIFF
--- a/docs/design-relations.md
+++ b/docs/design-relations.md
@@ -35,7 +35,7 @@ The MVP visualization is *you, and 1–2 hops out*. Whole-network views are bori
 
 A single value from a small set captures both "visible trust" and resonance, with room to add dimensions later. At heart it's a 1–4 **depth (of relationship) scale** — how deep the bond runs, whether that depth comes through closeness or through shared work (rungs 3–4 admit both). The descriptions exist to calibrate it: they're phrased *relative to the member's own relationships* ("like others I'm lucky to have", "more than most of my friends", "the rare few") so people with different objective social distributions still map sensibly, while the implied shape — many friends, fewer close, rare kin — gently discourages normalising one's whole web onto the top of the scale:
 
-- `1` — **Acquaintance**: I'm glad we've met and wish them well, but we haven't drawn particularly close.
+- `1` — **Acquaintance**: I'm glad we've met and wish them well.
 - `2` — **Friend**: A genuine friend whom I enjoy and make time for, like others I'm lucky to have.
 - `3` — **Close Friend**: I really confide in, count on, or collaborate with them more than most of my friends.
 - `4` — **Kin**: Among the rare few who feel like chosen family or co-founders — soul-level kinship that may last a lifetime.

--- a/src/lib/relation-value.ts
+++ b/src/lib/relation-value.ts
@@ -13,7 +13,7 @@ export const RELATION_VALUES: readonly RelationValue[] = [1, 2, 3, 4];
 export const RELATION_VALUE_LABELS: Record<RelationValue, { headline: string; detail: string }> = {
   1: {
     headline: "Acquaintance",
-    detail: "I'm glad we've met and wish them well, but we haven't drawn particularly close.",
+    detail: "I'm glad we've met and wish them well.",
   },
   2: {
     headline: "Friend",


### PR DESCRIPTION
**Summary:** Shorten the level-1 (Acquaintance) relation description to a single positive clause.

**Why:** The old ending ("but we haven't drawn particularly close") closed on a negation and implied acquaintance is just a precursor to friendship. Acquaintance is a valid, complete relationship, so the line should stay neutral about whether the bond deepens.

**Behavior:** The rating dialog and invite form now show "I'm glad we've met and wish them well." for value 1. The `design-relations.md` vocabulary mirror is updated to match.

**Test Plan:**
- ran `npm test` locally (360 functional + 28 e2e green)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
