### PR TITLE
feat(profile): sync displayName edits into auth metadata

### DIFF
--- a/docs/design-emails.md
+++ b/docs/design-emails.md
@@ -195,7 +195,9 @@ Supabase substitutes Go-template variables before sending. The ones in use:
   in prod). Useful for footer links.
 - `{{ .Data.displayName }}` — `auth.users.user_metadata.displayName`.
   Populated by `/signup` (`signInWithOtp` `options.data`) and by the
-  CSV importer; absent on admin-created users. Always wrap with
+  CSV importer; absent on admin-created users. Kept fresh after signup by
+  `PUT /me` (`syncDisplayNameToAuthMetadata`), which mirrors a profile
+  displayName edit back into `user_metadata`. Always wrap with
   `{{ if .Data.displayName }}…{{ end }}` so the missing case renders
   cleanly. Verified against Supabase docs: `{{ .Data }}` is
   user_metadata, not per-request options.data.

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-06 | James | PUT /me syncs displayName to auth metadata (#229)
+
+`PUT /me` now mirrors a displayName edit back into `auth.users.user_metadata` (best-effort) so auth-email greetings stop showing the signup-time name; no backfill, existing members self-heal on their next edit.
+
 ## 2026-06-05 | James | Parallel worktree "lanes" for concurrent dev/test
 
 Each git worktree can run its own isolated Supabase stack + dev/e2e ports, so several branches (or agents) run dev/test/e2e at once without clobbering one DB. To try it: `git worktree add ../is-app-worktrees/is-app-2` (the dir name sets the lane), then inside it `npm install && npm run setup && npm run make_lane_inside_worktree`; from then on `npm run dev` / `npm test` / `npm run test:e2e` use lane 2's stack on +200 ports. Reference: docs/strategy-worktree-lanes.md.

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -41,6 +41,7 @@ import {
   parseEditableProfile,
   reactivateProfile,
   setProfileHidden,
+  syncDisplayNameToAuthMetadata,
   toSlug,
   upsertProfile,
 } from "./profiles";
@@ -389,6 +390,13 @@ const api = new Hono<{ Variables: ApiVariables }>()
           return c.json({ error: "That display name is already taken. Please choose a different one." }, 409);
         }
         throw err;
+      }
+
+      // Mirror a displayName edit into auth.users.user_metadata so auth
+      // emails greet the member by their current name. Runs only after the
+      // DB write commits, so a slug clash (409 above) can't desync the two.
+      if (parsed.displayName !== undefined) {
+        await syncDisplayNameToAuthMetadata(user.id, parsed.displayName, user.user_metadata ?? {});
       }
     }
 

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -1,5 +1,8 @@
+import * as Sentry from "@sentry/nextjs";
 import type { User } from "@supabase/supabase-js";
 import { and, asc, eq, isNotNull, isNull, or, sql } from "drizzle-orm";
+
+import { supabaseAdmin } from "@/lib/supabase/admin";
 
 import { isUuid } from "./auth-middleware";
 import { attachAvatarUrls } from "./avatars";
@@ -94,6 +97,34 @@ export const upsertProfile = async (user: User): Promise<{ created: boolean }> =
     .returning({ id: profiles.id });
 
   return { created: rows.length > 0 };
