### PR TITLE
feat(admin): activity metrics + per-user request logging

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-04 | James | Activity instrumentation for launch
+
+Added `userId` (pseudonymous Supabase UUID) to the `api request` log so Axiom can count distinct people, and an admin **Activity metrics** view (`src/server/activity-metrics.ts`) reading the signup and invite funnels, plus a signed-in-past-week/month count from `auth.users.last_sign_in_at`, from current DB state.
+
 ## 2026-06-03 | James | Guard drizzle generate against stray auth-schema DDL
 
 An attempt to stop `drizzle-kit generate` re-emitting `CREATE/ALTER/DROP TABLE "auth"` for the `pgSchema("auth")` reference (`schemaFilter`/`tablesFilter` gate only `pull`; tables have no `.existing()` yet — drizzle-orm #1305): `auth.users` is now tracked in the `0013` snapshot baseline, with a functional guard rejecting auth-schema DDL as the backstop.

--- a/docs/doc-axiom.md
+++ b/docs/doc-axiom.md
@@ -21,6 +21,14 @@ Every API request is logged by Hono middleware in `src/server/api.ts` with:
 - `path` — request path
 - `status` — response status code
 - `duration` — response time in milliseconds
+- `userId` — the authenticated Supabase user UUID, or `null` on public/401 paths. This is the pseudonymous auth id only (never the email), keeping the log line consistent with the PII stance in `doc-sentry.md`.
+
+`userId` is what makes per-person analysis possible — distinct visitors, per-path adoption, return visits — that the request shape alone can't give. `next-axiom` nests it under `fields`, so query it as `['fields.userId']`:
+
+- **Distinct people active in a window:** `["vercel"] | where message == "api request" | summarize dcount(['fields.userId'])`
+- **Adoption by path (who touched what):** `["vercel"] | where message == "api request" | summarize dcount(['fields.userId']) by path`
+
+For funnel and per-member-state questions (signed up → set intention → built web → joined a program, plus the invite funnel), the DB is the better source — see the admin **Activity metrics** view (`/admin`, backed by `src/server/activity-metrics.ts`), which reads current state rather than aging-out logs.
 
 ## Environment Variables
 

--- a/src/app/admin/activity-metrics.tsx
+++ b/src/app/admin/activity-metrics.tsx
@@ -4,14 +4,32 @@ import { serverApiClient } from "@/lib/api-server";
 
 const pct = (n: number, total: number): string => (total > 0 ? `${Math.round((n / total) * 100)}%` : "—");
 
+const METRICS_TIMEOUT_MS = 5000;
+
+// Resolve `promise`, or reject after `ms`. Guards against a slow/hung
+// metrics read taking the whole admin page down to a 504: the queries
+// run over the Supabase transaction pooler, where a burst of reads can
+// stall, and a never-settling await would otherwise block the render
+// past the platform timeout.
+const withTimeout = <T,>(promise: Promise<T>, ms: number): Promise<T> =>
+  Promise.race([
+    promise,
+    new Promise<T>((_, reject) => setTimeout(() => reject(new Error(`activity metrics timed out after ${ms}ms`)), ms)),
+  ]);
+
 // Read-only funnel over the DB (see src/server/activity-metrics.ts).
 // Fetches its own data so the admin page only has to drop it into a
-// section. Best-effort: a failed read renders an inline notice and
-// reports to Sentry rather than throwing, so a metrics hiccup can't take
-// down the rest of the admin page.
+// section. Best-effort: a failed or slow read renders an inline notice
+// and reports to Sentry rather than throwing or hanging, so a metrics
+// hiccup can't take down the rest of the admin page.
 export async function ActivityMetrics() {
   try {
-    const res = await serverApiClient.api.admin.activity.$get();
+    const request = serverApiClient.api.admin.activity.$get();
+    // If the timeout wins the race the request keeps running; swallow its
+    // eventual settle so it can't surface as an unhandled rejection on a
+    // reused Fluid Compute instance.
+    request.catch(() => {});
+    const res = await withTimeout(request, METRICS_TIMEOUT_MS);
     if (!res.ok) throw new Error(`activity metrics request failed: ${res.status}`);
     const { metrics } = await res.json();
     const { members, invites } = metrics;

--- a/src/app/admin/activity-metrics.tsx
+++ b/src/app/admin/activity-metrics.tsx
@@ -14,13 +14,30 @@ export async function ActivityMetrics() {
     const res = await serverApiClient.api.admin.activity.$get();
     if (!res.ok) throw new Error(`activity metrics request failed: ${res.status}`);
     const { metrics } = await res.json();
-    const { members, invites } = metrics;
+    const { members, invites, sinceLaunch, launchDate } = metrics;
+
+    const launchLabel = new Date(launchDate).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+
+    const sinceRows = [
+      { label: "Signed in", value: sinceLaunch.signedIn },
+      { label: "Signed agreements", value: sinceLaunch.signedAgreements },
+      { label: "Set an intention", value: sinceLaunch.setIntention },
+      { label: "Edited their profile", value: sinceLaunch.editedProfile },
+      { label: "Built their web", value: sinceLaunch.builtWeb },
+      { label: "Joined a program", value: sinceLaunch.joinedProgram },
+      { label: "Invites created", value: sinceLaunch.invitesCreated },
+      { label: "Invites redeemed", value: sinceLaunch.invitesRedeemed },
+    ];
 
     const funnel = [
       { label: "Signed up", value: members.total },
       { label: "Signed agreements", value: members.signedAgreements },
       { label: "Set an intention", value: members.setIntention },
-      { label: "Filled out profile", value: members.updatedProfile },
+      { label: "Edited their profile", value: members.updatedProfile },
       { label: "Built their web", value: members.builtWeb },
       { label: "Joined a program", value: members.joinedProgram },
     ];
@@ -35,11 +52,25 @@ export async function ActivityMetrics() {
 
     return (
       <div className="flex flex-col gap-4">
+        <div className="rounded border border-primary/40 bg-primary/5">
+          <div className="border-b border-border px-3 py-2 text-sm font-medium">
+            Since launch <span className="font-normal text-muted-foreground">· {launchLabel}</span>
+          </div>
+          <dl className="divide-y divide-border">
+            {sinceRows.map((row) => (
+              <div key={row.label} className="flex items-baseline justify-between px-3 py-1.5 text-sm">
+                <dt className="text-muted-foreground">{row.label}</dt>
+                <dd className="tabular-nums">{row.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
         <div className="rounded border border-border">
           <div className="border-b border-border px-3 py-2 text-sm font-medium">
             Members{" "}
             <span className="font-normal text-muted-foreground">
-              · {members.new7d} new this week · {members.new30d} this month
+              · {members.new7d} new this week · {members.new30d} this month (all time)
             </span>
           </div>
           <dl className="divide-y divide-border">
@@ -61,7 +92,7 @@ export async function ActivityMetrics() {
         </div>
 
         <div className="rounded border border-border">
-          <div className="border-b border-border px-3 py-2 text-sm font-medium">Invites</div>
+          <div className="border-b border-border px-3 py-2 text-sm font-medium">Invites (all time)</div>
           <dl className="divide-y divide-border">
             {inviteRows.map((row) => (
               <div key={row.label} className="flex items-baseline justify-between px-3 py-1.5 text-sm">

--- a/src/app/admin/activity-metrics.tsx
+++ b/src/app/admin/activity-metrics.tsx
@@ -1,0 +1,80 @@
+import * as Sentry from "@sentry/nextjs";
+
+import { serverApiClient } from "@/lib/api-server";
+
+const pct = (n: number, total: number): string => (total > 0 ? `${Math.round((n / total) * 100)}%` : "—");
+
+// Read-only funnel over the DB (see src/server/activity-metrics.ts).
+// Fetches its own data so the admin page only has to drop it into a
+// section. Best-effort: a failed read renders an inline notice and
+// reports to Sentry rather than throwing, so a metrics hiccup can't take
+// down the rest of the admin page.
+export async function ActivityMetrics() {
+  try {
+    const res = await serverApiClient.api.admin.activity.$get();
+    if (!res.ok) throw new Error(`activity metrics request failed: ${res.status}`);
+    const { metrics } = await res.json();
+    const { members, invites } = metrics;
+
+    const funnel = [
+      { label: "Signed up", value: members.total },
+      { label: "Signed agreements", value: members.signedAgreements },
+      { label: "Set an intention", value: members.setIntention },
+      { label: "Filled out profile", value: members.updatedProfile },
+      { label: "Built their web", value: members.builtWeb },
+      { label: "Joined a program", value: members.joinedProgram },
+    ];
+
+    const inviteRows = [
+      { label: "Created", value: invites.created },
+      { label: "Redeemed", value: invites.redeemed },
+      { label: "Pending", value: invites.pending },
+      { label: "Expired", value: invites.expired },
+      { label: "Revoked", value: invites.revoked },
+    ];
+
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="rounded border border-border">
+          <div className="border-b border-border px-3 py-2 text-sm font-medium">
+            Members{" "}
+            <span className="font-normal text-muted-foreground">
+              · {members.new7d} new this week · {members.new30d} this month
+            </span>
+          </div>
+          <dl className="divide-y divide-border">
+            {funnel.map((row) => (
+              <div key={row.label} className="flex items-baseline justify-between px-3 py-1.5 text-sm">
+                <dt className="text-muted-foreground">{row.label}</dt>
+                <dd className="tabular-nums">
+                  {row.value}
+                  <span className="ml-2 text-xs text-muted-foreground">{pct(row.value, members.total)}</span>
+                </dd>
+              </div>
+            ))}
+          </dl>
+          <div className="border-t border-border px-3 py-2 text-xs text-muted-foreground">
+            Signed in: <span className="tabular-nums text-foreground">{members.signedIn7d}</span> past week ·{" "}
+            <span className="tabular-nums text-foreground">{members.signedIn30d}</span> past month (last full sign-in) ·
+            Deactivated: <span className="tabular-nums text-foreground">{members.deactivated}</span>
+          </div>
+        </div>
+
+        <div className="rounded border border-border">
+          <div className="border-b border-border px-3 py-2 text-sm font-medium">Invites</div>
+          <dl className="divide-y divide-border">
+            {inviteRows.map((row) => (
+              <div key={row.label} className="flex items-baseline justify-between px-3 py-1.5 text-sm">
+                <dt className="text-muted-foreground">{row.label}</dt>
+                <dd className="tabular-nums">{row.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </div>
+    );
+  } catch (err) {
+    Sentry.captureException(err);
+    return <p className="text-sm text-muted-foreground">Activity metrics unavailable.</p>;
+  }
+}

--- a/src/app/admin/activity-metrics.tsx
+++ b/src/app/admin/activity-metrics.tsx
@@ -14,30 +14,13 @@ export async function ActivityMetrics() {
     const res = await serverApiClient.api.admin.activity.$get();
     if (!res.ok) throw new Error(`activity metrics request failed: ${res.status}`);
     const { metrics } = await res.json();
-    const { members, invites, sinceLaunch, launchDate } = metrics;
-
-    const launchLabel = new Date(launchDate).toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
-
-    const sinceRows = [
-      { label: "Signed in", value: sinceLaunch.signedIn },
-      { label: "Signed agreements", value: sinceLaunch.signedAgreements },
-      { label: "Set an intention", value: sinceLaunch.setIntention },
-      { label: "Edited their profile", value: sinceLaunch.editedProfile },
-      { label: "Built their web", value: sinceLaunch.builtWeb },
-      { label: "Joined a program", value: sinceLaunch.joinedProgram },
-      { label: "Invites created", value: sinceLaunch.invitesCreated },
-      { label: "Invites redeemed", value: sinceLaunch.invitesRedeemed },
-    ];
+    const { members, invites } = metrics;
 
     const funnel = [
       { label: "Signed up", value: members.total },
       { label: "Signed agreements", value: members.signedAgreements },
       { label: "Set an intention", value: members.setIntention },
-      { label: "Edited their profile", value: members.updatedProfile },
+      { label: "Filled out profile", value: members.updatedProfile },
       { label: "Built their web", value: members.builtWeb },
       { label: "Joined a program", value: members.joinedProgram },
     ];
@@ -52,25 +35,11 @@ export async function ActivityMetrics() {
 
     return (
       <div className="flex flex-col gap-4">
-        <div className="rounded border border-primary/40 bg-primary/5">
-          <div className="border-b border-border px-3 py-2 text-sm font-medium">
-            Since launch <span className="font-normal text-muted-foreground">· {launchLabel}</span>
-          </div>
-          <dl className="divide-y divide-border">
-            {sinceRows.map((row) => (
-              <div key={row.label} className="flex items-baseline justify-between px-3 py-1.5 text-sm">
-                <dt className="text-muted-foreground">{row.label}</dt>
-                <dd className="tabular-nums">{row.value}</dd>
-              </div>
-            ))}
-          </dl>
-        </div>
-
         <div className="rounded border border-border">
           <div className="border-b border-border px-3 py-2 text-sm font-medium">
             Members{" "}
             <span className="font-normal text-muted-foreground">
-              · {members.new7d} new this week · {members.new30d} this month (all time)
+              · {members.new7d} new this week · {members.new30d} this month
             </span>
           </div>
           <dl className="divide-y divide-border">
@@ -92,7 +61,7 @@ export async function ActivityMetrics() {
         </div>
 
         <div className="rounded border border-border">
-          <div className="border-b border-border px-3 py-2 text-sm font-medium">Invites (all time)</div>
+          <div className="border-b border-border px-3 py-2 text-sm font-medium">Invites</div>
           <dl className="divide-y divide-border">
             {inviteRows.map((row) => (
               <div key={row.label} className="flex items-baseline justify-between px-3 py-1.5 text-sm">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { requireUser, serverApiClient } from "@/lib/api-server";
 
+import { ActivityMetrics } from "./activity-metrics";
 import { AdminHidden } from "./admin-hidden";
 import { AdminHints } from "./admin-hints";
 import { ButtondownSyncButtons } from "./buttondown-sync-buttons";
@@ -25,6 +26,11 @@ export default async function AdminPage() {
         <h1 className="text-2xl font-bold">Admin</h1>
         <BreadcrumbLink fallback="/" />
       </div>
+
+      <section className="flex w-full max-w-xl flex-col gap-2">
+        <h2 className="text-lg font-semibold">Activity metrics</h2>
+        <ActivityMetrics />
+      </section>
 
       <section className="flex w-full max-w-xl flex-col gap-2">
         <h2 className="text-lg font-semibold">App settings</h2>

--- a/src/server/activity-metrics.ts
+++ b/src/server/activity-metrics.ts
@@ -1,0 +1,150 @@
+import { and, count, countDistinct, eq, gt, gte, isNotNull, isNull, lte, type SQL, sql } from "drizzle-orm";
+
+import { db } from "./db";
+import { invites, profilePrograms, profiles, relations } from "./schema";
+
+// Read-only funnel over existing tables — no schema change, no event
+// stream. Answers "how many signed up and how far did they get" from
+// the state the app already records. The DB keeps last-touched, not
+// history, so the sign-in figures are snapshots, not retention curves.
+export type ActivityMetrics = {
+  members: {
+    // member-facing population — `hidden` admin test accounts excluded
+    total: number;
+    new7d: number;
+    new30d: number;
+    deactivated: number;
+    // funnel stages — each is "members who have ever done X"
+    signedAgreements: number;
+    setIntention: number;
+    updatedProfile: number;
+    builtWeb: number;
+    joinedProgram: number;
+    // distinct members who signed in within the window, from
+    // auth.users.last_sign_in_at — last *full* sign-in, not last visit. A
+    // member on a live session refreshes their token without
+    // re-authenticating, so this undercounts the still-logged-in active.
+    signedIn7d: number;
+    signedIn30d: number;
+  };
+  invites: {
+    created: number;
+    redeemed: number;
+    pending: number;
+    expired: number;
+    revoked: number;
+  };
+};
+
+const sevenDaysAgo = sql`now() - interval '7 days'`;
+const thirtyDaysAgo = sql`now() - interval '30 days'`;
+// `hidden` flags admin test accounts; they're invisible everywhere
+// member-facing, so the funnel excludes them too.
+const visible = eq(profiles.hidden, false);
+
+const profileCount = async (extra?: SQL): Promise<number> => {
+  const [row] = await db
+    .select({ c: count() })
+    .from(profiles)
+    .where(extra ? and(visible, extra) : visible);
+  return row?.c ?? 0;
+};
+
+const inviteCount = async (cond?: SQL): Promise<number> => {
+  const query = db.select({ c: count() }).from(invites);
+  const [row] = cond ? await query.where(cond) : await query;
+  return row?.c ?? 0;
+};
+
+// auth.users isn't fully modelled in Drizzle (schema.ts maps id + email
+// only, for FKs), so read last_sign_in_at with raw SQL — the same way
+// test-reset.ts reaches the auth schema. ::int keeps count() off the
+// bigint-as-string path postgres.js takes for int8.
+const signedInWithin = async (days: number): Promise<number> => {
+  const [row] = (await db.execute(sql`
+    SELECT count(DISTINCT u.id)::int AS count
+    FROM auth.users u
+    JOIN public.profiles p ON p.id = u.id
+    WHERE p.hidden = false
+      AND u.last_sign_in_at >= now() - (${days} * interval '1 day')
+  `)) as unknown as { count: number }[];
+  return row?.count ?? 0;
+};
+
+export const getActivityMetrics = async (): Promise<ActivityMetrics> => {
+  const [
+    total,
+    new7d,
+    new30d,
+    deactivated,
+    signedAgreements,
+    setIntention,
+    updatedProfile,
+    builtWeb,
+    joinedProgram,
+    signedIn7d,
+    signedIn30d,
+    invCreated,
+    invRedeemed,
+    invPending,
+    invExpired,
+    invRevoked,
+  ] = await Promise.all([
+    profileCount(),
+    profileCount(gte(profiles.createdAt, sevenDaysAgo)),
+    profileCount(gte(profiles.createdAt, thirtyDaysAgo)),
+    profileCount(isNotNull(profiles.deactivatedAt)),
+    profileCount(isNotNull(profiles.lastSignedAgreements)),
+    profileCount(isNotNull(profiles.currentIntention)),
+    profileCount(isNotNull(profiles.lastUpdatedProfile)),
+    // builtWeb — distinct visible members with ≥1 real (non-hint)
+    // relation. `value IS NOT NULL` is the non-hint marker (a check
+    // constraint ties is_hint to a null value).
+    db
+      .select({ c: countDistinct(relations.relatorId) })
+      .from(relations)
+      .innerJoin(profiles, eq(profiles.id, relations.relatorId))
+      .where(and(visible, isNotNull(relations.value)))
+      .then((rows) => rows[0]?.c ?? 0),
+    // joinedProgram — distinct visible members currently in ≥1 program
+    // (leftAt null means the membership is still active).
+    db
+      .select({ c: countDistinct(profilePrograms.profileId) })
+      .from(profilePrograms)
+      .innerJoin(profiles, eq(profiles.id, profilePrograms.profileId))
+      .where(and(visible, isNull(profilePrograms.leftAt)))
+      .then((rows) => rows[0]?.c ?? 0),
+    signedInWithin(7),
+    signedInWithin(30),
+    inviteCount(),
+    inviteCount(isNotNull(invites.redeemedAt)),
+    // pending / expired / revoked partition the un-redeemed invites; the
+    // pending vs expired split matches countActiveInvitesForCreator in invites.ts.
+    inviteCount(and(isNull(invites.redeemedAt), isNull(invites.revokedAt), gt(invites.expiresAt, sql`now()`))),
+    inviteCount(and(isNull(invites.redeemedAt), isNull(invites.revokedAt), lte(invites.expiresAt, sql`now()`))),
+    inviteCount(and(isNull(invites.redeemedAt), isNotNull(invites.revokedAt))),
+  ]);
+
+  return {
+    members: {
+      total,
+      new7d,
+      new30d,
+      deactivated,
+      signedAgreements,
+      setIntention,
+      updatedProfile,
+      builtWeb,
+      joinedProgram,
+      signedIn7d,
+      signedIn30d,
+    },
+    invites: {
+      created: invCreated,
+      redeemed: invRedeemed,
+      pending: invPending,
+      expired: invExpired,
+      revoked: invRevoked,
+    },
+  };
+};

--- a/src/server/activity-metrics.ts
+++ b/src/server/activity-metrics.ts
@@ -3,19 +3,11 @@ import { and, count, countDistinct, eq, gt, gte, isNotNull, isNull, lte, type SQ
 import { db } from "./db";
 import { invites, profilePrograms, profiles, relations } from "./schema";
 
-// Launch — when the invite went out. The `sinceLaunch` block counts
-// member *activity* (sign-ins, web, invites) from this instant: the
-// existing base responding to the invite, which is what matters at
-// launch, not newly-created accounts. Bump this one constant if the
-// real send moment shifts.
-const LAUNCH_DATE = new Date("2026-06-05T05:19:34Z");
-
 // Read-only funnel over existing tables — no schema change, no event
 // stream. Answers "how many signed up and how far did they get" from
 // the state the app already records. The DB keeps last-touched, not
 // history, so the sign-in figures are snapshots, not retention curves.
 export type ActivityMetrics = {
-  launchDate: string;
   members: {
     // member-facing population — `hidden` admin test accounts excluded
     total: number;
@@ -42,28 +34,13 @@ export type ActivityMetrics = {
     expired: number;
     revoked: number;
   };
-  // Activity since LAUNCH_DATE — each is "members who did X after launch"
-  // (or, for invites, "invites whose create/redeem happened after
-  // launch"), keyed off the relevant action timestamp.
-  sinceLaunch: {
-    signedIn: number;
-    signedAgreements: number;
-    setIntention: number;
-    editedProfile: number;
-    builtWeb: number;
-    joinedProgram: number;
-    invitesCreated: number;
-    invitesRedeemed: number;
-  };
 };
 
+const sevenDaysAgo = sql`now() - interval '7 days'`;
+const thirtyDaysAgo = sql`now() - interval '30 days'`;
 // `hidden` flags admin test accounts; they're invisible everywhere
 // member-facing, so the funnel excludes them too.
 const visible = eq(profiles.hidden, false);
-// A migration can leave currentIntention as "" rather than NULL, so an
-// empty/whitespace value mustn't count as "set". btrim(NULL) is NULL,
-// which also (correctly) fails the comparison.
-const intentionSet = sql`btrim(${profiles.currentIntention}) <> ''`;
 
 const profileCount = async (extra?: SQL): Promise<number> => {
   const [row] = await db
@@ -79,29 +56,17 @@ const inviteCount = async (cond?: SQL): Promise<number> => {
   return row?.c ?? 0;
 };
 
-// Distinct visible members currently in ≥1 program; with `extra` adds a
-// further predicate (e.g. assignedAt since launch).
-const programMemberCount = async (extra?: SQL): Promise<number> => {
-  const [row] = await db
-    .select({ c: countDistinct(profilePrograms.profileId) })
-    .from(profilePrograms)
-    .innerJoin(profiles, eq(profiles.id, profilePrograms.profileId))
-    .where(extra ? and(visible, extra) : visible);
-  return row?.c ?? 0;
-};
-
 // auth.users isn't fully modelled in Drizzle (schema.ts maps id + email
 // only, for FKs), so read last_sign_in_at with raw SQL — the same way
 // test-reset.ts reaches the auth schema. ::int keeps count() off the
-// bigint-as-string path postgres.js takes for int8. `threshold` is an
-// SQL fragment (a relative `now() - interval` or the launch timestamp).
-const signedInCount = async (threshold: SQL): Promise<number> => {
+// bigint-as-string path postgres.js takes for int8.
+const signedInWithin = async (days: number): Promise<number> => {
   const [row] = (await db.execute(sql`
     SELECT count(DISTINCT u.id)::int AS count
     FROM auth.users u
     JOIN public.profiles p ON p.id = u.id
     WHERE p.hidden = false
-      AND u.last_sign_in_at >= ${threshold}
+      AND u.last_sign_in_at >= now() - (${days} * interval '1 day')
   `)) as unknown as { count: number }[];
   return row?.count ?? 0;
 };
@@ -124,22 +89,13 @@ export const getActivityMetrics = async (): Promise<ActivityMetrics> => {
     invPending,
     invExpired,
     invRevoked,
-    slSignedIn,
-    slSignedAgreements,
-    slSetIntention,
-    slEditedProfile,
-    slBuiltWeb,
-    slJoinedProgram,
-    slInvitesCreated,
-    slInvitesRedeemed,
   ] = await Promise.all([
-    // ---- all-time members ----
     profileCount(),
-    profileCount(gte(profiles.createdAt, sql`now() - interval '7 days'`)),
-    profileCount(gte(profiles.createdAt, sql`now() - interval '30 days'`)),
+    profileCount(gte(profiles.createdAt, sevenDaysAgo)),
+    profileCount(gte(profiles.createdAt, thirtyDaysAgo)),
     profileCount(isNotNull(profiles.deactivatedAt)),
     profileCount(isNotNull(profiles.lastSignedAgreements)),
-    profileCount(intentionSet),
+    profileCount(isNotNull(profiles.currentIntention)),
     profileCount(isNotNull(profiles.lastUpdatedProfile)),
     // builtWeb — distinct visible members with ≥1 real (non-hint)
     // relation. `value IS NOT NULL` is the non-hint marker (a check
@@ -150,10 +106,16 @@ export const getActivityMetrics = async (): Promise<ActivityMetrics> => {
       .innerJoin(profiles, eq(profiles.id, relations.relatorId))
       .where(and(visible, isNotNull(relations.value)))
       .then((rows) => rows[0]?.c ?? 0),
-    programMemberCount(isNull(profilePrograms.leftAt)),
-    signedInCount(sql`now() - interval '7 days'`),
-    signedInCount(sql`now() - interval '30 days'`),
-    // ---- all-time invites ----
+    // joinedProgram — distinct visible members currently in ≥1 program
+    // (leftAt null means the membership is still active).
+    db
+      .select({ c: countDistinct(profilePrograms.profileId) })
+      .from(profilePrograms)
+      .innerJoin(profiles, eq(profiles.id, profilePrograms.profileId))
+      .where(and(visible, isNull(profilePrograms.leftAt)))
+      .then((rows) => rows[0]?.c ?? 0),
+    signedInWithin(7),
+    signedInWithin(30),
     inviteCount(),
     inviteCount(isNotNull(invites.redeemedAt)),
     // pending / expired / revoked partition the un-redeemed invites; the
@@ -161,22 +123,9 @@ export const getActivityMetrics = async (): Promise<ActivityMetrics> => {
     inviteCount(and(isNull(invites.redeemedAt), isNull(invites.revokedAt), gt(invites.expiresAt, sql`now()`))),
     inviteCount(and(isNull(invites.redeemedAt), isNull(invites.revokedAt), lte(invites.expiresAt, sql`now()`))),
     inviteCount(and(isNull(invites.redeemedAt), isNotNull(invites.revokedAt))),
-    // ---- since launch (activity, not signups) ----
-    // Bind the launch instant as an ISO string + explicit cast: a raw JS
-    // Date param fails postgres-js's bind path (the typed query builder
-    // serializes Dates for us, but db.execute doesn't).
-    signedInCount(sql`${LAUNCH_DATE.toISOString()}::timestamptz`),
-    profileCount(gte(profiles.lastSignedAgreements, LAUNCH_DATE)),
-    profileCount(and(intentionSet, gte(profiles.intentionUpdatedAt, LAUNCH_DATE))),
-    profileCount(gte(profiles.lastUpdatedProfile, LAUNCH_DATE)),
-    profileCount(gte(profiles.lastUpdatedWeb, LAUNCH_DATE)),
-    programMemberCount(gte(profilePrograms.assignedAt, LAUNCH_DATE)),
-    inviteCount(gte(invites.createdAt, LAUNCH_DATE)),
-    inviteCount(gte(invites.redeemedAt, LAUNCH_DATE)),
   ]);
 
   return {
-    launchDate: LAUNCH_DATE.toISOString(),
     members: {
       total,
       new7d,
@@ -196,16 +145,6 @@ export const getActivityMetrics = async (): Promise<ActivityMetrics> => {
       pending: invPending,
       expired: invExpired,
       revoked: invRevoked,
-    },
-    sinceLaunch: {
-      signedIn: slSignedIn,
-      signedAgreements: slSignedAgreements,
-      setIntention: slSetIntention,
-      editedProfile: slEditedProfile,
-      builtWeb: slBuiltWeb,
-      joinedProgram: slJoinedProgram,
-      invitesCreated: slInvitesCreated,
-      invitesRedeemed: slInvitesRedeemed,
     },
   };
 };

--- a/src/server/activity-metrics.ts
+++ b/src/server/activity-metrics.ts
@@ -3,11 +3,19 @@ import { and, count, countDistinct, eq, gt, gte, isNotNull, isNull, lte, type SQ
 import { db } from "./db";
 import { invites, profilePrograms, profiles, relations } from "./schema";
 
+// Launch — when the invite went out. The `sinceLaunch` block counts
+// member *activity* (sign-ins, web, invites) from this instant: the
+// existing base responding to the invite, which is what matters at
+// launch, not newly-created accounts. Bump this one constant if the
+// real send moment shifts.
+const LAUNCH_DATE = new Date("2026-06-05T05:19:34Z");
+
 // Read-only funnel over existing tables — no schema change, no event
 // stream. Answers "how many signed up and how far did they get" from
 // the state the app already records. The DB keeps last-touched, not
 // history, so the sign-in figures are snapshots, not retention curves.
 export type ActivityMetrics = {
+  launchDate: string;
   members: {
     // member-facing population — `hidden` admin test accounts excluded
     total: number;
@@ -34,13 +42,28 @@ export type ActivityMetrics = {
     expired: number;
     revoked: number;
   };
+  // Activity since LAUNCH_DATE — each is "members who did X after launch"
+  // (or, for invites, "invites whose create/redeem happened after
+  // launch"), keyed off the relevant action timestamp.
+  sinceLaunch: {
+    signedIn: number;
+    signedAgreements: number;
+    setIntention: number;
+    editedProfile: number;
+    builtWeb: number;
+    joinedProgram: number;
+    invitesCreated: number;
+    invitesRedeemed: number;
+  };
 };
 
-const sevenDaysAgo = sql`now() - interval '7 days'`;
-const thirtyDaysAgo = sql`now() - interval '30 days'`;
 // `hidden` flags admin test accounts; they're invisible everywhere
 // member-facing, so the funnel excludes them too.
 const visible = eq(profiles.hidden, false);
+// A migration can leave currentIntention as "" rather than NULL, so an
+// empty/whitespace value mustn't count as "set". btrim(NULL) is NULL,
+// which also (correctly) fails the comparison.
+const intentionSet = sql`btrim(${profiles.currentIntention}) <> ''`;
 
 const profileCount = async (extra?: SQL): Promise<number> => {
   const [row] = await db
@@ -56,17 +79,29 @@ const inviteCount = async (cond?: SQL): Promise<number> => {
   return row?.c ?? 0;
 };
 
+// Distinct visible members currently in ≥1 program; with `extra` adds a
+// further predicate (e.g. assignedAt since launch).
+const programMemberCount = async (extra?: SQL): Promise<number> => {
+  const [row] = await db
+    .select({ c: countDistinct(profilePrograms.profileId) })
+    .from(profilePrograms)
+    .innerJoin(profiles, eq(profiles.id, profilePrograms.profileId))
+    .where(extra ? and(visible, extra) : visible);
+  return row?.c ?? 0;
+};
+
 // auth.users isn't fully modelled in Drizzle (schema.ts maps id + email
 // only, for FKs), so read last_sign_in_at with raw SQL — the same way
 // test-reset.ts reaches the auth schema. ::int keeps count() off the
-// bigint-as-string path postgres.js takes for int8.
-const signedInWithin = async (days: number): Promise<number> => {
+// bigint-as-string path postgres.js takes for int8. `threshold` is an
+// SQL fragment (a relative `now() - interval` or the launch timestamp).
+const signedInCount = async (threshold: SQL): Promise<number> => {
   const [row] = (await db.execute(sql`
     SELECT count(DISTINCT u.id)::int AS count
     FROM auth.users u
     JOIN public.profiles p ON p.id = u.id
     WHERE p.hidden = false
-      AND u.last_sign_in_at >= now() - (${days} * interval '1 day')
+      AND u.last_sign_in_at >= ${threshold}
   `)) as unknown as { count: number }[];
   return row?.count ?? 0;
 };
@@ -89,13 +124,22 @@ export const getActivityMetrics = async (): Promise<ActivityMetrics> => {
     invPending,
     invExpired,
     invRevoked,
+    slSignedIn,
+    slSignedAgreements,
+    slSetIntention,
+    slEditedProfile,
+    slBuiltWeb,
+    slJoinedProgram,
+    slInvitesCreated,
+    slInvitesRedeemed,
   ] = await Promise.all([
+    // ---- all-time members ----
     profileCount(),
-    profileCount(gte(profiles.createdAt, sevenDaysAgo)),
-    profileCount(gte(profiles.createdAt, thirtyDaysAgo)),
+    profileCount(gte(profiles.createdAt, sql`now() - interval '7 days'`)),
+    profileCount(gte(profiles.createdAt, sql`now() - interval '30 days'`)),
     profileCount(isNotNull(profiles.deactivatedAt)),
     profileCount(isNotNull(profiles.lastSignedAgreements)),
-    profileCount(isNotNull(profiles.currentIntention)),
+    profileCount(intentionSet),
     profileCount(isNotNull(profiles.lastUpdatedProfile)),
     // builtWeb — distinct visible members with ≥1 real (non-hint)
     // relation. `value IS NOT NULL` is the non-hint marker (a check
@@ -106,16 +150,10 @@ export const getActivityMetrics = async (): Promise<ActivityMetrics> => {
       .innerJoin(profiles, eq(profiles.id, relations.relatorId))
       .where(and(visible, isNotNull(relations.value)))
       .then((rows) => rows[0]?.c ?? 0),
-    // joinedProgram — distinct visible members currently in ≥1 program
-    // (leftAt null means the membership is still active).
-    db
-      .select({ c: countDistinct(profilePrograms.profileId) })
-      .from(profilePrograms)
-      .innerJoin(profiles, eq(profiles.id, profilePrograms.profileId))
-      .where(and(visible, isNull(profilePrograms.leftAt)))
-      .then((rows) => rows[0]?.c ?? 0),
-    signedInWithin(7),
-    signedInWithin(30),
+    programMemberCount(isNull(profilePrograms.leftAt)),
+    signedInCount(sql`now() - interval '7 days'`),
+    signedInCount(sql`now() - interval '30 days'`),
+    // ---- all-time invites ----
     inviteCount(),
     inviteCount(isNotNull(invites.redeemedAt)),
     // pending / expired / revoked partition the un-redeemed invites; the
@@ -123,9 +161,22 @@ export const getActivityMetrics = async (): Promise<ActivityMetrics> => {
     inviteCount(and(isNull(invites.redeemedAt), isNull(invites.revokedAt), gt(invites.expiresAt, sql`now()`))),
     inviteCount(and(isNull(invites.redeemedAt), isNull(invites.revokedAt), lte(invites.expiresAt, sql`now()`))),
     inviteCount(and(isNull(invites.redeemedAt), isNotNull(invites.revokedAt))),
+    // ---- since launch (activity, not signups) ----
+    // Bind the launch instant as an ISO string + explicit cast: a raw JS
+    // Date param fails postgres-js's bind path (the typed query builder
+    // serializes Dates for us, but db.execute doesn't).
+    signedInCount(sql`${LAUNCH_DATE.toISOString()}::timestamptz`),
+    profileCount(gte(profiles.lastSignedAgreements, LAUNCH_DATE)),
+    profileCount(and(intentionSet, gte(profiles.intentionUpdatedAt, LAUNCH_DATE))),
+    profileCount(gte(profiles.lastUpdatedProfile, LAUNCH_DATE)),
+    profileCount(gte(profiles.lastUpdatedWeb, LAUNCH_DATE)),
+    programMemberCount(gte(profilePrograms.assignedAt, LAUNCH_DATE)),
+    inviteCount(gte(invites.createdAt, LAUNCH_DATE)),
+    inviteCount(gte(invites.redeemedAt, LAUNCH_DATE)),
   ]);
 
   return {
+    launchDate: LAUNCH_DATE.toISOString(),
     members: {
       total,
       new7d,
@@ -145,6 +196,16 @@ export const getActivityMetrics = async (): Promise<ActivityMetrics> => {
       pending: invPending,
       expired: invExpired,
       revoked: invRevoked,
+    },
+    sinceLaunch: {
+      signedIn: slSignedIn,
+      signedAgreements: slSignedAgreements,
+      setIntention: slSetIntention,
+      editedProfile: slEditedProfile,
+      builtWeb: slBuiltWeb,
+      joinedProgram: slJoinedProgram,
+      invitesCreated: slInvitesCreated,
+      invitesRedeemed: slInvitesRedeemed,
     },
   };
 };

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,3 +1,4 @@
+import type { User } from "@supabase/supabase-js";
 import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
@@ -5,6 +6,7 @@ import { log } from "next-axiom";
 
 import { isRelationValue } from "@/lib/relation-value";
 
+import { getActivityMetrics } from "./activity-metrics";
 import { getAppSettings } from "./app-settings";
 import { type ApiVariables, isAdmin, isUuid, requireAdmin, requireAuth } from "./auth-middleware";
 import { clearAvatar, encodeAvatar, MAX_AVATAR_UPLOAD_BYTES, replaceAvatar } from "./avatars";
@@ -73,6 +75,10 @@ const adminRoutes = new Hono<{ Variables: ApiVariables }>()
   .get("/appsettings", async (c) => {
     const appSettings = await getAppSettings();
     return c.json({ appSettings });
+  })
+  .get("/activity", async (c) => {
+    const metrics = await getActivityMetrics();
+    return c.json({ metrics });
   })
   .get("/hints", async (c) => {
     const hints = await listPendingHints();
@@ -257,6 +263,11 @@ const api = new Hono<{ Variables: ApiVariables }>()
       path: c.req.path,
       status: c.res.status,
       duration,
+      // The auth UUID (pseudonymous, never the email) so Axiom can count
+      // distinct people and per-path adoption. Unset on public/401 paths
+      // — this middleware logs after requireAuth runs but also fires for
+      // requests it never authenticates. See docs/doc-axiom.md.
+      userId: (c.get("user") as User | undefined)?.id ?? null,
     });
   })
   .use("*", requireAuth)

--- a/tests/functional/server/activity-metrics.test.ts
+++ b/tests/functional/server/activity-metrics.test.ts
@@ -50,7 +50,6 @@ const deleteUserAndProfile = async (id: string) => {
 };
 
 type ActivityMetrics = {
-  launchDate: string;
   members: {
     total: number;
     new7d: number;
@@ -65,16 +64,6 @@ type ActivityMetrics = {
     signedIn30d: number;
   };
   invites: { created: number; redeemed: number; pending: number; expired: number; revoked: number };
-  sinceLaunch: {
-    signedIn: number;
-    signedAgreements: number;
-    setIntention: number;
-    editedProfile: number;
-    builtWeb: number;
-    joinedProgram: number;
-    invitesCreated: number;
-    invitesRedeemed: number;
-  };
 };
 
 const fetchMetrics = async (): Promise<ActivityMetrics> => {
@@ -117,8 +106,6 @@ describe("GET /api/admin/activity", () => {
     const m = await fetchMetrics();
     for (const v of Object.values(m.members)) expect(typeof v).toBe("number");
     for (const v of Object.values(m.invites)) expect(typeof v).toBe("number");
-    for (const v of Object.values(m.sinceLaunch)) expect(typeof v).toBe("number");
-    expect(typeof m.launchDate).toBe("string");
   });
 
   it("counts a seeded member's progress in the right buckets", async () => {
@@ -135,13 +122,7 @@ describe("GET /api/admin/activity", () => {
     await insertUserAndProfile(relatee, { hidden: true });
     await db
       .update(profiles)
-      .set({
-        lastSignedAgreements: new Date(),
-        currentIntention: "be present",
-        intentionUpdatedAt: new Date(),
-        lastUpdatedProfile: new Date(),
-        lastUpdatedWeb: new Date(),
-      })
+      .set({ lastSignedAgreements: new Date(), currentIntention: "be present", lastUpdatedProfile: new Date() })
       .where(eq(profiles.id, member));
     await db.execute(sql`UPDATE auth.users SET last_sign_in_at = now() WHERE id = ${member}::uuid`);
     await db.insert(programs).values({ id: programId, slug: `prog-${programId}`, name: "Test Program" });
@@ -177,17 +158,6 @@ describe("GET /api/admin/activity", () => {
     expect(m.invites.created).toBeGreaterThanOrEqual(2);
     expect(m.invites.redeemed).toBeGreaterThanOrEqual(1);
     expect(m.invites.pending).toBeGreaterThanOrEqual(1);
-
-    // The cohort's actions are stamped now(), which is after the (earlier,
-    // fixed) LAUNCH_DATE constant, so each registers in the since-launch block.
-    expect(m.sinceLaunch.signedIn).toBeGreaterThanOrEqual(1);
-    expect(m.sinceLaunch.signedAgreements).toBeGreaterThanOrEqual(1);
-    expect(m.sinceLaunch.setIntention).toBeGreaterThanOrEqual(1);
-    expect(m.sinceLaunch.editedProfile).toBeGreaterThanOrEqual(1);
-    expect(m.sinceLaunch.builtWeb).toBeGreaterThanOrEqual(1);
-    expect(m.sinceLaunch.joinedProgram).toBeGreaterThanOrEqual(1);
-    expect(m.sinceLaunch.invitesCreated).toBeGreaterThanOrEqual(2);
-    expect(m.sinceLaunch.invitesRedeemed).toBeGreaterThanOrEqual(1);
 
     await db.delete(invites).where(sql`${invites.id} IN (${inviteRedeemed}::uuid, ${invitePending}::uuid)`);
     await db.delete(relations).where(eq(relations.relatorId, member));

--- a/tests/functional/server/activity-metrics.test.ts
+++ b/tests/functional/server/activity-metrics.test.ts
@@ -1,0 +1,169 @@
+import { randomUUID } from "node:crypto";
+import type { User } from "@supabase/supabase-js";
+import { eq, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+import { createServerClient } from "@supabase/ssr";
+
+import app from "@/server/api";
+import { db } from "@/server/db";
+import { invites, profilePrograms, profiles, programs, relations } from "@/server/schema";
+
+const mockCreateServerClient = vi.mocked(createServerClient);
+
+const fakeUser = (id: string): User =>
+  ({
+    id,
+    email: `${id}@testfake.local`,
+    user_metadata: {},
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+  }) as User;
+
+const authAs = (userId: string | null) => {
+  mockCreateServerClient.mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? fakeUser(userId) : null },
+        error: null,
+      }),
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test mock shape
+  } as any);
+};
+
+const insertUserAndProfile = async (id: string, opts: { isAdmin?: boolean; hidden?: boolean } = {}) => {
+  await db.execute(
+    sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${id}::uuid, ${`${id}@testfake.local`}, false, false)`,
+  );
+  await db.insert(profiles).values({ id, isAdmin: opts.isAdmin ?? false, hidden: opts.hidden ?? false });
+};
+
+const deleteUserAndProfile = async (id: string) => {
+  await db.delete(profiles).where(eq(profiles.id, id));
+  await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+};
+
+type ActivityMetrics = {
+  members: {
+    total: number;
+    new7d: number;
+    new30d: number;
+    deactivated: number;
+    signedAgreements: number;
+    setIntention: number;
+    updatedProfile: number;
+    builtWeb: number;
+    joinedProgram: number;
+    signedIn7d: number;
+    signedIn30d: number;
+  };
+  invites: { created: number; redeemed: number; pending: number; expired: number; revoked: number };
+};
+
+const fetchMetrics = async (): Promise<ActivityMetrics> => {
+  const res = await app.request("/api/admin/activity");
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { metrics: ActivityMetrics }).metrics;
+};
+
+describe("GET /api/admin/activity", () => {
+  let admin: string;
+  let nonAdmin: string;
+
+  beforeEach(async () => {
+    admin = randomUUID();
+    nonAdmin = randomUUID();
+    await insertUserAndProfile(admin, { isAdmin: true });
+    await insertUserAndProfile(nonAdmin);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(admin);
+    await deleteUserAndProfile(nonAdmin);
+  });
+
+  it("returns 404 for an authenticated non-admin", async () => {
+    authAs(nonAdmin);
+    const res = await app.request("/api/admin/activity");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 when no session is present", async () => {
+    authAs(null);
+    const res = await app.request("/api/admin/activity");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns a numeric value for every bucket", async () => {
+    authAs(admin);
+    const m = await fetchMetrics();
+    for (const v of Object.values(m.members)) expect(typeof v).toBe("number");
+    for (const v of Object.values(m.invites)) expect(typeof v).toBe("number");
+  });
+
+  it("counts a seeded member's progress in the right buckets", async () => {
+    // Counts are global and the local DB is shared across parallel test
+    // files, so exact totals are unstable. Seed a known cohort and assert
+    // each bucket is at least our contribution — that catches a column or
+    // table wired to the wrong source (the bug class here) without racing
+    // other files' inserts and deletes.
+    const member = randomUUID();
+    const relatee = randomUUID();
+    const programId = randomUUID();
+    await insertUserAndProfile(member);
+    // hidden so it also exercises the visible-only filter on builtWeb's relatee join
+    await insertUserAndProfile(relatee, { hidden: true });
+    await db
+      .update(profiles)
+      .set({ lastSignedAgreements: new Date(), currentIntention: "be present", lastUpdatedProfile: new Date() })
+      .where(eq(profiles.id, member));
+    await db.execute(sql`UPDATE auth.users SET last_sign_in_at = now() WHERE id = ${member}::uuid`);
+    await db.insert(programs).values({ id: programId, slug: `prog-${programId}`, name: "Test Program" });
+    await db.insert(profilePrograms).values({ profileId: member, programId });
+    await db.insert(relations).values({ relatorId: member, relateeId: relatee, value: 3, isHint: false });
+
+    const inviteRedeemed = randomUUID();
+    const invitePending = randomUUID();
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    await db.insert(invites).values([
+      {
+        id: inviteRedeemed,
+        code: `r-${inviteRedeemed}`,
+        note: "redeemed invite",
+        expiresAt: tomorrow,
+        redeemedBy: member,
+        redeemedAt: new Date(),
+      },
+      { id: invitePending, code: `p-${invitePending}`, note: "pending invite", expiresAt: tomorrow },
+    ]);
+
+    authAs(admin);
+    const m = await fetchMetrics();
+    expect(m.members.total).toBeGreaterThanOrEqual(1);
+    expect(m.members.new7d).toBeGreaterThanOrEqual(1);
+    expect(m.members.signedAgreements).toBeGreaterThanOrEqual(1);
+    expect(m.members.setIntention).toBeGreaterThanOrEqual(1);
+    expect(m.members.updatedProfile).toBeGreaterThanOrEqual(1);
+    expect(m.members.builtWeb).toBeGreaterThanOrEqual(1);
+    expect(m.members.joinedProgram).toBeGreaterThanOrEqual(1);
+    expect(m.members.signedIn7d).toBeGreaterThanOrEqual(1);
+    expect(m.members.signedIn30d).toBeGreaterThanOrEqual(1);
+    expect(m.invites.created).toBeGreaterThanOrEqual(2);
+    expect(m.invites.redeemed).toBeGreaterThanOrEqual(1);
+    expect(m.invites.pending).toBeGreaterThanOrEqual(1);
+
+    await db.delete(invites).where(sql`${invites.id} IN (${inviteRedeemed}::uuid, ${invitePending}::uuid)`);
+    await db.delete(relations).where(eq(relations.relatorId, member));
+    await db.delete(profilePrograms).where(eq(profilePrograms.profileId, member));
+    await db.delete(programs).where(eq(programs.id, programId));
+    await deleteUserAndProfile(member);
+    await deleteUserAndProfile(relatee);
+  });
+});

--- a/tests/functional/server/activity-metrics.test.ts
+++ b/tests/functional/server/activity-metrics.test.ts
@@ -50,6 +50,7 @@ const deleteUserAndProfile = async (id: string) => {
 };
 
 type ActivityMetrics = {
+  launchDate: string;
   members: {
     total: number;
     new7d: number;
@@ -64,6 +65,16 @@ type ActivityMetrics = {
     signedIn30d: number;
   };
   invites: { created: number; redeemed: number; pending: number; expired: number; revoked: number };
+  sinceLaunch: {
+    signedIn: number;
+    signedAgreements: number;
+    setIntention: number;
+    editedProfile: number;
+    builtWeb: number;
+    joinedProgram: number;
+    invitesCreated: number;
+    invitesRedeemed: number;
+  };
 };
 
 const fetchMetrics = async (): Promise<ActivityMetrics> => {
@@ -106,6 +117,8 @@ describe("GET /api/admin/activity", () => {
     const m = await fetchMetrics();
     for (const v of Object.values(m.members)) expect(typeof v).toBe("number");
     for (const v of Object.values(m.invites)) expect(typeof v).toBe("number");
+    for (const v of Object.values(m.sinceLaunch)) expect(typeof v).toBe("number");
+    expect(typeof m.launchDate).toBe("string");
   });
 
   it("counts a seeded member's progress in the right buckets", async () => {
@@ -122,7 +135,13 @@ describe("GET /api/admin/activity", () => {
     await insertUserAndProfile(relatee, { hidden: true });
     await db
       .update(profiles)
-      .set({ lastSignedAgreements: new Date(), currentIntention: "be present", lastUpdatedProfile: new Date() })
+      .set({
+        lastSignedAgreements: new Date(),
+        currentIntention: "be present",
+        intentionUpdatedAt: new Date(),
+        lastUpdatedProfile: new Date(),
+        lastUpdatedWeb: new Date(),
+      })
       .where(eq(profiles.id, member));
     await db.execute(sql`UPDATE auth.users SET last_sign_in_at = now() WHERE id = ${member}::uuid`);
     await db.insert(programs).values({ id: programId, slug: `prog-${programId}`, name: "Test Program" });
@@ -158,6 +177,17 @@ describe("GET /api/admin/activity", () => {
     expect(m.invites.created).toBeGreaterThanOrEqual(2);
     expect(m.invites.redeemed).toBeGreaterThanOrEqual(1);
     expect(m.invites.pending).toBeGreaterThanOrEqual(1);
+
+    // The cohort's actions are stamped now(), which is after the (earlier,
+    // fixed) LAUNCH_DATE constant, so each registers in the since-launch block.
+    expect(m.sinceLaunch.signedIn).toBeGreaterThanOrEqual(1);
+    expect(m.sinceLaunch.signedAgreements).toBeGreaterThanOrEqual(1);
+    expect(m.sinceLaunch.setIntention).toBeGreaterThanOrEqual(1);
+    expect(m.sinceLaunch.editedProfile).toBeGreaterThanOrEqual(1);
+    expect(m.sinceLaunch.builtWeb).toBeGreaterThanOrEqual(1);
+    expect(m.sinceLaunch.joinedProgram).toBeGreaterThanOrEqual(1);
+    expect(m.sinceLaunch.invitesCreated).toBeGreaterThanOrEqual(2);
+    expect(m.sinceLaunch.invitesRedeemed).toBeGreaterThanOrEqual(1);
 
     await db.delete(invites).where(sql`${invites.id} IN (${inviteRedeemed}::uuid, ${invitePending}::uuid)`);
     await db.delete(relations).where(eq(relations.relatorId, member));


### PR DESCRIPTION
## What & why

Before the launch invite goes out, this adds the instrumentation to answer "how many people try this, and how far do they get?" — without standing up a new analytics vendor.

### 1. Per-user request logging
`src/server/api.ts` adds a `userId` field to the `api request` log line — the pseudonymous Supabase auth UUID, `null` on public/401 paths, never the email. This lets Axiom count distinct people and per-path adoption, which the request shape alone couldn't.

### 2. Admin "Activity metrics" view
A read-only funnel at the top of `/admin`, sourced from current DB state (no schema change, no migration):
- **Members:** signed up → signed agreements → set intention → filled profile → built web → joined a program, each with % of total; plus new-this-week/month.
- **Sign-ins:** distinct members signed in past week / month, from `auth.users.last_sign_in_at` (read via raw SQL — that column isn't modelled in Drizzle, only `id`/`email` for FKs).
- **Invites:** created / redeemed / pending / expired / revoked.

The metrics section is fault-isolated: a read failure renders an inline notice and reports to Sentry instead of taking down the rest of the admin page.

## Notes / decisions
- **Logging the auth UUID** is a deliberate call — pseudonymous, never email/cookies, consistent with the Sentry PII stance. Approved.
- **Sign-in counts are a snapshot, not retention.** `last_sign_in_at` is the last *full* sign-in, not the last visit (a live session refreshes its token without re-authenticating), so it undercounts the still-logged-in active. True day-N retention would want a real event stream — deliberately deferred.
- No schema change, so no expand-contract / `prod:db:expand` step needed.

## Testing
- `npm test` green locally: lint, typecheck, 364 functional, 28 e2e.
- New functional test covers admin gating (404/401), response shape, and a seeded-cohort funnel check (lower-bound assertions, since the local DB is shared across parallel test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
