### PR TITLE
feat(relations): add "No Relationship" remove option (#352)

### DIFF
--- a/docs/design-relations.md
+++ b/docs/design-relations.md
@@ -40,7 +40,7 @@ A single value from a small set captures both "visible trust" and resonance, wit
 - `3` — **Close Friend**: I really confide in, count on, or collaborate with them more than most of my friends.
 - `4` — **Kin**: Among the rare few who feel like chosen family or co-founders — soul-level kinship that may last a lifetime.
 
-The absence of a relation is an absence of a row. There is no explicit "0 / no connection of interest" rating — un-rated suggestions simply re-surface in future feeds, and at MVP scale (50–100 members) that's a non-problem. A future "intentional dissonance" value (`-1`) is also deferred — the social cost of publicly logged negative feelings wants more design care than we have lived experience to provide right now.
+The absence of a relation is an absence of a row. There is no explicit "0 / no connection of interest" value — un-rated suggestions simply re-surface in future feeds, and at MVP scale (50–100 members) that's a non-problem. A future "intentional dissonance" value (`-1`) is also deferred — the social cost of publicly logged negative feelings wants more design care than we have lived experience to provide right now.
 
 ## Data model
 
@@ -91,10 +91,10 @@ export const relations = pgTable(
 
 Two valid row states:
 
-- **Confirmed rating.** `value` ∈ 1..4, `isHint = false`. `hintedBy` may or may not be set (preserving the trail of who originally seeded it, even after confirmation).
+- **Confirmed relationship.** `value` ∈ 1..4, `isHint = false`. `hintedBy` may or may not be set (preserving the trail of who originally seeded it, even after confirmation).
 - **Pending hint.** `value` IS NULL, `isHint = true`. `hintedBy` is set on creation (the API requires it), but the FK is `onDelete: set null` so a hint can become anonymous if the hinter's profile is deleted. The check constraint accepts `hintedBy IS NULL` to make this safe.
 
-A hint becomes a confirmed rating by setting `value` and flipping `isHint` to false.
+A hint becomes a confirmed relationship by setting `value` and flipping `isHint` to false.
 
 Sparse representation: there is no row for "haven't been shown" or "haven't acted" — that state is `(no row in relations)`. Cost: no "deferred / ask me later" affordance — at 50–100 members the suggestion pool is small enough that simply re-surfacing un-rated suggestions each visit is fine. Revisit if the feed gets noisy.
 
@@ -146,7 +146,7 @@ relationValue: integer("creator_value"), // 1..4 if set; null allowed for admin-
 
 Plus a check constraint `invites_creator_value_range` enforcing `creator_value IS NULL OR creator_value BETWEEN 1 AND 4`.
 
-The inviter declares their relation to the invitee at invite-creation time, immediately after the "who is this?" input. The picker offers 1–4 (the same vocabulary as the rating dialog). A soft warn at 1 nudges the inviter to reconsider: weak-tie invites tend to make for weak community fit, and we'd rather members invite people they actually have a relation with. Admin-issued invites may leave the value null.
+The inviter declares their relation to the invitee at invite-creation time, immediately after the "who is this?" input. The picker offers 1–4 (the same vocabulary as the relating dialog). A soft warn at 1 nudges the inviter to reconsider: weak-tie invites tend to make for weak community fit, and we'd rather members invite people they actually have a relation with. Admin-issued invites may leave the value null.
 
 On invite redemption, if `relationValue IS NOT NULL`, materialize a `relations` row: `relatorId = invites.createdBy`, `relateeId = invites.redeemedBy`, `value = invites.relationValue`, `isHint = false`, `hintedBy = null`. The new member opens the app and finds their inviter at the top of the suggestion feed via the "people who've rated me" signal — the warmest possible first interaction.
 
@@ -171,14 +171,14 @@ The "welcome page" expands into a guided multi-step tour. Steps land on real app
 
 1. **Welcome.** Brief framing of IS Web and what the next ~2 minutes will set up.
 2. **Profile.** Edit the standard profile fields.
-3. **Relations: meet your suggestions.** The suggestion feed renders, pre-populated. The inviter sits at the top — their relation to the new member was materialized from `invites.creator_value` at redemption, so they show up as the strongest "people who've rated me" signal. Below them, the invite's hint rows. New suggestions appear as ratings happen (the inviter's high-rated connections, anyone else who has already rated the new member).
+3. **Relations: meet your suggestions.** The suggestion feed renders, pre-populated. The inviter sits at the top — their relation to the new member was materialized from `invites.creator_value` at redemption, so they show up as the strongest "people who've rated me" signal. Below them, the invite's hint rows. New suggestions appear as relationships form (the inviter's high-rated connections, anyone else who has already rated the new member).
 4. **See your web.** Personal subgraph view — the user themselves at center, their newly rated connections at one hop. The Done button transitions from edit to view mode and bumps `last_updated_web`.
 
 ### Edit mode ↔ View mode
 
 The personal subgraph is always displayed, regardless of mode — the web is the page, not a tab. Mode toggles only what surfaces around it:
 
-- **Edit mode.** Suggestion feed visible below the graph (single column on mobile, grid on desktop). Cards are clickable to open the rating dialog. Edits persist in real time, and the graph re-renders optimistically as ratings happen.
+- **Edit mode.** Suggestion feed visible below the graph (single column on mobile, grid on desktop). Cards are clickable to open the relating dialog. Edits persist in real time, and the graph re-renders optimistically as relationships form.
 - **View mode.** Suggestion feed hidden. The graph is the only content, oriented toward exploration and reading.
 
 The toggle is a paired **Edit** / **Done** button — Edit in view mode, Done in edit mode. **Done** has one side effect: bumping `last_updated_web` on the user's profile — a signal of "I'm done updating for now," used by other members' "recently active" suggestion signal. Real-time persistence means no batched save is happening; the button captures intent, not state. Members can re-enter edit mode any time.