+};
+
+// The inverse of upsertProfile's first-sign-in copy: push a profile
+// displayName edit back into auth.users.user_metadata so auth emails
+// (magic-link, recovery) greet the member by their current name instead
+// of their signup-time one — see docs/design-emails.md → {{ .Data.displayName }}.
+//
+// existingMetadata is spread so GoTrue-managed fields (email_verified,
+// phone_verified, sub) survive the write. Best-effort: the profiles row is
+// the source of truth, so a GoTrue hiccup must not fail the profile save —
+// the greeting just stays stale until the next edit. We capture so a
+// persistent failure still pages someone.
+export const syncDisplayNameToAuthMetadata = async (
+  userId: string,
+  displayName: string | null,
+  existingMetadata: Record<string, unknown>,
+): Promise<void> => {
+  try {
+    const { error } = await supabaseAdmin.auth.admin.updateUserById(userId, {
+      user_metadata: { ...existingMetadata, displayName },
+    });
+    if (error) throw error;
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { area: "profile.metadata_sync" },
+      extra: { userId },
+    });
+  }
 };
 
 export type ProfileForSelf = {

--- a/tests/functional/server/api-me.test.ts
+++ b/tests/functional/server/api-me.test.ts
@@ -7,13 +7,33 @@ vi.mock("@supabase/ssr", () => ({
   createServerClient: vi.fn(),
 }));
 
+// Stub the privileged client so PUT /me's auth.users metadata sync is
+// observable without a real GoTrue round-trip (the test users are raw
+// SQL inserts, not GoTrue-created accounts).
+vi.mock("@/lib/supabase/admin", () => ({
+  supabaseAdmin: {
+    auth: { admin: { updateUserById: vi.fn().mockResolvedValue({ data: {}, error: null }) } },
+  },
+}));
+
+// The metadata sync swallows GoTrue failures to Sentry; mock it so the
+// best-effort path is observable and silent.
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+import * as Sentry from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 
+import { supabaseAdmin } from "@/lib/supabase/admin";
 import app from "@/server/api";
 import { db } from "@/server/db";
 import { profiles } from "@/server/schema";
 
 const mockCreateServerClient = vi.mocked(createServerClient);
+const mockUpdateUserById = vi.mocked(supabaseAdmin.auth.admin.updateUserById);
+const mockCaptureException = vi.mocked(Sentry.captureException);
 
 // Unique per run: upsertProfile derives the profile slug via toSlug,
 // which hits a global unique constraint, and parallel test files share
@@ -35,6 +55,8 @@ describe("GET /api/me", () => {
 
   beforeEach(async () => {
     testUserId = randomUUID();
+    mockUpdateUserById.mockClear();
+    mockCaptureException.mockClear();
     await db.execute(
       sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${testUserId}::uuid, 'me-test@testfake.local', false, false)`,
     );
@@ -182,10 +204,72 @@ describe("GET /api/me", () => {
       // The failed update must leave the caller's own slug untouched.
       const [row] = await db.select().from(profiles).where(eq(profiles.id, testUserId));
       expect(row?.slug).not.toBe("member-name");
+
+      // A clash short-circuits before the metadata sync, so profiles and
+      // user_metadata never disagree about the name.
+      expect(mockUpdateUserById).not.toHaveBeenCalled();
     } finally {
       await db.delete(profiles).where(eq(profiles.id, otherId));
       await db.execute(sql`DELETE FROM auth.users WHERE id = ${otherId}::uuid`);
     }
+  });
+
+  it("PUT /me mirrors a displayName edit into auth.users.user_metadata", async () => {
+    // A user whose metadata carries GoTrue-managed fields alongside the
+    // name, so we can prove the sync preserves them.
+    mockCreateServerClient.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: {
+            user: {
+              ...makeUser(testUserId, "me-test@testfake.local"),
+              user_metadata: { displayName: "Old Name", email_verified: true, sub: testUserId },
+            },
+          },
+          error: null,
+        }),
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: test mock shape
+    } as any);
+
+    const res = await putMe({ displayName: "Fresh Name" });
+    expect(res.status).toBe(200);
+
+    expect(mockUpdateUserById).toHaveBeenCalledTimes(1);
+    expect(mockUpdateUserById).toHaveBeenCalledWith(testUserId, {
+      // GoTrue-managed fields survive; only displayName changes.
+      user_metadata: { displayName: "Fresh Name", email_verified: true, sub: testUserId },
+    });
+  });
+
+  it("PUT /me clears the metadata displayName when set to null", async () => {
+    const res = await putMe({ displayName: null });
+    expect(res.status).toBe(200);
+    expect(mockUpdateUserById).toHaveBeenCalledWith(testUserId, {
+      user_metadata: { displayName: null },
+    });
+  });
+
+  it("PUT /me does not touch auth metadata when displayName is absent", async () => {
+    const res = await putMe({ bio: "Edited my bio, not my name." });
+    expect(res.status).toBe(200);
+    expect(mockUpdateUserById).not.toHaveBeenCalled();
+  });
+
+  it("PUT /me still succeeds (and captures) when the metadata sync fails", async () => {
+    // GoTrue returns an error: the profile write already committed, so the
+    // request must still succeed — the greeting just stays stale until the
+    // next edit, and the failure is captured rather than thrown.
+    mockUpdateUserById.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: "gotrue down" },
+      // biome-ignore lint/suspicious/noExplicitAny: partial admin error shape
+    } as any);
+
+    const res = await putMe({ displayName: "Resilient Name" });
+    expect(res.status).toBe(200);
+    expect((await res.json()).profile.displayName).toBe("Resilient Name");
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
Summary: PUT /me now mirrors a displayName change into auth.users.user_metadata so auth-email greetings reflect the member's current name.

Why: Email templates greet via {{ .Data.displayName }} (= user_metadata), which only upsertProfile populated — one-way, at first sign-in. Later profile edits left it stale, so magic-link and recovery emails kept showing the signup-time name.

Behavior: After a PUT /me whose payload includes displayName, the new syncDisplayNameToAuthMetadata calls supabase.auth.admin.updateUserById, spreading existing metadata so GoTrue-managed fields (email_verified, sub, ...) survive. Best-effort: a GoTrue failure captures to Sentry and does not fail the save; a slug-clash 409 short-circuits before the sync. No backfill — existing members self-heal on their next profile edit.

Test Plan:
- ran `npm test` locally — lint, typecheck, 368 functional, 28 e2e, all green

Closes #229

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
