### PR TITLE
Group homepage cards into labeled categories

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-07 | Benji | Homepage card categories
+
+Grouped the logged-in homepage cards into three labeled sections — Community (Programs, Member directory, Current intentions), Personal (My web, My profile), and Admin (Invite a friend, Give Feedback) — with small uppercase category headers. Keeps the 2-column responsive grid within each section.
+
 ## 2026-06-06 | James | Logging convention: log.<level> over console.log (#262)
 
 Codified in `docs/doc-axiom.md`: structured `log.<level>` (message = feature label) for app telemetry that should reach Axiom; `console.log` only for explicit dev/test helpers. Enforced by Biome `suspicious/noConsole`, with `off` overrides for `src/lib/timing.ts` and `tests/`/`scripts/`. Server Components must `await log.flush()`.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,7 +86,10 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
 
       <div className="flex w-full max-w-lg flex-col gap-6">
         <section aria-label="Community" className="flex flex-col gap-3">
-          <p className="font-sans text-sm font-semibold uppercase tracking-wide text-muted-foreground" aria-hidden="true">
+          <p
+            className="font-sans text-sm font-semibold uppercase tracking-wide text-muted-foreground"
+            aria-hidden="true"
+          >
             Community
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
@@ -101,7 +104,10 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
         </section>
 
         <section aria-label="Personal" className="flex flex-col gap-3">
-          <p className="font-sans text-sm font-semibold uppercase tracking-wide text-muted-foreground" aria-hidden="true">
+          <p
+            className="font-sans text-sm font-semibold uppercase tracking-wide text-muted-foreground"
+            aria-hidden="true"
+          >
             Personal
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
@@ -111,7 +117,10 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
         </section>
 
         <section aria-label="System" className="flex flex-col gap-3">
-          <p className="font-sans text-sm font-semibold uppercase tracking-wide text-muted-foreground" aria-hidden="true">
+          <p
+            className="font-sans text-sm font-semibold uppercase tracking-wide text-muted-foreground"
+            aria-hidden="true"
+          >
             System
           </p>
           <div className="grid gap-4 sm:grid-cols-2">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,7 +86,7 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
 
       <div className="flex w-full max-w-lg flex-col gap-6">
         <section aria-label="Community" className="flex flex-col gap-3">
-          <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground" aria-hidden="true">
+          <p className="font-sans text-sm font-semibold uppercase tracking-wide text-muted-foreground" aria-hidden="true">
             Community
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
@@ -101,7 +101,7 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
         </section>
 
         <section aria-label="Personal" className="flex flex-col gap-3">
-          <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground" aria-hidden="true">
+          <p className="font-sans text-sm font-semibold uppercase tracking-wide text-muted-foreground" aria-hidden="true">
             Personal
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
@@ -110,9 +110,9 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
           </div>
         </section>
 
-        <section aria-label="Contribute" className="flex flex-col gap-3">
-          <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground" aria-hidden="true">
-            Contribute
+        <section aria-label="System" className="flex flex-col gap-3">
+          <p className="font-sans text-sm font-semibold uppercase tracking-wide text-muted-foreground" aria-hidden="true">
+            System
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
             <NavCard

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,7 +58,7 @@ function NavCard({ href, title, description }: NavCardProps) {
       href={href}
       className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-5 transition-all hover:border-primary/40 hover:bg-accent hover:shadow-sm"
     >
-      <h2 className="text-lg font-semibold text-card-foreground group-hover:text-accent-foreground">{title}</h2>
+      <h3 className="text-lg font-semibold text-card-foreground group-hover:text-accent-foreground">{title}</h3>
       <p className="text-sm text-muted-foreground">{description}</p>
     </Link>
   );
@@ -85,8 +85,10 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
       </div>
 
       <div className="flex w-full max-w-lg flex-col gap-6">
-        <section className="flex flex-col gap-3">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Community</h2>
+        <section aria-label="Community" className="flex flex-col gap-3">
+          <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground" aria-hidden="true">
+            Community
+          </p>
           <div className="grid gap-4 sm:grid-cols-2">
             <NavCard href="/programs" title="Programs" description="Explore and join IS Web programs." />
             <NavCard href="/members" title="Member directory" description="Browse and find other members." />
@@ -98,16 +100,20 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
           </div>
         </section>
 
