### PR TITLE
feat(ui): block unsupported browsers with a legible notice (#365)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,7 @@
       "!supabase/templates/**/*.html",
       "!docs/_temp-*",
       "!drizzle/meta",
+      "!public/legacy-check.js",
       "!tests/functional/server/__data__"
     ]
   },

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-07 | James | Visible blocker for outdated browsers (#365)
+
+A layout-level ES5 check (`public/legacy-check.js`) feature-detects old browser engines and reveals a plain-HTML `LegacyBrowserNotice`.
+
 ## 2026-06-07 | Benji | Homepage card categories
 
 Grouped the logged-in homepage cards into three labeled sections — Community (Programs, Member directory, Current intentions), Personal (My web, My profile), and System (Invite a friend, Give Feedback) — with small uppercase category headers. Keeps the 2-column responsive grid within each section.

--- a/public/legacy-check.js
+++ b/public/legacy-check.js
@@ -1,0 +1,34 @@
+/*
+ * Boot-time browser capability check.
+ *
+ * This file is deliberately hand-written ES5 and is served verbatim from
+ * /public (never bundled or transpiled). It has to run on engines that
+ * CANNOT parse the main app bundle: Next 16 / React 19 emit ~2020-era syntax
+ * (optional chaining, nullish coalescing), so on an older engine — Safari ≤10,
+ * IE 11, legacy Edge, a dated Android/Chrome — the bundle throws a SyntaxError,
+ * React never hydrates, and interactive controls silently fall back to native
+ * behavior (e.g. the signup "Check code" button does a bare form submit that
+ * wipes the field). We can't catch that from inside the bundle, so we detect it
+ * out here and reveal a plain-HTML notice instead.
+ *
+ * Keep this ES5 (var, no arrow functions, no `?.`/`??`) so the warning can
+ * display on the very browsers it is meant to warn. It is excluded from
+ * Biome for the same reason — see biome.json.
+ */
+(function () {
+  // Each of these landed in Safari 13.1 / Chrome 85 / Firefox 77 — the same
+  // generation that added the syntax the app bundle needs. If any is missing,
+  // the bundle cannot run here.
+  var ok =
+    typeof String.prototype.replaceAll === "function" &&
+    typeof window.Promise !== "undefined" &&
+    typeof window.Promise.allSettled === "function" &&
+    typeof window.fetch === "function";
+
+  if (ok) return;
+
+  var el = document.getElementById("legacy-browser-warning");
+  if (el) el.style.display = "block";
+  // Lock scrolling so the blocking overlay can't be scrolled past.
+  if (document.body) document.body.style.overflow = "hidden";
+})();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { Gudea, Ovo } from "next/font/google";
 
 import { AuthProvider } from "@/components/auth-provider";
+import { LegacyBrowserNotice } from "@/components/legacy-browser-notice";
 import { NavigationHistory } from "@/components/navigation-history";
 import { QueryProvider } from "@/components/query-provider";
 import { SiteHeader } from "@/components/site-header";
@@ -51,6 +52,7 @@ export default async function RootLayout({
   return (
     <html lang="en" className={cn("font-sans", gudea.variable, ovo.variable)}>
       <body className="antialiased">
+        <LegacyBrowserNotice />
         <AuthProvider initialUser={user}>
           <QueryProvider>
             <NavigationHistory />

--- a/src/components/legacy-browser-notice.tsx
+++ b/src/components/legacy-browser-notice.tsx
@@ -1,0 +1,102 @@
+import type { CSSProperties } from "react";
+
+// A graceful, blocking "your browser is too old" notice for engines that can't
+// run the app. Next 16 / React 19 emit ~2020-era syntax (optional chaining,
+// nullish coalescing); older engines across the board — Safari ≤10, IE 11,
+// legacy Edge, dated Android/Chrome — fail to parse the bundle, so React never
+// hydrates and interactive controls silently fall back to native behavior. None
+// of React runs there, so this is deliberately plain server-rendered HTML plus an
+// ES5 script (public/legacy-check.js) that reveals the overlay without the
+// framework.
+//
+// Styling targets old browsers broadly: inline values only,
+// no oklch tokens / CSS variables / flex `gap`; rgba and box-shadow are fine
+// (IE9+). The hide/show toggle is `display:block`/`none` (universally honored);
+// flexbox only centers the card and falls back to `margin:0 auto` (horizontal) +
+// top padding where it's absent or buggy (IE10, old Android). See GitHub issue
+// #365.
+const overlayBase: CSSProperties = {
+  position: "fixed",
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  zIndex: 2147483647,
+  backgroundColor: "rgba(0, 0, 0, 0.8)",
+  // Scroll the overlay itself (not the page behind) if the card is taller than a
+  // short/old viewport, so the message can't get clipped out of reach.
+  overflowY: "auto",
+};
+
+const centerer: CSSProperties = {
+  boxSizing: "border-box",
+  width: "100%",
+  height: "100%",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "24px",
+};
+
+const cardStyle: CSSProperties = {
+  boxSizing: "border-box",
+  width: "100%",
+  maxWidth: "460px",
+  // `margin: 0 auto` centers horizontally even when the flex container above is
+  // ignored (engines without working flexbox fall back to block layout).
+  margin: "0 auto",
+  backgroundColor: "#ffffff",
+  color: "#1c1917",
+  borderRadius: "12px",
+  padding: "28px 32px",
+  textAlign: "center",
+  // Cross-platform system stack — not WebKit-only `-apple-system`, which leaves
+  // non-Apple engines fontless. Falls through to Arial/sans-serif everywhere.
+  fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+  boxShadow: "0 10px 40px rgba(0, 0, 0, 0.35)",
+};
+
+const headingStyle: CSSProperties = {
+  margin: "0 0 12px",
+  fontSize: "20px",
+  fontWeight: 700,
+  color: "#7f1d1d",
+};
+
+const messageStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "15px",
+  lineHeight: 1.5,
+};
+
+const HEADING = "Please update your browser";
+const MESSAGE =
+  "The IS Web App requires a modern web browser — less than 6 years old, approximately. Please open this page in the latest Chrome, Firefox, Safari, or Edge to continue.";
+
+function NoticeCard() {
+  return (
+    <div style={centerer}>
+      <div style={cardStyle} role="alert">
+        <p style={headingStyle}>{HEADING}</p>
+        <p style={messageStyle}>{MESSAGE}</p>
+      </div>
+    </div>
+  );
+}
+
+export function LegacyBrowserNotice() {
+  return (
+    <>
+      <div id="legacy-browser-warning" style={{ ...overlayBase, display: "none" }}>
+        <NoticeCard />
+      </div>
+      {/* Same notice for browsers with JavaScript disabled, where the app also can't run. */}
+      <noscript>
+        <div style={{ ...overlayBase, display: "block" }}>
+          <NoticeCard />
+        </div>
+      </noscript>
+      <script defer src="/legacy-check.js" />
+    </>
+  );
+}


### PR DESCRIPTION
Summary: Show a blocking, centered notice on browsers too old to run the app, instead of letting the UI silently fail.

Why: Browsers that can't parse the modern bundle (Safari ≤10, IE 11, legacy Edge, dated Android/Chrome) never hydrate, so interactive controls fall back to native behavior — a signup visitor's "Check code" click did a bare form submit that wiped the field with no error.

Behavior: A boot-time ES5 check (`public/legacy-check.js`) feature-detects the capability gap, reveals a full-screen `LegacyBrowserNotice`, and locks page scroll. Both run as plain server-rendered HTML + a deferred script, outside the framework, so they work even when the bundle can't parse. No visible change on current browsers (overlay stays `display:none`). Styling is old-browser-safe (inline values, no oklch / CSS-vars / flex-gap); `legacy-check.js` is excluded from Biome to keep it ES5.

Test Plan:
- ran `npm test` locally — lint, typecheck, functional, and 29 e2e all green, including the `/signup` invite flow the notice sits over
- captured the overlay on Chromium with the probed capabilities stripped: control hidden, simulated-old shows the blocking modal

Closes #365

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
