### PR TITLE
fix(tests): unique fixtures to end the functional-suite flake

### DIFF
--- a/docs/strategy-worktree-lanes.md
+++ b/docs/strategy-worktree-lanes.md
@@ -91,6 +91,14 @@ stable manual session *and* an e2e run simultaneously, use two lanes.
 - **Footprint:** ~10 containers + ~2 GB RAM per lane. 2–4 lanes is comfortable
   on 16 GB+; beyond that, push e2e to CI (which already runs against per-branch
   Vercel previews) instead of adding local stacks.
+- **Looping e2e (running the suite many times):** pre-start ONE lane server and
+  reuse it — `npm run dev -- --port <E2E_PORT>`, which Playwright picks up via
+  `reuseExistingServer`. Don't let each `playwright test` cold-start the server:
+  that tree-kills `next dev` between runs, and repeated kill-mid-compile corrupts
+  the Turbopack `.next` cache until first-request route compilation outruns
+  Playwright's 60 s `webServer` timeout (socket bound, never serving — the run
+  fails before any test). One reused server ran 20 cycles clean; the cold-start
+  loop cliffs after ~5. If a lane's `.next` wedges, delete it to rebuild.
 - **Stop a lane's stack:** `npm run dev:db:stop` from that worktree.
 - **Remove a lane:** `git worktree remove ../is-app-worktrees/is-app-2`.
 - **Windows port grabbing:** reserve a lane's Supabase block once in an admin

--- a/tests/functional/server/api-me.test.ts
+++ b/tests/functional/server/api-me.test.ts
@@ -15,11 +15,16 @@ import { profiles } from "@/server/schema";
 
 const mockCreateServerClient = vi.mocked(createServerClient);
 
