### PR TITLE
docs(emails): record confirmations-off decision; fix template drift

### DIFF
--- a/docs/design-emails.md
+++ b/docs/design-emails.md
@@ -26,15 +26,25 @@ reachable:
 | `magic_link`      | `/signin` and `/signup` (both existing and new emails) |
 | `recovery`        | `/forgot-password`                              |
 
-**Verified in Inbucket during implementation:** the `confirmation` template
-(commonly assumed to fire for brand-new signups) is *not* reached by current
-flows. GoTrue's `/otp` endpoint sends the `magic_link` template for both
-existing and new users; `confirmation` only fires from `signUp({ email, password })`,
-which the app doesn't call anywhere. So a single magic-link template body
-needs to read naturally for both "sign in" and "first-time sign up" cases.
+`signInWithOtp` — the only account-creation path (`/signup`) — renders
+`magic_link` for both returning and brand-new emails, so one magic-link body
+has to read naturally as both "sign in" and "first-time sign up." This holds
+because **email confirmations are off** (prod dashboard → Authentication →
+Email; local `supabase/config.toml` → `enable_confirmations = false`). With
+confirmations *on*, a first-time email gets the `confirmation` template instead
+([discussion #28947](https://github.com/orgs/supabase/discussions/28947)) — the
+unstyled-signup-email bug (#366).
 
-The remaining templates (`invite`, `confirmation`, `email_change`,
-`reauthentication`) are unreachable from current UI and stay on Supabase
+Confirmations are off **by design**: account creation is OTP-only, so the link
+click already proves the recipient controls the inbox and sets
+`email_confirmed_at` — a separate confirmation step adds no security on this
+path. Adding a `signUp({ email, password })` flow is the one change that would
+flip the decision; that PR re-enables confirmations and authors a styled
+`confirmation.html`. Full rationale: `docs/doc-supabase.md` → Authentication →
+Email.
+
+The other templates (`invite`, `confirmation`, `email_change`,
+`reauthentication`) aren't reached by current flows and stay on Supabase
 defaults.
 
 ---
@@ -46,7 +56,6 @@ Template bodies live in the repo:
 ```
 supabase/templates/
   magic-link.html
-  confirmation.html
   recovery.html
   templates.manifest.mjs    # type → { subject, file }
 ```
@@ -55,7 +64,7 @@ The HTML files are the single source of truth. Subjects sit alongside them
 in `templates.manifest.mjs` because Supabase carries the subject as a
 separate config field, not as `<title>` on the body.
 
-Files are self-contained — no shared layout / partials. For three templates
+Files are self-contained — no shared layout / partials. For two templates
 the duplication is cheap; introducing a build step would be premature.
 If the count grows, the option is to compose at build time into a
 gitignored `supabase/templates/_generated/` directory that both the local
@@ -66,20 +75,16 @@ config and the prod sync read from.
 ## Local dev wiring
 
 `supabase/config.toml` already supports per-template overrides. Each template
-gets a block referencing the file by path relative to `supabase/`:
+gets a block referencing the file by path relative to the repo root:
 
 ```toml
 [auth.email.template.magic_link]
-subject = "Your Intentional Society sign-in link"
-content_path = "./templates/magic-link.html"
-
-[auth.email.template.confirmation]
-subject = "Confirm your Intentional Society account"
-content_path = "./templates/confirmation.html"
+subject = "Sign in to the IS Web App"
+content_path = "./supabase/templates/magic-link.html"
 
 [auth.email.template.recovery]
-subject = "Reset your Intentional Society password"
-content_path = "./templates/recovery.html"
+subject = "Reset your IS Web App password"
+content_path = "./supabase/templates/recovery.html"
 ```
 
 `supabase start` picks these up. Config changes are not hot-reloaded — a
@@ -107,8 +112,6 @@ Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}
 {
   "mailer_subjects_magic_link": "...",
   "mailer_templates_magic_link_content": "<html>...</html>",
-  "mailer_subjects_confirmation": "...",
-  "mailer_templates_confirmation_content": "<html>...</html>",
   "mailer_subjects_recovery": "...",
   "mailer_templates_recovery_content": "<html>...</html>"
 }

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-07 | James | Supabase config change: Irrelevant "Confirm email" setting is off (#366)
+
+Production Supabase **Confirm email** toggle is now off so new invitees get the branded `magic_link` — the path returning members already use. Re-enable only if a `signUp({ email, password })` path is ever added.
+
 ## 2026-06-07 | James | Visible blocker for outdated browsers (#365)
 
 A layout-level ES5 check (`public/legacy-check.js`) feature-detects old browser engines and reveals a plain-HTML `LegacyBrowserNotice`.

--- a/docs/doc-supabase.md
+++ b/docs/doc-supabase.md
@@ -80,6 +80,14 @@ The `/**` wildcard covers the `emailRedirectTo` targets all three forms pass —
 - **Email (magic link):** enabled — primary sign-in path.
 - **Email + password:** enabled — backs the password-reset flow at `/forgot-password` and the change-password form in profile edit. Sign-in via password is also possible from `/signin` for any member who has set one.
 
+### Authentication → Email — "Confirm email" is off
+
+The **Confirm email** toggle (Authentication → Email provider) is **off** in prod, matching local (`supabase/config.toml` → `enable_confirmations = false`). With it on, a brand-new email at `/signup` received Supabase's stock, unstyled `confirmation` template instead of the branded `magic_link` one (#366).
+
+Off is safe here because account creation is OTP-only: `signInWithOtp` is the sole path to a user row, and clicking the emailed link both creates the account and sets `email_confirmed_at` — the click already proves inbox ownership, which is the whole job of a confirmation step. Every account lands confirmed regardless of the toggle, and the password surfaces (`signInWithPassword`, `updateUser({ password })`) only act on accounts already created — and thus already confirmed — via OTP.
+
+Supabase's [general-configuration guide](https://supabase.com/docs/guides/auth/general-configuration) advises keeping confirmations on; that guidance targets the `signUp({ email, password })` default, where a user could otherwise hold a session without proving email ownership. The app has no such path. Adding one is the single condition that flips this decision — re-enable the toggle and author a styled `confirmation.html` (`docs/design-emails.md` → Templates in scope) in that same change.
+
 ### Authentication → SMTP
 
 Production routes auth emails through custom SMTP (Resend). Configure under Authentication → SMTP Settings:
@@ -99,7 +107,7 @@ See `docs/doc-resend.md` for why Resend over alternatives, the sending-domain ra
 
 ### Authentication → Email templates
 
-Auth email templates (magic link, signup confirmation, password recovery) are **managed from the repo**, not the dashboard. Source files live in `supabase/templates/` with a manifest at `supabase/templates/templates.manifest.mjs`. The local stack picks them up via `[auth.email.template.*]` blocks in `supabase/config.toml`. To update prod, edit the files and run `npm run update_email_templates` — the script PATCHes the Supabase Management API and overwrites whatever's in the dashboard. Dashboard edits will be silently clobbered on the next push; the repo wins. `npm run download_email_templates` snapshots the current hosted state to the committed `supabase/templates/_remote-snapshot/` directory — run it before each push so the snapshot stays current and the PR diff shows exactly what's changing for recipients.
+Auth email templates (magic link, password recovery) are **managed from the repo**, not the dashboard. Source files live in `supabase/templates/` with a manifest at `supabase/templates/templates.manifest.mjs`. The local stack picks them up via `[auth.email.template.*]` blocks in `supabase/config.toml`. To update prod, edit the files and run `npm run update_email_templates` — the script PATCHes the Supabase Management API and overwrites whatever's in the dashboard. Dashboard edits will be silently clobbered on the next push; the repo wins. `npm run download_email_templates` snapshots the current hosted state to the committed `supabase/templates/_remote-snapshot/` directory — run it before each push so the snapshot stays current and the PR diff shows exactly what's changing for recipients.
 
 Design and rationale: `docs/design-emails.md`.
 


### PR DESCRIPTION
Summary: Document that prod email confirmations are deliberately off so new
members get the branded magic_link, and correct design-emails.md to match the
real two-template setup.

Why: A new member received Supabase's stock unstyled "Confirm your signup"
email (#366). Account creation is OTP-only, so the link click already proves
inbox ownership — a confirmation step adds no security here. The fix was to
keep confirmations off and route new members through the already-styled
magic_link, not to author a confirmation template. The old "confirmation is
unreachable" note was a local-only false negative (local off, prod on) that
hid the drift.

Behavior: Docs only — no code or runtime change. design-emails.md now states
magic_link covers new + returning because confirmations are off, and drops the
phantom confirmation.html / confirmation config block / confirmation PATCH
field that never existed in the real manifest. New doc-supabase.md subsection
records the "Confirm email = off" prod setting and why it's safe for an
OTP-only app. Devjournal entry added.

Test Plan:
- ran `npm test` locally — 385 functional + 29 e2e green; re-ran green after rebasing onto current main

(#366)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
