### PR TITLE
fix(e2e): warm routes in setup to end first-test cold-start flake

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-06 | James | E2E warms routes in setup; nav budget back to 12s
+
+The e2e setup project now warms the page-serving path (public routes + one sign-in) before timed tests, so the first spec no longer cold-starts inside `signInAs`'s budget; `TIMEOUT_MS` dropped 20s → 12s — warm a slow new route in `reset.setup.ts` rather than re-inflating the budget.
+
 ## 2026-06-06 | James | PUT /me syncs displayName to auth metadata (#229)
 
 `PUT /me` now mirrors a displayName edit back into `auth.users.user_metadata` (best-effort) so auth-email greetings stop showing the signup-time name; no backfill, existing members self-heal on their next edit.

--- a/tests/e2e/helpers/session.ts
+++ b/tests/e2e/helpers/session.ts
@@ -7,10 +7,13 @@ import { expect, type Page } from "@playwright/test";
 // Playwright setup project (see tests/e2e/reset.setup.ts).
 export type TestRole = "regular" | "admin";
 
-// Shared wait budget for page.waitForURL across the suite. Bumped from
-// 10s after Vercel preview cold-starts made 10s flaky; revisit once we
-// chase down the underlying first-request slowness.
-export const TIMEOUT_MS = 20_000;
+// Shared wait budget for page.waitForURL across the suite. The setup
+// project now warms the page-serving path (reset.setup.ts), so the first
+// test no longer pays cold-start compile / function spin-up inside this
+// budget — the original reason it was bumped 10s → 20s. With the server
+// warm, every navigation is a warm-route hit, so 12s is a comfortable
+// margin that also fails fast on a genuinely stuck navigation.
+export const TIMEOUT_MS = 12_000;
 
 const EMAILS: Record<TestRole, string> = {
   regular: "e2e-regular@testfake.local",

--- a/tests/e2e/reset.setup.ts
+++ b/tests/e2e/reset.setup.ts
@@ -1,6 +1,6 @@
 import { test as setup } from "@playwright/test";
 
-import { resetSeededUsers } from "./helpers/session";
+import { resetSeededUsers, signInAs } from "./helpers/session";
 
 // Runs once at the top of every e2e run. Wipes profile fields and
 // deletes invites for the two seeded users so the welcome spec's
@@ -11,4 +11,23 @@ setup("reset seeded test users", async ({ baseURL }) => {
     throw new Error("reset.setup.ts: baseURL is not configured");
   }
   await resetSeededUsers(baseURL);
+});
+
+// Warm the page-serving path before any timed test runs. Local e2e hits
+// `next dev`, which compiles each route on first request; CI's first hit
+// cold-starts the Vercel functions. Either way the *first* test used to
+// pay that cost inside signInAs's waitForURL budget and flake (always the
+// alphabetically-first spec). Paying it here, in untimed setup, makes the
+// first real test no longer special — and lets TIMEOUT_MS sit tight at 12s.
+//
+// The reset above only warms one API function; this warms the React/SSR
+// page pipeline + the public routes, then signs in once to warm the authed
+// landing the way every test reaches it. The sign-in is read-only (no
+// completeWelcome), so the welcome spec still sees a fresh user. Best-effort
+// throughout: a warm-up miss must never turn into a suite failure.
+setup("warm up the page-serving path", async ({ page }) => {
+  for (const path of ["/signin", "/", "/signup", "/forgot-password"]) {
+    await page.goto(path).catch(() => {});
+  }
+  await signInAs(page, "regular").catch(() => {});
 });


### PR DESCRIPTION
Summary: The e2e setup project now warms the page-serving path before any timed test, removing the cold-start cost that made the alphabetically-first spec flake.

Why: Local e2e runs against `next dev` (compiles routes on first request); CI hits the Vercel preview (functions cold-start on first request). Either way the first test paid that cost inside signInAs's waitForURL budget and intermittently timed out — re-running "fixed" it only because the retry hit warm routes. The 20s budget was a band-aid (bumped from 10s) the code already flagged for revisit.

Behavior: reset.setup.ts gains a second setup step that GETs the public routes and signs in once (read-only — no completeWelcome, so the welcome spec still sees a fresh user) to warm the authed landing. With the server warmed in untimed setup, TIMEOUT_MS drops 20s -> 12s: comfortable margin on warm routes, and faster failure on a genuinely stuck navigation.

Test Plan:
- ran `npm test` locally on a cold server (port 3093 free): 385 functional + 29 e2e green; the previously-flaky about.spec passed first-run at the 12s budget

Note: no tracking issue — this cold-start flake is distinct from #357's shared-DB race.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