@@ -195,21 +195,22 @@ Surfaced in approximate priority order. At MVP scale (50–100 members), simpler
 
 Sources 1–4 carry an explicit "reason" surfaced in the UI (`addedYou` / `hintedBy <name>` / `via <inviter>` / `recently active`) — a sub-line that grounds the suggestion in something legible. Source 5 has no derived signal and renders without a reason chip.
 
-The asymmetry-visibility ethos: when someone shows up because they rated me, I don't see their rating before responding. This is a soft UI hiding, not a hard constraint, and I see their rating on the completed two-way relation.
+The asymmetry-visibility ethos: when someone shows up because they rated me, I don't see their value before responding. This is a soft UI hiding, not a hard constraint, and I see their value on the completed two-way relation.
 
 The feed renders as a single section titled **"Add people to your relational web"** — sources 1–4 (each marked with the corner indicator that opens the reason on hover) come first, followed by source 5. The indicator is enough to distinguish signal-bearing cards from directory cards without a section break.
 
-### Rating a suggestion
+### Relating to a suggestion
 
 Clicking a suggestion card opens a small modal:
 
-- A vertical column of four buttons labeled **1**, **2**, **3**, **4**, each next to its vocabulary description. Clicking a button sets the rating and closes the dialog — no separate Save step.
-- Numeric keystrokes 1–4 are caught as a backup shortcut, equivalent to clicking the matching button.
+- A vertical column of four buttons labeled **1**, **2**, **3**, **4**, each next to its vocabulary description. Clicking a button sets the relationship and closes the dialog — no separate Save step.
+- Numeric keystrokes 1–4 are caught as a backup shortcut, equivalent to clicking the matching button (plus `0` when the remove option below is present).
+- **Removing a mistaken relationship (#352).** When the dialog opens on a relationship that already exists — an edge click in the graph, or **Edit** on a member's profile — a **0 — No Relationship** option appears above 1–4, described "Remove this relationship from my web." Selecting it deletes the `relations` row (relator = me, `isHint = false`) and closes the dialog, instant like the 1–4 buttons and undone by simply relating again. Absence of a relationship stays absence of a row: nothing stores a `0`. The option is hidden on fresh suggestion cards (no relationship to remove) and on pending hints (the row has no `value`, so it never surfaces — the relator still can't withdraw a hint here).
 - Clicking outside the dialog dismisses it and cancels — no relation is created. The suggestion remains un-rated and re-surfaces in a future feed cycle.
 - For hint cards (`isHint = true`), the dialog surfaces the `hintedBy` attribution ("James suggested you know this person"). Selecting any of 1–4 confirms the hint: `value` is set, `isHint` flips to false.
 - For "people who rated me" cards, the relator's value of me stays hidden in the dialog (consistent with the soft-UI-hide policy) and is revealed once I've responded.
 
-On rating, the mutation goes through Hono RPC; TanStack Query optimistically updates the local cache so the graph re-renders with the new relation before the server round-trip completes. Failed mutations revert with an error toast.
+On relating, the mutation goes through Hono RPC; TanStack Query optimistically updates the local cache so the graph re-renders with the new relation before the server round-trip completes. Failed mutations revert with an error toast.
 
 ### Personal subgraph view
 
@@ -223,7 +224,7 @@ Hint rows (`value IS NULL`) are filtered out of the visualization. They live on 
 
 **Click behavior** (same in both modes):
 
-- **Edge (relation) click** — opens the rating dialog pre-filled with the current value. Same dialog component as the suggestion-feed rating flow; selecting a new 1–4 updates `value` and re-renders. Outside-click cancels with no change.
+- **Edge (relation) click** — opens the relating dialog pre-filled with the current value. Same dialog component as the suggestion-feed relating flow; selecting a new 1–4 updates `value` and re-renders. Outside-click cancels with no change.
 - **Node (person) click** — navigates to that person's profile page.
 
 **Small-N rendering.** A brand-new member's first graph has 1–3 nodes (themselves, their inviter, maybe a confirmed hint or two). The graph component must render gracefully at these sizes — a single node should look intentional. Test cases at N = 1, 2, 3 are part of the implementation acceptance criteria.
@@ -235,8 +236,8 @@ Whole-network views are out of scope at MVP. The data model permits them — any
 The predecessor here is SumApp + Kumu, used at Limicon 2024 and 2025. Specific pain points to design against:
 
 - **Random-ordered grid of all members.** Replaced by the suggestion feed, ordered by signal (people who rated you > hints > inviter's connections > recently active).
-- **No hover detail.** Each suggestion card surfaces enough profile information to make a rating decision without navigating away.
-- **No multiselect.** Some affordance for multi-select will let you tap/click multiple people and assign them the same rating.
+- **No hover detail.** Each suggestion card surfaces enough profile information to make a relating decision without navigating away.
+- **No multiselect.** Some affordance for multi-select will let you tap/click multiple people and assign them the same value.
 - **No "what's new since last visit."** `last_updated_web` and the recently-active suggestion signal address this directly.
 - **Static, no responsiveness.** Real-time RPC persistence, optimistic UI updates via TanStack Query.
 
@@ -249,7 +250,8 @@ These are choices made during the design interview. Each is reversible but refle
 | Decision | Rationale |
 | --- | --- |
 | One dimension, 4 values (1..4) | Capture visible-trust and resonance with the smallest possible model. Add dimensions later if needed. |
-| No explicit `0` rating | Considered and dropped. Un-rated suggestions re-surface in the feed; the only state distinction is "have row, value 1..4" vs "no row." Simpler dialog, simpler check constraints, fewer affordances to design. |
+| No explicit `0` value | Considered and dropped. Un-rated suggestions re-surface in the feed; the only state distinction is "have row, value 1..4" vs "no row." Simpler dialog, simpler check constraints, fewer affordances to design. (A later `0 — No Relationship` control deletes the row entirely — see below — but still stores no `0`.) |
+| `0 — No Relationship` removes a mistaken relation (#352) | Members need to undo a wrong relationship. Done as a row delete, not a stored `0` — keeps "absence = no row" and the check constraints intact. Surfaces only when a confirmed relationship exists; pending hints stay non-removable by the relator. |
 | Doubly unidirectional, no symmetrization | Asymmetry is information, and people can see it. |
 | Open data model, cozy UX layer | Members can see all relations in principle; the app's defaults make exploration deliberate. |
 | Sparse state, no `suggestion_state` table | No row = no interaction. Trade-off: no "deferred / ask me later" — re-surface un-rated suggestions each visit. |
@@ -269,11 +271,10 @@ These are choices made during the design interview. Each is reversible but refle
 - **Inferred relations from in-app activity** (event co-attendance, thread participation). Layer on top of self-declared data once the core feature lands.
 - **Quarterly Convening as refresh ritual.** Once the events table exists, "your last update was before the winter convening — refresh before Saturday's gathering" becomes a first-class nudge.
 - **Coordination feature leg.** Posting board / matchmaker that uses the graph as filter/ranker. Layered on top of relations once data density is reasonable.
-- **`-1` "intentional dissonance" rating.** Skipped at MVP; revisit with lived data.
+- **`-1` "intentional dissonance" value.** Skipped at MVP; revisit with lived data.
 - **Whole-network browsing modes.** Permitted by the data model, deferred from the MVP UX.
 - **Embedded subgraph displays on member profile pages.** A read-only `WebGraph` centered on the profile's member, alongside their bio. The data model already supports this — the `WebGraph` component is being built parameterized on `centerMemberId` so this slots in without rework. Visibility specifics (full personal subgraph at 2 hops vs. first-degree only, hint exclusion) to settle when this lands.
 
 ## Open questions
 
-- **Hint edit / withdrawal.** If a hint is wrong, can the relator dismiss it without rating? At MVP: any of 1–4 confirms the hint; outside-click cancels and leaves the hint in place to re-surface next visit. There is no "delete this hint" affordance for the relator. Likely fine; revisit if hints become a source of friction.
-- **Vocabulary refinement.** The 1–4 labels are a draft. Worth user-testing with a handful of members before committing.
+- **Hint edit / withdrawal.** If a hint is wrong, can the relator dismiss it without relating? At MVP: any of 1–4 confirms the hint; outside-click cancels and leaves the hint in place to re-surface next visit. There is no "delete this hint" affordance for the relator — the #352 "No Relationship" remove control is scoped to confirmed relationships (`isHint = false`), so it doesn't touch this. Likely fine; revisit if hints become a source of friction.

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-05 | James | Relations: remove a mistaken relationship (#352)
+
+A `0 — No Relationship` control above 1–4 in the relating dialog deletes the relations row, shown only when editing a relationship that already exists (graph edge click, member-profile **Edit**).
+
 ## 2026-06-04 | James | Activity instrumentation for launch
 
 Added `userId` (pseudonymous Supabase UUID) to the `api request` log so Axiom can count distinct people, and an admin **Activity metrics** view (`src/server/activity-metrics.ts`) reading the signup and invite funnels, plus a signed-in-past-week/month count from `auth.users.last_sign_in_at`, from current DB state.

--- a/src/app/admin/admin-hints.tsx
+++ b/src/app/admin/admin-hints.tsx
@@ -87,7 +87,7 @@ export function AdminHints() {
       <div className="flex flex-col gap-3 rounded border border-border p-3">
         <p className="text-sm text-muted-foreground">
           Seed a hint that <em>relator</em> might know <em>target</em>. The hint surfaces on the relator's suggestion
-          feed; they convert it by rating, or it stays pending.
+          feed; they convert it by relating, or it stays pending.
         </p>
         <MemberTypeahead
           label="Relator (whose feed gets the hint)"

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -198,7 +198,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
       await tx.update(profiles).set({ referredBy: inviterId }).where(eq(profiles.id, userId));
 
-      // Materialize the inviter→redeemer rating (from relation_value)
+      // Materialize the inviter→redeemer relationship (from relation_value)
       // and the redeemer→relatee hints (from invite_hints) into
       // relations rows. Same tx as the redemption itself so a failure
       // here rolls back the consumed invite — the new member never

--- a/src/app/myweb/my-web.tsx
+++ b/src/app/myweb/my-web.tsx
@@ -41,7 +41,7 @@ export function MyWeb({ initialLastUpdatedWeb }: { initialLastUpdatedWeb: Date |
   // was the explicit "I'm done" click. The toggle is freely flipable.
   const [mode, setMode] = useState<Mode>(initialLastUpdatedWeb ? "view" : "edit");
   // Lifted to MyWeb so both the suggestion feed (WebBuilder) and the
-  // graph (WebGraph) can request a rating dialog from a single source.
+  // graph (WebGraph) can request a relating dialog from a single source.
   const [relatingTarget, setRelatingTarget] = useState<RelatingTarget | null>(null);
   // Controlled tour state so a "Replay guided tour" action can re-fire
   // it for returning members. The initial-run decision (first visit,
@@ -102,7 +102,7 @@ export function MyWeb({ initialLastUpdatedWeb }: { initialLastUpdatedWeb: Date |
           )}
           {markDone.isError && (
             <p role="alert" className="text-sm text-destructive">
-              Couldn&apos;t save your update — your ratings are still saved.
+              Couldn&apos;t save your update — your relationships are still saved.
             </p>
           )}
         </div>

--- a/src/app/myweb/relating-dialog.tsx
+++ b/src/app/myweb/relating-dialog.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api";
 import type { RelationCandidatesFeed } from "@/lib/api-types";
 import {
+  RELATION_REMOVE_LABEL,
   RELATION_VALUE_LABELS,
   RELATION_VALUE_VISIBILITY_NOTE,
   RELATION_VALUES,
@@ -70,7 +71,7 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
     },
     onSettled: (_data, _err, { relateeId }) => {
       // Re-sync candidates and subgraph so any newly-revealed cards
-      // (e.g. inviter's connections opened up by this rating) appear
+      // (e.g. inviter's connections opened up by relating to them) appear
       // and the graph picks up the new edge once it exists.
       queryClient.invalidateQueries({ queryKey: RELATION_CANDIDATES_QUERY_KEY });
       queryClient.invalidateQueries({ queryKey: RELATION_SUBGRAPH_QUERY_KEY });
@@ -80,8 +81,33 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
     },
   });
 
+  // Deletes the confirmed relationship — the "No Relationship" option. No
+  // optimistic feed edit: a rated member isn't in the candidates feed, so
+  // there's nothing to drop. onSettled re-syncs once the delete lands —
+  // the edge leaves the graph, the per-member control reverts to "Not yet
+  // connected", and the member can resurface as a suggestion.
+  const removeMutation = useMutation({
+    mutationFn: async ({ relateeId }: { relateeId: string }) => {
+      const res = await apiClient.api.relations.value[":relateeId"].$delete({
+        param: { relateeId },
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `relations/value DELETE: ${res.status}`);
+      }
+      return res.json();
+    },
+    onSettled: (_data, _err, { relateeId }) => {
+      queryClient.invalidateQueries({ queryKey: RELATION_CANDIDATES_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: RELATION_SUBGRAPH_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: relationValueQueryKey(relateeId) });
+    },
+  });
+
+  const busy = mutation.isPending || removeMutation.isPending;
+
   const relate = (value: RelationValue) => {
-    if (!target || mutation.isPending) return;
+    if (!target || busy) return;
     setPendingValue(value);
     mutation.mutate(
       { relateeId: target.id, value },
@@ -98,13 +124,33 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
     );
   };
 
-  // 1–4 keyboard shortcut while the dialog is open. Re-attached on
-  // every render — cheap, and avoids stale closures on `relate` /
-  // `target`. Skips when a text field would have caught the keystroke.
+  const remove = () => {
+    if (!target || busy) return;
+    removeMutation.mutate(
+      { relateeId: target.id },
+      {
+        // No onRelated() — removing a relationship isn't the "added a
+        // person" signal the welcome tour waits on.
+        onSuccess: () => onClose(),
+      },
+    );
+  };
+
+  // 0–4 keyboard shortcut while the dialog is open (0 only when there's a
+  // relationship to remove). Re-attached on every render — cheap, and
+  // avoids stale closures on `relate` / `remove` / `target`. Skips when a
+  // text field would have caught the keystroke.
   useEffect(() => {
     if (!target) return;
     const handler = (e: KeyboardEvent) => {
       if (e.target instanceof HTMLElement && (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA")) {
+        return;
+      }
+      // 0 removes, but only when there's a relationship to remove —
+      // matches the button, which is hidden on fresh suggestion cards.
+      if (e.key === "0" && target.currentValue != null) {
+        e.preventDefault();
+        remove();
         return;
       }
       const n = Number.parseInt(e.key, 10);
@@ -125,7 +171,7 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
     <Dialog.Root
       open={open}
       onOpenChange={(next) => {
-        if (!next && !mutation.isPending) onClose();
+        if (!next && !busy) onClose();
       }}
     >
       <Dialog.Portal>
@@ -137,7 +183,7 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
           }
         >
           <Dialog.Close
-            disabled={mutation.isPending}
+            disabled={busy}
             aria-label="Close"
             className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
           >
@@ -156,10 +202,29 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
           </p>
 
           <p className="mt-3 text-xs text-muted-foreground">
-            Keyboard shortcuts: Number keys 1 through 4, or Esc to cancel
+            Keyboard shortcuts: Number keys {target?.currentValue != null ? "0" : "1"} through 4, or Esc to cancel
           </p>
 
           <div className="mt-2 flex flex-col gap-2">
+            {/* "No Relationship" surfaces only when a relationship already
+                exists — the made-by-mistake escape hatch. It deletes the
+                row (no `0` is stored), so it makes no sense on a fresh
+                suggestion card where there's nothing to remove. */}
+            {target?.currentValue != null && (
+              <Button
+                variant="destructive"
+                className="h-auto justify-start gap-3 px-3 py-2 text-left whitespace-normal"
+                disabled={busy}
+                onClick={remove}
+              >
+                <span className="text-lg font-bold tabular-nums">0</span>
+                <span className="flex min-w-0 flex-col">
+                  <span className="font-semibold">{RELATION_REMOVE_LABEL.headline}</span>
+                  <span className="text-sm leading-snug text-destructive/70">{RELATION_REMOVE_LABEL.detail}</span>
+                </span>
+                {removeMutation.isPending && <span className="ml-auto text-sm">…</span>}
+              </Button>
+            )}
             {RELATION_VALUES.map((value) => {
               const { headline, detail } = RELATION_VALUE_LABELS[value];
               const isCurrent = target?.currentValue === value;
@@ -169,7 +234,7 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
                   key={value}
                   variant={isCurrent ? "secondary" : "primary"}
                   className="h-auto justify-start gap-3 px-3 py-2 text-left whitespace-normal"
-                  disabled={mutation.isPending}
+                  disabled={busy}
                   onClick={() => relate(value)}
                 >
                   <span className="text-lg font-bold tabular-nums">{value}</span>
@@ -193,10 +258,16 @@ export function RelatingDialog({ target, onClose, onRelated }: Props) {
             })}
           </div>
 
-          {mutation.isError && (
+          {removeMutation.isError ? (
             <p role="alert" className="mt-3 text-sm text-destructive">
-              Couldn&apos;t save the rating. Click again to retry.
+              Couldn&apos;t remove the relationship. Click again to retry.
             </p>
+          ) : (
+            mutation.isError && (
+              <p role="alert" className="mt-3 text-sm text-destructive">
+                Couldn&apos;t save the relationship. Click again to retry.
+              </p>
+            )
           )}
 
           <p className="mt-3 text-xs text-muted-foreground">Notes: {RELATION_VALUE_VISIBILITY_NOTE}</p>

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -155,7 +155,7 @@ function NumberedEdge({ id, sourceX, sourceY, targetX, targetY, style, data }: E
           type="button"
           onClick={handleClick}
           disabled={!isClickable}
-          aria-label={isClickable ? "Adjust your rating" : undefined}
+          aria-label={isClickable ? "Adjust this relationship" : undefined}
           style={{
             position: "absolute",
             transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
@@ -220,14 +220,14 @@ export function WebGraph({
     window.localStorage.setItem(VIEW_STORAGE_KEY, JSON.stringify(view));
   }, [view]);
   // The view options become part of the query key so toggling refetches
-  // automatically and the rating-mutation invalidator (which uses the
+  // automatically and the relating-dialog's mutation invalidator (which uses the
   // bare ["relations", "subgraph"] key) still hits every variant.
   const { data, isPending, isError } = useQuery({
     queryKey: [...RELATION_SUBGRAPH_QUERY_KEY, view] as const,
     queryFn: () => fetchSubgraph(view),
     // The default view is prefetched server-side and dehydrated into
     // this cache; staleTime keeps the client from immediately refetching
-    // it on mount. Mutations still invalidate via the rating-dialog
+    // it on mount. Mutations still invalidate via the relating-dialog
     // onSettled handler, so this only suppresses redundant fetches.
     staleTime: 60_000,
     // Without this, toggling a view checkbox the first time collapses
@@ -559,7 +559,7 @@ export function WebGraph({
   if (empty) {
     return (
       <p className="text-base text-muted-foreground">
-        No connections yet — start rating members in Edit mode and they&apos;ll appear here.
+        No connections yet — start relating to members in Edit mode and they&apos;ll appear here.
       </p>
     );
   }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -31,6 +31,11 @@ export type ChangelogEntry = {
 // ordering; a functional test asserts it stays sorted.
 export const changelog: ChangelogEntry[] = [
   {
+    date: "2026-06-05",
+    title: "Remove a relationship",
+    description: "You can now remove relationships by setting a depth of 0.",
+  },
+  {
     date: "2026-06-04",
     title: "Clearer relationship labels",
     description:

--- a/src/lib/relation-value.ts
+++ b/src/lib/relation-value.ts
@@ -9,7 +9,7 @@ export const isRelationValue = (v: unknown): v is RelationValue =>
 export const RELATION_VALUES: readonly RelationValue[] = [1, 2, 3, 4];
 
 // Mirror of the vocabulary in design-relations.md. Shared by every UI
-// that lets a member pick a 1..4 value (rating dialog, invite form).
+// that lets a member pick a 1..4 value (relating dialog, invite form).
 export const RELATION_VALUE_LABELS: Record<RelationValue, { headline: string; detail: string }> = {
   1: {
     headline: "Acquaintance",
@@ -30,7 +30,16 @@ export const RELATION_VALUE_LABELS: Record<RelationValue, { headline: string; de
   },
 };
 
-// Reassurance shown wherever a member picks a 1..4 value — the rating
+// The "No Relationship" affordance shown above 1..4 when a confirmed
+// relationship already exists — the escape hatch for a relation made by
+// mistake. It deletes the relations row rather than storing a `0`:
+// absence of a relationship is absence of a row (see design-relations.md).
+export const RELATION_REMOVE_LABEL = {
+  headline: "No Relationship",
+  detail: "Remove this relationship from my web.",
+};
+
+// Reassurance shown wherever a member picks a 1..4 value — the relating
 // dialog and the invite form. One definition so the two never drift.
 export const RELATION_VALUE_VISIBILITY_NOTE =
   "Yes, these become visible to them and others. It's okay to pick a different relationship depth estimate than they do for you! Everyone will have their own slightly unique interpretation.";

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -55,6 +55,7 @@ import {
 import {
   createRelationHint,
   deleteRelationHint,
+  deleteRelationValue,
   getPersonalWeb,
   getRelationSuggestions,
   getRelationValue,
@@ -654,6 +655,19 @@ const api = new Hono<{ Variables: ApiVariables }>()
       return c.json({ ok: true });
     },
   )
+  // Remove the caller's own confirmed relationship with :relateeId — the "No
+  // Relationship" control. relatorId is fixed to the authed user, so a
+  // member can only delete their own outgoing edge. Idempotent: deleting
+  // an absent relation still returns 200, so a stale UI never errors.
+  .delete("/relations/value/:relateeId", async (c) => {
+    const user = c.get("user");
+    const relateeId = c.req.param("relateeId");
+    if (!isUuid(relateeId)) {
+      return c.json({ error: "relateeId must be a UUID" }, 400);
+    }
+    await deleteRelationValue({ relatorId: user.id, relateeId });
+    return c.json({ ok: true });
+  })
   .post("/relations/hint", async (c) => {
     const user = c.get("user");
     // Generic 404 — same rationale as /api/admin/*: don't advertise

--- a/src/server/relations.ts
+++ b/src/server/relations.ts
@@ -41,7 +41,7 @@ export type RelationSuggestionReason =
   | { type: "recentlyActive" }
   | { type: "member" };
 
-// Card payload for the rating-decision UI. Fields are chosen so a
+// Card payload for the relating-decision UI. Fields are chosen so a
 // member can decide without navigating away from the suggestion feed.
 export type RelationSuggestion = Omit<SuggestionCardRow, "avatarPath"> & { avatarUrl: string | null };
 
@@ -439,7 +439,7 @@ export const updateRelationValue = async (params: {
   if (params.relatorId === params.relateeId) return { error: "self_relating" };
 
   // The `relations_hint_state` check requires value and isHint to move
-  // together; a pending hint converting to a confirmed rating must set
+  // together; a pending hint converting to a confirmed relationship must set
   // both in the same statement.
   try {
     await db
@@ -464,6 +464,32 @@ export const updateRelationValue = async (params: {
   }
 
   return { ok: true };
+};
+
+export type DeleteRelationValueResult = { ok: true; deleted: boolean };
+
+// Removes the member's confirmed relationship with `relateeId` — the "No
+// Relationship" affordance for a relation made by mistake. Scoped to
+// isHint = false so it never silently clears a pending hint (the design
+// keeps hint-withdrawal off the relator's plate). Idempotent: a missing
+// row reports deleted=false rather than erroring, so a double-click or a
+// stale second tab still resolves as success.
+export const deleteRelationValue = async (params: {
+  relatorId: string;
+  relateeId: string;
+}): Promise<DeleteRelationValueResult> => {
+  const result = await db
+    .delete(relations)
+    .where(
+      and(
+        eq(relations.relatorId, params.relatorId),
+        eq(relations.relateeId, params.relateeId),
+        eq(relations.isHint, false),
+      ),
+    )
+    .returning({ relatorId: relations.relatorId });
+
+  return { ok: true, deleted: result.length > 0 };
 };
 
 export type CreateRelationHintResult =
@@ -572,7 +598,7 @@ export const listPendingHints = async (): Promise<PendingHint[]> => {
 
 export type DeleteRelationHintResult = { ok: true } | { error: "not_found" };
 
-// Refuses to delete a confirmed rating — the isHint = true predicate
+// Refuses to delete a confirmed relationship — the isHint = true predicate
 // scopes the delete to pending hints only.
 export const deleteRelationHint = async (params: {
   relatorId: string;

--- a/tests/e2e/myweb.spec.ts
+++ b/tests/e2e/myweb.spec.ts
@@ -4,7 +4,7 @@ import { completeWelcome, resetSeededUsers, signInAs, TIMEOUT_MS } from "./helpe
 
 // Smoke coverage of /myweb's wiring: page loads, the WebBuilder
 // suggestion feed renders, the Done button toggles into View mode and
-// the Edit button toggles back. The rich rating-flow path is left to
+// the Edit button toggles back. The rich relating-flow path is left to
 // PR 4's e2e once the welcome tour seeds enough relational data to
 // drive a populated suggestion feed.
 

--- a/tests/functional/client/relating-dialog.test.tsx
+++ b/tests/functional/client/relating-dialog.test.tsx
@@ -1,0 +1,59 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  apiClient: {
+    api: {
+      relations: {
+        value: {
+          ":relateeId": {
+            $put: vi.fn(),
+            $delete: vi.fn(),
+          },
+        },
+      },
+    },
+  },
+}));
+
+import { RelatingDialog, type RelatingTarget } from "@/app/myweb/relating-dialog";
+import { apiClient } from "@/lib/api";
+
+const $delete = vi.mocked(apiClient.api.relations.value[":relateeId"].$delete);
+
+const renderDialog = (target: RelatingTarget | null, onClose = vi.fn()) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RelatingDialog target={target} onClose={onClose} />
+    </QueryClientProvider>,
+  );
+  return { onClose };
+};
+
+describe("RelatingDialog — No Relationship option", () => {
+  it("offers the No Relationship option when a relationship already exists", async () => {
+    renderDialog({ id: "m1", displayName: "Ada", currentValue: 3 });
+
+    expect(await screen.findByRole("button", { name: /No Relationship/ })).toBeVisible();
+  });
+
+  it("hides the No Relationship option for a fresh suggestion with no relationship", async () => {
+    renderDialog({ id: "m1", displayName: "Ada" });
+
+    // The 1–4 buttons render, but there's nothing to remove.
+    expect(await screen.findByRole("button", { name: /Acquaintance/ })).toBeVisible();
+    expect(screen.queryByRole("button", { name: /No Relationship/ })).toBeNull();
+  });
+
+  it("removes via DELETE and closes the dialog on success", async () => {
+    $delete.mockResolvedValue({ ok: true, json: async () => ({ ok: true }) } as never);
+    const { onClose } = renderDialog({ id: "m1", displayName: "Ada", currentValue: 3 });
+
+    fireEvent.click(await screen.findByRole("button", { name: /No Relationship/ }));
+
+    await waitFor(() => expect($delete).toHaveBeenCalledWith({ param: { relateeId: "m1" } }));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/tests/functional/server/relations-schema.test.ts
+++ b/tests/functional/server/relations-schema.test.ts
@@ -48,7 +48,7 @@ describe("relations table constraints", () => {
     await deleteUserAndProfile(relateeId);
   });
 
-  it("accepts a confirmed rating in the 1..4 range", async () => {
+  it("accepts a confirmed relationship in the 1..4 range", async () => {
     await db.insert(relations).values({ relatorId, relateeId, value: 3 });
     const [row] = await db.select().from(relations).where(eq(relations.relatorId, relatorId));
     expect(row.value).toBe(3);

--- a/tests/functional/server/relations.test.ts
+++ b/tests/functional/server/relations.test.ts
@@ -13,6 +13,7 @@ import app from "@/server/api";
 import { db } from "@/server/db";
 import { createInvite } from "@/server/invites";
 import {
+  deleteRelationValue,
   getPersonalWeb,
   getRelationSuggestions,
   getRelationValue,
@@ -80,7 +81,7 @@ describe("updateRelationValue", () => {
     await deleteUserAndProfile(relateeId);
   });
 
-  it("creates a confirmed rating row", async () => {
+  it("creates a confirmed relationship row", async () => {
     const r = await updateRelationValue({ relatorId, relateeId, value: 3 });
     expect(r).toEqual({ ok: true });
 
@@ -89,7 +90,7 @@ describe("updateRelationValue", () => {
     expect(row.isHint).toBe(false);
   });
 
-  it("re-rating updates value and bumps updatedAt without changing the primary key", async () => {
+  it("updating an existing relationship changes value and bumps updatedAt without changing the primary key", async () => {
     await updateRelationValue({ relatorId, relateeId, value: 2 });
     const [first] = await db.select().from(relations).where(eq(relations.relatorId, relatorId));
 
@@ -126,12 +127,12 @@ describe("updateRelationValue", () => {
     }
   });
 
-  it("rejects self-rating before hitting the DB constraint", async () => {
+  it("rejects self-relating before hitting the DB constraint", async () => {
     const r = await updateRelationValue({ relatorId, relateeId: relatorId, value: 3 });
     expect(r).toEqual({ error: "self_relating" });
   });
 
-  it("rejects rating a non-existent ratee", async () => {
+  it("rejects relating to a non-existent ratee", async () => {
     const r = await updateRelationValue({ relatorId, relateeId: randomUUID(), value: 3 });
     expect(r).toEqual({ error: "relatee_not_found" });
   });
@@ -170,6 +171,55 @@ describe("getRelationValue", () => {
   it("ignores hint rows (value-less, isHint=true)", async () => {
     await db.insert(relations).values({ relatorId, relateeId, value: null, isHint: true, hintedBy: relateeId });
     expect(await getRelationValue({ relatorId, relateeId })).toBeNull();
+  });
+});
+
+describe("deleteRelationValue", () => {
+  let relatorId: string;
+  let relateeId: string;
+
+  beforeEach(async () => {
+    relatorId = randomUUID();
+    relateeId = randomUUID();
+    await insertUserAndProfile(relatorId);
+    await insertUserAndProfile(relateeId);
+  });
+
+  afterEach(async () => {
+    await deleteUserAndProfile(relatorId);
+    await deleteUserAndProfile(relateeId);
+  });
+
+  it("removes a confirmed relationship", async () => {
+    await updateRelationValue({ relatorId, relateeId, value: 3 });
+
+    const r = await deleteRelationValue({ relatorId, relateeId });
+    expect(r).toEqual({ ok: true, deleted: true });
+
+    const rows = await db.select().from(relations).where(eq(relations.relatorId, relatorId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("is idempotent — deleting an absent relation reports deleted=false, not an error", async () => {
+    expect(await deleteRelationValue({ relatorId, relateeId })).toEqual({ ok: true, deleted: false });
+  });
+
+  it("leaves a pending hint untouched (scoped to isHint=false)", async () => {
+    await db.insert(relations).values({ relatorId, relateeId, value: null, isHint: true, hintedBy: relateeId });
+
+    expect(await deleteRelationValue({ relatorId, relateeId })).toEqual({ ok: true, deleted: false });
+
+    const [row] = await db.select().from(relations).where(eq(relations.relatorId, relatorId));
+    expect(row.isHint).toBe(true);
+  });
+
+  it("is directional — does not delete the reverse edge", async () => {
+    await updateRelationValue({ relatorId: relateeId, relateeId: relatorId, value: 4 });
+
+    expect(await deleteRelationValue({ relatorId, relateeId })).toEqual({ ok: true, deleted: false });
+
+    const rows = await db.select().from(relations).where(eq(relations.relatorId, relateeId));
+    expect(rows).toHaveLength(1);
   });
 });
 
@@ -373,7 +423,7 @@ describe("getPersonalWeb", () => {
     expect(sub.edges).toEqual([]);
   });
 
-  it("hops=1, outgoing only — returns my ratings", async () => {
+  it("hops=1, outgoing only — returns my relationships", async () => {
     await updateRelationValue({ relatorId: center, relateeId: a, value: 3 });
     await updateRelationValue({ relatorId: center, relateeId: b, value: 2 });
     const sub = await getPersonalWeb({ centerId: center, includeIncoming: false, includeOutgoing: true, hops: 1 });
@@ -382,7 +432,7 @@ describe("getPersonalWeb", () => {
     expect(sub.edges.every((e) => e.relatorId === center)).toBe(true);
   });
 
-  it("hops=1, incoming only — returns ratings of me", async () => {
+  it("hops=1, incoming only — returns relationships pointing at me", async () => {
     await updateRelationValue({ relatorId: a, relateeId: center, value: 3 });
     const sub = await getPersonalWeb({ centerId: center, includeIncoming: true, includeOutgoing: false, hops: 1 });
     expect(new Set(sub.nodes.map((n) => n.id))).toEqual(new Set([center, a]));
@@ -585,7 +635,7 @@ describe("materializeInviteRelations", () => {
     await deleteUserAndProfile(h2);
   });
 
-  it("inserts a confirmed inviter→redeemer rating from creator_value", async () => {
+  it("inserts a confirmed inviter→redeemer relationship from creator_value", async () => {
     const r = await createInvite({ createdBy: inviter, note: "creator value materialization" });
     if ("error" in r) throw new Error("seed failed");
     const [row] = await db.select({ id: invites.id }).from(invites).where(eq(invites.code, r.code));
@@ -794,7 +844,7 @@ describe("PUT /api/relations/value/:relateeId", () => {
     expect((await put(other, { value: "3" })).status).toBe(400);
   });
 
-  it("rejects self-rating", async () => {
+  it("rejects self-relating", async () => {
     const res = await put(me, { value: 3 });
     expect(res.status).toBe(400);
     expect((await res.json()).error).toBe("self_relating");
@@ -807,6 +857,59 @@ describe("PUT /api/relations/value/:relateeId", () => {
 
   it("rejects malformed UUID in path", async () => {
     const res = await put("not-a-uuid", { value: 3 });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/relations/value/:relateeId", () => {
+  let me: string;
+  let other: string;
+
+  beforeEach(async () => {
+    me = randomUUID();
+    other = randomUUID();
+    await insertUserAndProfile(me);
+    await insertUserAndProfile(other);
+    authAs(me);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(me);
+    await deleteUserAndProfile(other);
+  });
+
+  const del = (relateeId: string) => app.request(`/api/relations/value/${relateeId}`, { method: "DELETE" });
+
+  it("removes the caller's relationship and returns 200", async () => {
+    await updateRelationValue({ relatorId: me, relateeId: other, value: 3 });
+
+    const res = await del(other);
+    expect(res.status).toBe(200);
+
+    const rows = await db.select().from(relations).where(eq(relations.relatorId, me));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("returns 200 even when no relation exists (idempotent)", async () => {
+    const res = await del(other);
+    expect(res.status).toBe(200);
+  });
+
+  it("only deletes the caller's own outgoing edge", async () => {
+    // other → me exists; me deleting "other" must not touch it, since the
+    // route fixes relatorId to the authed user.
+    await updateRelationValue({ relatorId: other, relateeId: me, value: 4 });
+
+    const res = await del(other);
+    expect(res.status).toBe(200);
+
+    const rows = await db.select().from(relations).where(eq(relations.relatorId, other));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("rejects malformed UUID in path", async () => {
+    const res = await del("not-a-uuid");
     expect(res.status).toBe(400);
   });
 });
@@ -926,7 +1029,7 @@ describe("POST /api/relations/hint (admin-only)", () => {
     expect(res.status).toBe(404);
   });
 
-  it("400 on self-rating", async () => {
+  it("400 on self-relating", async () => {
     authAs(admin);
     const res = await post({ relatorId: relator, relateeId: relator });
     expect(res.status).toBe(400);
@@ -979,7 +1082,7 @@ describe("DELETE /api/relations/hint/:relatorId/:relateeId (admin-only)", () => 
     expect(rows).toEqual([]);
   });
 
-  it("refuses to delete a confirmed rating (404)", async () => {
+  it("refuses to delete a confirmed relationship (404)", async () => {
     await updateRelationValue({ relatorId: relator, relateeId: target, value: 3 });
     authAs(admin);
     const res = await app.request(`/api/relations/hint/${relator}/${target}`, { method: "DELETE" });


### PR DESCRIPTION
Summary: Add a "0 — No Relationship" control to the relating dialog that
removes an existing relationship, and rename "rating" terminology to
"relationship" across the feature.

Why: Members had no way to undo a relationship made by mistake (#352).
Implemented as a row delete rather than a stored 0, preserving the data
model's "absence of a relationship = absence of a row" invariant and the
existing 1..4 check constraints.

Behavior:
- The relating dialog shows a "0 — No Relationship" button above 1–4, but
  only when a relationship already exists (a graph edge-click or the
  member-profile Edit). Clicking it — or pressing 0 — deletes the
  relationship and closes the dialog, instant like the 1–4 buttons.
- New DELETE /api/relations/value/:relateeId, scoped to the caller's own
  outgoing edge and to confirmed relationships (isHint=false); idempotent
  (deleting an absent relationship still returns 200). No schema change.
- Pending hints stay non-removable by the relator — the option never
  surfaces on a value-less row.
- Member-facing copy plus comments, tests, and docs now use
  "relationship"/"relation"/"relating" instead of "rating".
- New member-facing changelog entry; the /about version bumps to 2026-06-05.

Test Plan:
- ran `npm test` locally (375 functional + 28 Playwright e2e, all green)

Closes #352

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
