### PR TITLE
feat(dev): parallel worktree lanes for concurrent dev/test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Intentional Society web application — an authenticated app for a small, global
 ## Commands
 
 - `npm run setup` — one-time: generate `.env.local` with local Supabase defaults (idempotent)
+- `npm run make_lane_inside_worktree` — one-time: turn the current git worktree into an isolated parallel "lane" (own Supabase stack + ports); see `docs/strategy-worktree-lanes.md`
 - `npm run dev` — start local Supabase (if needed) + dev server (http://localhost:3000)
 - `npm run build` — production build
 - `npm run lint` — Biome
@@ -73,6 +74,7 @@ Design and rationale: [docs/spec-portable-ai-procedures.md](docs/spec-portable-a
 ## Key docs
 
 - `docs/strategy-branching.md` — branching strategy and rationale
+- `docs/strategy-worktree-lanes.md` — running parallel worktrees as isolated "lanes" (own Supabase stack + ports) for concurrent dev/test
 - `docs/strategy-committing.md` — commit conventions and expand-contract pattern
 - `docs/strategy-db-transactions.md` — writing transactions that survive the Supabase connection pooler
 - `docs/strategy-project-management.md` — GitHub Projects board conventions

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-05 | James | Parallel worktree "lanes" for concurrent dev/test
+
+Each git worktree can run its own isolated Supabase stack + dev/e2e ports, so several branches (or agents) run dev/test/e2e at once without clobbering one DB. To try it: `git worktree add ../is-app-worktrees/is-app-2` (the dir name sets the lane), then inside it `npm install && npm run setup && npm run make_lane_inside_worktree`; from then on `npm run dev` / `npm test` / `npm run test:e2e` use lane 2's stack on +200 ports. Reference: docs/strategy-worktree-lanes.md.
+
 ## 2026-06-05 | James | Relations: remove a mistaken relationship (#352)
 
 A `0 — No Relationship` control above 1–4 in the relating dialog deletes the relations row, shown only when editing a relationship that already exists (graph edge click, member-profile **Edit**).

--- a/docs/strategy-worktree-lanes.md
+++ b/docs/strategy-worktree-lanes.md
@@ -1,0 +1,102 @@
+# Parallel worktree "lanes"
+
+Run several checkouts of this repo side by side — each on its own branch,
+each able to run `npm run dev` / `npm test` / `npm run test:e2e` at the same
+time without colliding. This is for working (or driving multiple agents) on
+more than one branch at once, with shared git history and easy cross-branch
+diffs.
+
+## Why a "lane" is needed
+
+The local Supabase stack is a singleton: it's keyed by `project_id` in
+`supabase/config.toml` and binds fixed host ports, and the e2e suite binds a
+fixed web-server port (3093) and wipes the database via `/api/_test/reset`.
+Two checkouts pointed at one stack therefore clobber each other's data and
+ports. GoTrue (auth) and Storage can't be multi-tenanted, so the only real
+isolation is **one full Supabase stack per worktree** — a *lane*.
+
+A lane is just a port offset + a renamed Supabase project, derived from the
+worktree's directory name:
+
+| Dir name   | Lane | Offset |
+|------------|------|--------|
+| `is-app`   | 0    | base ports, untouched |
+| `is-app-2` | 2    | +200 |
+| `is-app-3` | 3    | +300 |
+
+| Service              | Base  | Lane 2 | Lane 3 |
+|----------------------|-------|--------|--------|
+| Supabase API / Kong  | 54321 | 54521  | 54621  |
+| Postgres             | 54322 | 54522  | 54622  |
+| Studio               | 54323 | 54523  | 54623  |
+| Inbucket (email)     | 54324 | 54524  | 54624  |
+| shadow / analytics / pooler | 54320/54327/54329 | +200 | +300 |
+| `next dev`           | 3000  | 3200   | 3300   |
+| e2e web server       | 3093  | 3293   | 3393   |
+
+## Creating a lane
+
+A `git worktree` shares the object store and refs with the main checkout (so
+branches and commits are visible from either, and `git diff` works across
+them), while living at a separate path. Per worktree, one time:
+
+```sh
+# from the main checkout (C:\All\code\is-app)
+git worktree add ../is-app-worktrees/is-app-2     # the checkout; dir name sets the lane
+cd ../is-app-worktrees/is-app-2
+npm install                                       # node_modules isn't shared across worktrees
+npm run setup                                     # generates this worktree's .env.local
+npm run make_lane_inside_worktree                 # converts THIS worktree into lane 2
+```
+
+`make_lane_inside_worktree` reads the lane from the directory name and, in
+this worktree only:
+
+- rewrites `supabase/config.toml` — `project_id` + every port + the auth
+  redirect URLs — re-deriving from the committed version each run (idempotent),
+  then sets `git update-index --skip-worktree` so the edit never shows as a
+  diff or gets committed;
+- rewrites `.env.local` — the Supabase API + `DATABASE_URL` ports — and adds
+  `E2E_PORT` (read by `playwright.config.ts`) + `LANE_DEV_PORT` (read by the
+  `npm run dev` wrapper, `scripts/dev-server.mjs`) so both servers land on this
+  lane's ports automatically. Next can't take the port from `.env` directly —
+  it binds before env files load — hence the wrapper.
+
+Local Supabase keys are identical across stacks (fixed demo JWT secret), so
+only URLs/ports change. Preview a lane without writing anything:
+`npm run make_lane_inside_worktree -- --name=is-app-2 --dry-run`.
+
+## Running in a lane
+
+After configuring, the normal commands "just work" against the lane's stack:
+
+```sh
+npm run dev                     # interactive dev server on this lane's port
+npm run test:e2e                # auto-uses E2E_PORT; isolated DB + auth
+npm run test:functional         # isolated DB
+```
+
+**One DB-touching activity per lane at a time.** A lane is a single Supabase
+stack = a single database. The two app ports keep the dev server and the e2e
+server from colliding, but they share the lane's DB — so running e2e *and* a
+manual dev session in the **same** lane at once lets e2e's reset wipe the DB
+under your session. Across lanes there's no interference at all; if you want a
+stable manual session *and* an e2e run simultaneously, use two lanes.
+
+## Reuse, teardown, caveats
+
+- **Reuse a slot for another branch:** `git switch <branch>` inside the
+  worktree (a branch checked out in another worktree is blocked by git — a
+  guardrail, not a limit). The lane config is independent of the branch.
+- **Footprint:** ~10 containers + ~2 GB RAM per lane. 2–4 lanes is comfortable
+  on 16 GB+; beyond that, push e2e to CI (which already runs against per-branch
+  Vercel previews) instead of adding local stacks.
+- **Stop a lane's stack:** `npm run dev:db:stop` from that worktree.
+- **Remove a lane:** `git worktree remove ../is-app-worktrees/is-app-2`.
+- **Windows port grabbing:** reserve a lane's Supabase block once in an admin
+  shell (the script prints the exact command):
+  `netsh int ipv4 add excludedportrange protocol=tcp startport=54520 numberofports=10`.
+- **If `config.toml` changes upstream:** because the file is `--skip-worktree`
+  in lanes, a pull won't update it there. Run `git update-index
+  --no-skip-worktree supabase/config.toml`, pull, then re-run
+  `npm run make_lane_inside_worktree` (it re-derives from the new base).

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,12 +8,17 @@ const isProd = process.env.NODE_ENV === "production";
 // does not need it, so we keep it out of the production policy.
 const scriptSrc = isProd ? "script-src 'self' 'unsafe-inline'" : "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
 
-// Local Supabase (started by `npm run dev`) runs at http://127.0.0.1:54321.
-// The browser auth client and AuthProvider token refresh call it directly, so
-// it has to be in connect-src for dev — but never in production.
+// Local Supabase (started by `npm run dev`) runs at http://127.0.0.1:54321 by
+// default. Derive the origin from NEXT_PUBLIC_SUPABASE_URL so worktree "lanes"
+// on offset ports (e.g. :54521) work without editing this file — see
+// docs/strategy-worktree-lanes.md.
+const localSupabaseUrl = new URL(process.env.NEXT_PUBLIC_SUPABASE_URL ?? "http://127.0.0.1:54321");
+
+// The browser auth client and AuthProvider token refresh call Supabase
+// directly, so it has to be in connect-src for dev — but never in production.
 const connectSrc = isProd
   ? "connect-src 'self' https://*.supabase.co"
-  : "connect-src 'self' https://*.supabase.co http://127.0.0.1:54321";
+  : `connect-src 'self' https://*.supabase.co ${localSupabaseUrl.origin}`;
 
 const securityHeaders = [
   { key: "X-Frame-Options", value: "DENY" },
@@ -51,15 +56,16 @@ const securityHeaders = [
 // Avatar objects are served from Supabase Storage (signed URLs) and
 // rendered through next/image, so the optimizer must be allowed to
 // fetch from the Supabase host. Local dev points at the Supabase
-// container on 127.0.0.1:54321 — mirror the isProd CSP branching.
+// container (host/port from NEXT_PUBLIC_SUPABASE_URL) — mirror the isProd
+// CSP branching.
 const remotePatterns: NonNullable<NextConfig["images"]>["remotePatterns"] = [
   { protocol: "https", hostname: "*.supabase.co", pathname: "/storage/v1/object/**" },
 ];
 if (!isProd) {
   remotePatterns.push({
     protocol: "http",
-    hostname: "127.0.0.1",
-    port: "54321",
+    hostname: localSupabaseUrl.hostname,
+    port: localSupabaseUrl.port,
     pathname: "/storage/v1/object/**",
   });
 }

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   },
   "scripts": {
     "setup": "node scripts/setup.mjs",
+    "make_lane_inside_worktree": "node scripts/make-lane-inside-worktree.mjs",
     "update_main_branch_protection": "node scripts/update-main-branch-protection.mjs",
     "update_email_templates": "node scripts/update-email-templates.mjs",
     "download_email_templates": "node scripts/update-email-templates.mjs --download",
-    "dev": "npm run dev:db && next dev",
+    "dev": "npm run dev:db && node scripts/dev-server.mjs",
     "dev:db": "node scripts/check-env.mjs && node scripts/ensure-docker.mjs && node scripts/ensure-supabase.mjs && node scripts/migrate.mjs && node scripts/seed-e2e-users.mjs",
     "dev:db:stop": "npx supabase stop",
     "dev:db:reset": "npx supabase db reset && npx drizzle-kit migrate",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,11 @@ import { config as loadEnv } from "dotenv";
 loadEnv({ path: ".env.local", quiet: true });
 
 const isCI = !!process.env.CI;
-const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3093";
+// Lane-aware port: `npm run make_lane_inside_worktree` writes E2E_PORT into a
+// worktree's .env.local so parallel lanes don't collide on one web server.
+// Defaults to 3093 for the base worktree / CI. See docs/strategy-worktree-lanes.md.
+const e2ePort = process.env.E2E_PORT || "3093";
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://localhost:${e2ePort}`;
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -58,8 +62,8 @@ export default defineConfig({
   webServer: isCI
     ? undefined
     : {
-        command: "npm run dev -- --port 3093",
-        url: "http://localhost:3093",
+        command: `npm run dev -- --port ${e2ePort}`,
+        url: `http://localhost:${e2ePort}`,
         reuseExistingServer: true,
       },
 });

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Thin wrapper around `next dev` so a worktree "lane" runs on its own port
+// without typing --port every time. Next can't read PORT from .env (it binds
+// the HTTP server before any env files load — see the Next CLI docs), so
+// `make_lane_inside_worktree` writes LANE_DEV_PORT into the lane's .env.local
+// and this passes it through as --port.
+//
+// An explicit --port/-p always wins (e.g. Playwright's web server runs
+// `npm run dev -- --port <E2E_PORT>`); in that case we forward it untouched
+// and add nothing. The base worktree has no LANE_DEV_PORT, so plain
+// `npm run dev` behaves exactly as before (port 3000).
+
+import { spawn } from "node:child_process";
+import { config } from "dotenv";
+
+config({ path: ".env.local", quiet: true });
+
+const forwarded = process.argv.slice(2);
+const hasExplicitPort = forwarded.some((a) => a === "--port" || a === "-p");
+const lanePort = process.env.LANE_DEV_PORT;
+const portArgs = !hasExplicitPort && lanePort ? ["--port", lanePort] : [];
+
+const child = spawn("npx", ["next", "dev", ...portArgs, ...forwarded], {
+  stdio: "inherit",
+  shell: true,
+});
+child.on("exit", (code) => process.exit(code ?? 0));

--- a/scripts/make-lane-inside-worktree.mjs
+++ b/scripts/make-lane-inside-worktree.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+// Configure the CURRENT git worktree as an isolated "lane" so several
+// worktrees can run `npm run dev` / `npm test` / `npm run test:e2e` in
+// parallel without clobbering each other's database, auth, or ports.
+//
+// Background: the local Supabase stack is a singleton keyed by `project_id`
+// (config.toml) on fixed host ports, and e2e binds a fixed web-server port
+// and wipes the DB via /api/_test/reset. Two worktrees sharing one stack
+// therefore step on each other. GoTrue/Storage can't be multi-tenanted, so
+// the only true isolation is one full stack per worktree — that's a "lane".
+//
+// A lane is derived from the worktree directory name:
+//   is-app      -> lane 0 (the base worktree; left untouched)
+//   is-app-2    -> lane 2
+//   is-app-3    -> lane 3
+// Lane N shifts every port by N*100 and renames the Supabase project, so
+// the existing dev:db / migrate / seed flow isolates itself with no other
+// changes. This script is the one-time, in-place configure step you run
+// AFTER `git worktree add` + `npm install` + `npm run setup`.
+//
+// What it rewrites IN THIS WORKTREE ONLY (git worktrees have their own
+// checked-out files and their own index):
+//   - supabase/config.toml : project_id + every port + auth redirect URLs,
+//     then `git update-index --skip-worktree` so the local edit never shows
+//     as a diff or gets committed. The base text is taken from `git show
+//     HEAD:supabase/config.toml`, so re-running always re-derives cleanly.
+//   - .env.local           : the Supabase API + DATABASE_URL ports, plus an
+//     E2E_PORT line that playwright.config.ts reads for its web server.
+//
+// Local Supabase keys are deterministic across stacks (fixed demo JWT
+// secret), so only URLs/ports change — never the keys.
+//
+// Flags:
+//   --dry-run         print the planned changes; write nothing, touch no git
+//   --name=<dirname>  pretend the worktree is named <dirname> (preview/testing)
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const nameOverride = args.find((a) => a.startsWith("--name="))?.slice("--name=".length);
+
+// Base port assignments straight out of supabase/config.toml + the app's
+// dev (3000) and Playwright web-server (3093) ports. Lane N adds N*100.
+const SUPABASE_PORTS = {
+  api: { key: "port", base: 54321 },
+  db: { key: "port", base: 54322 },
+  shadow: { key: "shadow_port", base: 54320 },
+  pooler: { key: "port", base: 54329 },
+  studio: { key: "port", base: 54323 },
+  inbucket: { key: "port", base: 54324 },
+  analytics: { key: "port", base: 54327 },
+  inspector: { key: "inspector_port", base: 8083 },
+};
+const APP_PORTS = { dev: 3000, e2e: 3093 };
+const LANE_STRIDE = 100;
+const MAX_LANE = 9; // N*100 keeps the 5432x block inside 543xx–544xx..552xx
+
+function fail(msg) {
+  process.stderr.write(`make-lane-inside-worktree: ${msg}\n`);
+  process.exit(1);
+}
+
+// `name` is the project name in package.json (the base worktree's dir name
+// by convention). Lane is the trailing -N on the current dir; bare name = 0.
+const baseName = JSON.parse(readFileSync(resolve(repoRoot, "package.json"), "utf8")).name;
+const worktreeName = nameOverride ?? basename(repoRoot);
+
+function parseLane(dirName) {
+  if (dirName === baseName) return 0;
+  const m = dirName.match(new RegExp(`^${baseName}-(\\d+)$`));
+  if (!m) {
+    fail(
+      `worktree dir "${dirName}" isn't a recognized lane name.\n` +
+        `  Expected "${baseName}" (base, lane 0) or "${baseName}-<N>" (e.g. "${baseName}-2").\n` +
+        `  Rename the worktree dir to set its lane, or pass --name=${baseName}-2 to preview.`,
+    );
+  }
+  const lane = Number(m[1]);
+  if (lane < 1 || lane > MAX_LANE) {
+    fail(`lane ${lane} out of range (1–${MAX_LANE}); higher lanes would overflow the reserved port blocks.`);
+  }
+  return lane;
+}
+
+const lane = parseLane(worktreeName);
+const off = lane * LANE_STRIDE;
+
+if (lane === 0) {
+  process.stdout.write(
+    `This is the base worktree ("${baseName}", lane 0) — it keeps the default ports, nothing to configure.\n` +
+      `  Create a lane with:  git worktree add ../${baseName}-worktrees/${baseName}-2 && cd … && npm install && npm run setup && npm run make_lane_inside_worktree\n`,
+  );
+  process.exit(0);
+}
+
+const port = (p) => p.base + off;
+const apiPort = port(SUPABASE_PORTS.api);
+const dbPort = port(SUPABASE_PORTS.db);
+const studioPort = port(SUPABASE_PORTS.studio);
+const inbucketPort = port(SUPABASE_PORTS.inbucket);
+const devPort = APP_PORTS.dev + off;
+const e2ePort = APP_PORTS.e2e + off;
+
+// --- supabase/config.toml -------------------------------------------------
+// Re-derive from the committed version so repeated runs are idempotent and
+// never compound on an already-laned file.
+function pristineConfig() {
+  const res = spawnSync("git", ["show", "HEAD:supabase/config.toml"], { cwd: repoRoot, encoding: "utf8" });
+  if (res.status !== 0) fail(`could not read HEAD:supabase/config.toml (${(res.stderr ?? "").trim()})`);
+  return res.stdout;
+}
+
+function setPort(text, { key, base }) {
+  // The (key, value) pair is unique per line — value disambiguates the
+  // several `port = …` keys — so this targets exactly one line. Throwing on
+  // a miss surfaces config.toml drift instead of silently producing a lane
+  // that overlaps the base ports.
+  const re = new RegExp(`^(\\s*${key}\\s*=\\s*)${base}\\b`, "m");
+  if (!re.test(text)) fail(`expected "${key} = ${base}" in config.toml — has the stack config changed?`);
+  return text.replace(re, `$1${base + off}`);
+}
+
+function buildConfig() {
+  let text = pristineConfig();
+  text = text.replace(/^(\s*project_id\s*=\s*)"[^"]*"/m, `$1"${worktreeName}"`);
+  for (const def of Object.values(SUPABASE_PORTS)) text = setPort(text, def);
+  // Auth redirect allow-list + site_url point at the dev server; shift them
+  // to this lane's dev port so interactive auth flows resolve. (e2e runs on
+  // e2ePort and, like the base stack on :3093, doesn't depend on the
+  // allow-list for the password-login flows the suite exercises.)
+  text = text.replaceAll(":3000", `:${devPort}`);
+  return text;
+}
+
+// --- .env.local -----------------------------------------------------------
+function setEnvLine(text, key, value) {
+  const line = `${key}=${value}`;
+  const re = new RegExp(`^${key}=.*$`, "m");
+  if (re.test(text)) return text.replace(re, line);
+  const sep = text === "" || text.endsWith("\n") ? "" : "\n";
+  return `${text}${sep}${line}\n`;
+}
+
+function buildEnv() {
+  const envPath = resolve(repoRoot, ".env.local");
+  if (!existsSync(envPath)) {
+    fail(".env.local is missing — run `npm run setup` in this worktree first, then re-run this script.");
+  }
+  let text = readFileSync(envPath, "utf8");
+  text = setEnvLine(text, "NEXT_PUBLIC_SUPABASE_URL", `http://127.0.0.1:${apiPort}`);
+  text = setEnvLine(text, "DATABASE_URL", `postgresql://postgres:postgres@127.0.0.1:${dbPort}/postgres`);
+  text = setEnvLine(text, "E2E_PORT", String(e2ePort));
+  text = setEnvLine(text, "LANE_DEV_PORT", String(devPort));
+  return { envPath, text };
+}
+
+// --- apply ----------------------------------------------------------------
+const configText = buildConfig();
+const { envPath, text: envText } = buildEnv();
+const configPath = resolve(repoRoot, "supabase", "config.toml");
+
+const portRows = [
+  ["Supabase API / Kong", apiPort],
+  ["Postgres", dbPort],
+  ["Studio", studioPort],
+  ["Inbucket (email)", inbucketPort],
+  ["next dev", devPort],
+  ["e2e web server", e2ePort],
+];
+const summary =
+  `Lane ${lane}  (project_id "${worktreeName}", port offset +${off})\n` +
+  portRows.map(([label, p]) => `  ${label.padEnd(22)} ${p}`).join("\n") +
+  `\n  Studio:        http://127.0.0.1:${studioPort}` +
+  `\n  Interactive:   npm run dev        (auto-uses LANE_DEV_PORT=${devPort})` +
+  `\n  e2e:           npm run test:e2e   (auto-uses E2E_PORT=${e2ePort})`;
+
+if (dryRun) {
+  process.stdout.write(`[dry-run] ${summary}\n\n[dry-run] would rewrite supabase/config.toml and ${envPath}\n`);
+  process.exit(0);
+}
+
+writeFileSync(configPath, configText);
+writeFileSync(envPath, envText);
+
+// Keep the local config.toml edit out of git: this worktree's index only.
+const skip = spawnSync("git", ["update-index", "--skip-worktree", "supabase/config.toml"], {
+  cwd: repoRoot,
+  encoding: "utf8",
+});
+if (skip.status !== 0) {
+  process.stderr.write(
+    `  warning: could not set --skip-worktree on supabase/config.toml (${(skip.stderr ?? "").trim()}).\n` +
+      `  The lane still works, but git will show config.toml as modified. Run manually:\n` +
+      `    git update-index --skip-worktree supabase/config.toml\n`,
+  );
+}
+
+process.stdout.write(`${summary}\n\nConfigured. Start it with:  npm run dev\n`);
+process.stdout.write(
+  `Windows only — reserve this lane's Supabase ports (admin shell, once):\n` +
+    `  netsh int ipv4 add excludedportrange protocol=tcp startport=${SUPABASE_PORTS.shadow.base + off} numberofports=10\n`,
+);


### PR DESCRIPTION
Summary: Configure a git worktree as an isolated "lane" so multiple
checkouts can run dev/test/e2e in parallel without colliding.

Why: The local Supabase stack is a singleton keyed by project_id on fixed
ports, and e2e binds a fixed web-server port and resets the DB — so two
worktrees sharing one stack clobber each other. GoTrue/Storage can't be
multi-tenanted, so one stack per worktree is the only true isolation. This
unblocks running several branches (or agents) side by side.

Behavior: `npm run make_lane_inside_worktree` reads the lane from the
worktree dir name (is-app-2 -> lane 2) and, in that worktree only, rewrites
supabase/config.toml (project_id + every port + auth URLs, then
skip-worktree) and .env.local (Supabase + DB ports, E2E_PORT, LANE_DEV_PORT).
`npm run dev` gains a thin wrapper so each lane binds its own port (Next
can't read PORT from .env). next.config.ts now derives the dev CSP/image host
from NEXT_PUBLIC_SUPABASE_URL instead of hardcoding :54321. The base worktree
is unchanged.

Test Plan:
- `npm test` on base: lint (202 files), typecheck, vitest 375/375, e2e 28/28
  -- green; ran 4x while a lane-2 suite ran concurrently, base passed each time.
- Live two-stack run: created is-app-2, configured lane 2, brought a second
  Supabase stack up on +200 ports alongside base; lane-2 e2e 28/28 and vitest
  375/375 against its own DB.
- Script safety: lane-0 (base) no-ops; --dry-run/--name preview writes nothing.
- A concurrent lane-2 run surfaced a pre-existing functional-suite flake
  (parallel files share the `test-user` slug; reproduces on main without this
  branch) -- unrelated to this PR's files.

Docs: docs/strategy-worktree-lanes.md + CLAUDE.md pointer + devjournal entry.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