+// Unique per run: upsertProfile derives the profile slug via toSlug,
+// which hits a global unique constraint, and parallel test files share
+// one DB — a fixed "Test User" collides with profiles.test.ts.
+const TEST_DISPLAY_NAME = `Test User ${randomUUID().slice(0, 8)}`;
+
 const makeUser = (id: string, email: string): User =>
   ({
     id,
     email,
-    user_metadata: { displayName: "Test User" },
+    user_metadata: { displayName: TEST_DISPLAY_NAME },
     app_metadata: {},
     aud: "authenticated",
     created_at: "2026-01-01T00:00:00Z",
@@ -73,7 +78,7 @@ describe("GET /api/me", () => {
       email: "me-test@testfake.local",
       profile: {
         id: testUserId,
-        displayName: "Test User",
+        displayName: TEST_DISPLAY_NAME,
         bio: null,
         keywords: [],
         location: null,

--- a/tests/functional/server/buttondown-first-save.test.ts
+++ b/tests/functional/server/buttondown-first-save.test.ts
@@ -150,7 +150,10 @@ describe("runFirstProfileSaveSync (inline hook)", () => {
 
   it("raises an unsubscribe alert and writes nothing when the subscriber is unsubscribed", async () => {
     const profileId = await makeProfile({ email: "fs-dan@example.com" });
-    const programId = await makeProgram({ buttondownTag: "weekly", slug: "weekly-prog" });
+    // Unique slug per run: parallel files share one DB, so a fixed slug
+    // races buttondown-sync's twin test on programs_slug_unique.
+    const heldSlug = `weekly-prog-${randomUUID().slice(0, 8)}`;
+    const programId = await makeProgram({ buttondownTag: "weekly", slug: heldSlug });
     await db.insert(profilePrograms).values({ profileId, programId });
 
     const initial: ButtondownSubscriber = {
@@ -174,7 +177,7 @@ describe("runFirstProfileSaveSync (inline hook)", () => {
     expect(alerts[0]).toMatchObject({
       profileId,
       email: "fs-dan@example.com",
-      programSlugsHeld: ["weekly-prog"],
+      programSlugsHeld: [heldSlug],
     });
   });
 

--- a/tests/functional/server/buttondown-sync.test.ts
+++ b/tests/functional/server/buttondown-sync.test.ts
@@ -222,7 +222,9 @@ describe("runButtondownSync (daily reconciler)", () => {
       email: "eve@example.com",
       buttondownSubscriberId: "sub_eve",
     });
-    const programId = await makeProgram({ buttondownTag: "weekly", slug: "weekly-prog" });
+    // Unique slug per run — see the twin test in buttondown-first-save.
+    const heldSlug = `weekly-prog-${randomUUID().slice(0, 8)}`;
+    const programId = await makeProgram({ buttondownTag: "weekly", slug: heldSlug });
     await join(profileId, programId);
 
     const initial = sampleSubscriber({
@@ -247,7 +249,7 @@ describe("runButtondownSync (daily reconciler)", () => {
     expect(my).toMatchObject({
       profileId,
       email: "eve@example.com",
-      programSlugsHeld: ["weekly-prog"],
+      programSlugsHeld: [heldSlug],
     });
   });
 

--- a/tests/functional/server/profiles.test.ts
+++ b/tests/functional/server/profiles.test.ts
@@ -15,6 +15,11 @@ import {
 } from "@/server/profiles";
 import { profiles } from "@/server/schema";
 
+// Unique per run: toSlug(displayName) feeds the global profiles slug
+// unique constraint, and parallel test files share one DB — a fixed
+// "Test User" collides with api-me.test.ts on the derived slug.
+const TEST_DISPLAY_NAME = `Test User ${randomUUID().slice(0, 8)}`;
+
 describe("upsertProfile", () => {
   let testUserId: string;
 
@@ -36,7 +41,7 @@ describe("upsertProfile", () => {
   it("is idempotent across repeated calls for the same user", async () => {
     const user = {
       id: testUserId,
-      user_metadata: { displayName: "Test User" },
+      user_metadata: { displayName: TEST_DISPLAY_NAME },
       app_metadata: {},
       aud: "authenticated",
       created_at: "2026-01-01T00:00:00Z",
@@ -48,13 +53,13 @@ describe("upsertProfile", () => {
     const rows = await db.select().from(profiles).where(eq(profiles.id, testUserId));
 
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.displayName).toBe("Test User");
+    expect(rows[0]?.displayName).toBe(TEST_DISPLAY_NAME);
   });
 
   it("reports created=true on first call and created=false thereafter", async () => {
     const user = {
       id: testUserId,
-      user_metadata: { displayName: "Test User" },
+      user_metadata: { displayName: TEST_DISPLAY_NAME },
       app_metadata: {},
       aud: "authenticated",
       created_at: "2026-01-01T00:00:00Z",


### PR DESCRIPTION
Summary: De-flake the functional-server suite by making its few shared
fixed fixtures unique per run; document the e2e-loop gotcha found while
validating.

Why: functional-server runs test files in parallel against one shared
local DB with no per-test isolation. A few fixed values on UNIQUE
constraints were shared across files, so two files inserting the same
value concurrently raced to a Postgres 23505 — a wandering ~20% flake
that also went intermittently red in CI.

Behavior: No production code changes; test fixtures and docs only.
- profiles.slug "test-user" (derived from displayName "Test User") in
  api-me + profiles → displayName suffixed with randomUUID.
- programs.slug "weekly-prog" in buttondown-first-save + buttondown-sync
  → per-test random slug, asserted via the same variable.
- weekly-web-updates was already safe (onConflictDoNothing on a
  prod-hardcoded slug) and sync-locks already scopes to its own lock
  name — left untouched.
- docs(lanes): caveat to loop e2e by reusing one dev server, since
  cold-restart-per-run corrupts Turbopack .next and trips Playwright's
  60s webServer timeout.

Test Plan:
- ran `npm test` locally — green: lint, typecheck, 375 functional
  tests, e2e 28 passed.
- functional-server suite run 23× clean (20× parallel + 3× full)
  against the prior ~20% flake rate.
- e2e validated 20/20 green via the reuse-server approach the new docs
  caveat recommends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
