### PR TITLE
chore(logging): prefer log.<level> over console.log

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -45,6 +45,9 @@
       "recommended": true,
       "style": {
         "noNonNullAssertion": "error"
+      },
+      "suspicious": {
+        "noConsole": "error"
       }
     }
   },
@@ -106,6 +109,19 @@
         "rules": {
           "style": {
             "noNonNullAssertion": "off"
+          },
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["src/lib/timing.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
           }
         }
       }

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-06 | James | Logging convention: log.<level> over console.log (#262)
+
+Codified in `docs/doc-axiom.md`: structured `log.<level>` (message = feature label) for app telemetry that should reach Axiom; `console.log` only for explicit dev/test helpers. Enforced by Biome `suspicious/noConsole`, with `off` overrides for `src/lib/timing.ts` and `tests/`/`scripts/`. Server Components must `await log.flush()`.
+
 ## 2026-06-06 | James | E2E warms routes in setup; nav budget back to 12s
 
 The e2e setup project now warms the page-serving path (public routes + one sign-in) before timed tests, so the first spec no longer cold-starts inside `signInAs`'s budget; `TIMEOUT_MS` dropped 20s → 12s — warm a slow new route in `reset.setup.ts` rather than re-inflating the budget.

--- a/docs/doc-axiom.md
+++ b/docs/doc-axiom.md
@@ -14,6 +14,17 @@ Axiom receives logs through two channels:
   - `log.info()` / `log.warn()` / `log.error()` / `log.debug()` for structured logging from client and server
   - Automatic Web Vitals reporting
 
+## Logging conventions
+
+Two rules keep logs queryable in Axiom:
+
+- **App code that should reach Axiom uses `log.<level>()`** from `next-axiom` (`log.info` / `warn` / `error` / `debug`). The **message is a stable feature label**, and structured data goes in the fields object — `log.info("api request", { method, path, status })`. next-axiom nests the object under `fields`, so a consistent label lets every query filter by `message` and split on `['fields.*']` (see the canonical example at `src/server/api.ts`, and the Buttondown queries below). Reusing a label across call sites is deliberate: the `"probe-149"` events in `/me`, the home page, and `/_test/reset` all carry `fields.route` so one query compares them.
+- **`console.log` is only for explicit dev/test helpers** whose output you read inline as raw text, never telemetry you'd query — e.g. `src/lib/timing.ts`, a header-gated latency print, and the `tests/`/`scripts/` tooling. A raw `console.log` still reaches Axiom via the Vercel log drain, but lands as an unstructured `message` string you can't filter on.
+
+This is enforced by Biome's `suspicious/noConsole` rule, with per-path `off` overrides in `biome.json` for the legitimate helpers above. To add app telemetry, reach for `log.<level>` — if Biome flags a `console` call, that's the signal.
+
+One caveat: `next-axiom`'s `log` buffers and flushes on a throttle, and Route Handlers drain it as a side effect of the request. A **Server Component has no such wrapper**, so `await log.flush()` after logging there (as `src/app/page.tsx` does) to guarantee the event is sent before the function freezes.
+
 ## Request Logging
 
 Every API request is logged by Hono middleware in `src/server/api.ts` with:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { log } from "next-axiom";
 
 import { AppWordmark } from "@/components/app-wordmark";
 import { Button } from "@/components/ui/button";
@@ -124,11 +125,16 @@ export default async function Home() {
 
   // Diagnostic for #149: log whether the redirect-to-/welcome gate
   // sees a profile and what bio is. Gated on x-debug-timing to keep
-  // production logs uncluttered. Remove once #149 is resolved.
+  // production logs uncluttered. A Server Component has no request
+  // wrapper to drain next-axiom's buffer, so flush() explicitly. Remove
+  // once #149 is resolved.
   if ((await headers()).get("x-debug-timing") === "1") {
-    console.log(
-      `[debug-149] home me.profile=${me.profile ? "present" : "null"} bio=${JSON.stringify(me.profile?.bio)}`,
-    );
+    log.debug("probe-149", {
+      route: "home",
+      hasProfile: Boolean(me.profile),
+      bio: me.profile?.bio ?? null,
+    });
+    await log.flush();
   }
 
   // Gate: route members into the multi-step welcome flow until every

--- a/src/lib/timing.ts
+++ b/src/lib/timing.ts
@@ -16,6 +16,9 @@ export const timed = async <T>(request: { headers: Headers }, label: string, fn:
   try {
     return await fn();
   } finally {
+    // Intentional console.log, not log.<level>: this is an ad-hoc latency
+    // print read inline in the function log, not Axiom telemetry to query.
+    // The biome noConsole allowlist covers this file — see docs/doc-axiom.md.
     console.log(`[timing] ${label}=${(performance.now() - start).toFixed(1)}ms`);
   }
 };

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -326,16 +326,22 @@ const api = new Hono<{ Variables: ApiVariables }>()
     }
 
     if (debug) {
-      console.log(
-        `[probe-149] route=me stage=${stage} user=${user.id} ` +
-          `bio=${JSON.stringify(profile?.bio ?? null)} ` +
-          `agreements=${profile?.lastSignedAgreements ? "set" : "null"} ` +
-          `profile=${profile?.lastUpdatedProfile ? "set" : "null"} ` +
-          `programs=${profile?.lastReviewedPrograms ? "set" : "null"} ` +
-          `ctid=${probe?.ctid ?? ""} xmin=${probe?.xmin ?? ""} ` +
-          `inRecovery=${probe?.inRecovery ?? ""} ` +
-          `serverAddr=${probe?.serverAddr ?? ""} backendPid=${probe?.backendPid ?? ""}`,
-      );
+      // message "probe-149" is the feature label; split on fields.route
+      // to compare the /me read against the /home and /reset probes.
+      log.debug("probe-149", {
+        route: "me",
+        stage,
+        userId: user.id,
+        bio: profile?.bio ?? null,
+        agreements: Boolean(profile?.lastSignedAgreements),
+        profile: Boolean(profile?.lastUpdatedProfile),
+        programs: Boolean(profile?.lastReviewedPrograms),
+        ctid: probe?.ctid ?? null,
+        xmin: probe?.xmin ?? null,
+        inRecovery: probe?.inRecovery ?? null,
+        serverAddr: probe?.serverAddr ?? null,
+        backendPid: probe?.backendPid ?? null,
+      });
     }
 
     return c.json({ id: user.id, email: user.email, profile });

--- a/src/server/test-reset.ts
+++ b/src/server/test-reset.ts
@@ -1,4 +1,5 @@
 import { inArray, sql } from "drizzle-orm";
+import { log } from "next-axiom";
 
 import { db } from "./db";
 import { invites, profiles } from "./schema";
@@ -113,19 +114,27 @@ export const resetE2EUsers = async (): Promise<{
 
   // #149 baseline: log the probe data on every successful reset (not
   // only on the anomaly throw in tests/e2e/helpers/session.ts), so
-  // Vercel function logs accumulate a per-run record of which Supavisor
-  // backend the reset's read-back landed on. Across enough runs we can
-  // tell whether reads scatter across backends or stick, and spot any
-  // run where inRecovery or serverAddr drifts from the steady state.
-  console.log(
-    `[probe-149] route=reset users=${users.length} updatedIds=${JSON.stringify(updatedIds)} ` +
-      profilesAfter
-        .map(
-          (p) =>
-            `${p.email}=${JSON.stringify(p.rows.map((r) => ({ ctid: r.ctid, xmin: r.xmin, bio: r.bio, inRecovery: r.inRecovery, serverAddr: r.serverAddr, backendPid: r.backendPid })))}`,
-        )
-        .join(" "),
-  );
+  // Axiom accumulates a per-run record of which Supavisor backend the
+  // reset's read-back landed on. Across enough runs we can tell whether
+  // reads scatter across backends or stick, and spot any run where
+  // inRecovery or serverAddr drifts from the steady state. message
+  // "probe-149" matches the /me and /home probes; split on fields.route.
+  log.debug("probe-149", {
+    route: "reset",
+    users: users.length,
+    updatedIds,
+    profiles: profilesAfter.map((p) => ({
+      email: p.email,
+      rows: p.rows.map((r) => ({
+        ctid: r.ctid,
+        xmin: r.xmin,
+        bio: r.bio,
+        inRecovery: r.inRecovery,
+        serverAddr: r.serverAddr,
+        backendPid: r.backendPid,
+      })),
+    })),
+  });
 
   return { reset: users.length, updatedIds, profiles: profilesAfter };
 };


### PR DESCRIPTION
Summary: Route the #149 diagnostic probes through next-axiom's structured
log.debug, document the log.<level>-vs-console.log convention, and enforce
it with Biome.

Why: App code mixed structured log.<level> with raw console.log, so probe
output reached Axiom as unstructured message text that can't be filtered by
field (#262).

Behavior:
- The /me, home, and /reset #149 probes emit log.debug("probe-149",
  { route, ... }); the shared message label plus fields.route makes them
  queryable together. The home Server Component awaits log.flush() since no
  request wrapper drains the buffer there.
- src/lib/timing.ts keeps console.log — an ad-hoc latency print, the
  documented exception.
- Biome suspicious/noConsole is now an error, with off overrides for
  src/lib/timing.ts and tests/**, scripts/**.
- docs/doc-axiom.md gains a "Logging conventions" section.

Test Plan:
- ran `npm test` locally (functional 385 passed, e2e 29 passed)

Closes #262

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