-        <section className="flex flex-col gap-3">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Personal</h2>
+        <section aria-label="Personal" className="flex flex-col gap-3">
+          <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground" aria-hidden="true">
+            Personal
+          </p>
           <div className="grid gap-4 sm:grid-cols-2">
             <NavCard href="/myweb" title="My web" description="Build your relational map by adding connections!" />
             <NavCard href="/profile" title="My profile" description="View and edit your profile information." />
           </div>
         </section>
 
-        <section className="flex flex-col gap-3">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Admin</h2>
+        <section aria-label="Contribute" className="flex flex-col gap-3">
+          <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground" aria-hidden="true">
+            Contribute
+          </p>
           <div className="grid gap-4 sm:grid-cols-2">
             <NavCard
               href="/invites"
@@ -120,9 +126,9 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
               rel="noopener noreferrer"
               className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-5 transition-all hover:border-primary/40 hover:bg-accent hover:shadow-sm"
             >
-              <h2 className="text-lg font-semibold text-card-foreground group-hover:text-accent-foreground">
+              <h3 className="text-lg font-semibold text-card-foreground group-hover:text-accent-foreground">
                 Give Feedback
-              </h2>
+              </h3>
               <p className="text-sm text-muted-foreground">
                 Share your thoughts, suggestions, or report issues with the app.
               </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -84,34 +84,51 @@ function LoggedInHome({ displayName }: { displayName: string | null }) {
         </p>
       </div>
 
-      <div className="grid w-full max-w-lg gap-4 sm:grid-cols-2">
-        <NavCard href="/programs" title="Programs" description="Explore and join IS Web programs." />
-        <NavCard href="/members" title="Member directory" description="Browse and find other members." />
-        <NavCard
-          href="/intentions"
-          title="Current intentions"
-          description="See what the whole network is working toward."
-        />
-        <NavCard href="/myweb" title="My web" description="Build your relational map by adding connections!" />
-        <NavCard href="/profile" title="My profile" description="View and edit your profile information." />
-        <NavCard
-          href="/invites"
-          title="Invite a friend"
-          description="Generate an invite code to bring someone into the network."
-        />
-        <a
-          href="https://docs.google.com/forms/d/e/1FAIpQLScXhdSxbQ3LxjiYhqN2fmuyy66SK292rTYEZV3QaHgzn1eVjA/viewform?usp=dialog"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-5 transition-all hover:border-primary/40 hover:bg-accent hover:shadow-sm"
-        >
-          <h2 className="text-lg font-semibold text-card-foreground group-hover:text-accent-foreground">
-            Give Feedback
-          </h2>
-          <p className="text-sm text-muted-foreground">
-            Share your thoughts, suggestions, or report issues with the app.
-          </p>
-        </a>
+      <div className="flex w-full max-w-lg flex-col gap-6">
+        <section className="flex flex-col gap-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Community</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <NavCard href="/programs" title="Programs" description="Explore and join IS Web programs." />
+            <NavCard href="/members" title="Member directory" description="Browse and find other members." />
+            <NavCard
+              href="/intentions"
+              title="Current intentions"
+              description="See what the whole network is working toward."
+            />
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Personal</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <NavCard href="/myweb" title="My web" description="Build your relational map by adding connections!" />
+            <NavCard href="/profile" title="My profile" description="View and edit your profile information." />
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Admin</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <NavCard
+              href="/invites"
+              title="Invite a friend"
+              description="Generate an invite code to bring someone into the network."
+            />
+            <a
+              href="https://docs.google.com/forms/d/e/1FAIpQLScXhdSxbQ3LxjiYhqN2fmuyy66SK292rTYEZV3QaHgzn1eVjA/viewform?usp=dialog"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-5 transition-all hover:border-primary/40 hover:bg-accent hover:shadow-sm"
+            >
+              <h2 className="text-lg font-semibold text-card-foreground group-hover:text-accent-foreground">
+                Give Feedback
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Share your thoughts, suggestions, or report issues with the app.
+              </p>
+            </a>
+          </div>
+        </section>
       </div>
     </main>
   );


### PR DESCRIPTION
Groups the logged-in homepage cards into three labeled sections with small uppercase category headers:

- **Community** — Programs, Member directory, Current intentions
- **Personal** — My web, My profile
- **Admin** — Invite a friend, Give Feedback

Keeps the 2-column responsive grid within each section. No logic changes.

Addresses https://github.com/orgs/Intentional-Society/projects/2/views/1?pane=issue&itemId=196098252&issue=Intentional-Society%7Cis-app%7C337