### PR TITLE
test(e2e): make warm-up fail loudly with bounded retries

### DIFF
--- a/tests/e2e/reset.setup.ts
+++ b/tests/e2e/reset.setup.ts
@@ -29,18 +29,20 @@ const WARMUP_FIRST_NAV_TIMEOUT_MS = 30_000;
 const WARMUP_RETRY_NAV_TIMEOUT_MS = 8_000;
 const WARMUP_ATTEMPTS = 2;
 
-// Hard ceiling on the whole route-warming phase, shared across all routes:
-// once it's spent, warm-up gives up loudly instead of grinding through every
-// remaining route's retries. This — not the per-attempt windows — is what
-// bounds the worst case when the network browns out mid-run. A persistent
-// brownout still recovers via CI's project-level `retries: 2`, which re-runs
-// the whole setup test later.
+// Hard ceilings on each warm-up phase — the routes loop and the sign-in
+// respectively. Once a phase's budget is spent it gives up loudly instead of
+// grinding through every remaining retry. These — not the per-attempt windows
+// — are what bound the worst case when the network browns out mid-run. A
+// persistent brownout still recovers via CI's project-level `retries: 2`,
+// which re-runs the whole setup test later.
 const WARMUP_ROUTES_BUDGET_MS = 75_000;
+const WARMUP_SIGN_IN_BUDGET_MS = 25_000;
 
-// Generous backstop above the route budget + sign-in warm-up, so the named
-// budget/attempt errors below fire first. Playwright's 30s default test
-// timeout is far too tight for a cold first hit, and would trip with an
-// opaque message before the retry logic could run.
+// The setup test timeout sits above both phase budgets plus waitForURL slack
+// (75s + 25s + ~12s), so the named budget/attempt errors below always fire
+// before Playwright's opaque "Test timeout exceeded" message. Its 30s default
+// is far too tight for a cold first hit, and would trip before the retry logic
+// could run.
 const WARMUP_TEST_TIMEOUT_MS = 120_000;
 
 // Navigate to a route with one short retry, bounded by both its per-attempt
@@ -88,11 +90,21 @@ setup("warm up the page-serving path", async ({ page }) => {
   }
 
   // Warm the authed landing through a real sign-in, retrying on the same
-  // cold/brownout terms. signInAs's own waitForURL runs on the 12s TIMEOUT_MS;
-  // a first attempt that misses a cold landing usually warms it enough for the
-  // retry to land.
+  // cold/brownout terms. signInAs carries no explicit timeout on its goto or
+  // form actions, and Playwright Test defaults navigationTimeout/actionTimeout
+  // to 0 — so those operations would otherwise fall back to the whole remaining
+  // test budget, letting one hung goto trip the opaque test timeout. Cap every
+  // navigation/action to the remaining sign-in budget so this phase fails with
+  // the named error below instead. (signInAs's waitForURL keeps its own 12s.)
+  const signInDeadline = Date.now() + WARMUP_SIGN_IN_BUDGET_MS;
   let lastError: unknown;
   for (let attempt = 1; attempt <= WARMUP_ATTEMPTS; attempt++) {
+    const remaining = signInDeadline - Date.now();
+    if (remaining <= 0) {
+      break;
+    }
+    page.setDefaultNavigationTimeout(remaining);
+    page.setDefaultTimeout(remaining);
     try {
       await signInAs(page, "regular");
       return;

--- a/tests/e2e/reset.setup.ts
+++ b/tests/e2e/reset.setup.ts
@@ -1,4 +1,4 @@
-import { test as setup } from "@playwright/test";
+import { type Page, test as setup } from "@playwright/test";
 
 import { resetSeededUsers, signInAs } from "./helpers/session";
 
@@ -13,21 +13,93 @@ setup("reset seeded test users", async ({ baseURL }) => {
   await resetSeededUsers(baseURL);
 });
 
-// Warm the page-serving path before any timed test runs. Local e2e hits
-// `next dev`, which compiles each route on first request; CI's first hit
-// cold-starts the Vercel functions. Either way the *first* test used to
-// pay that cost inside signInAs's waitForURL budget and flake (always the
-// alphabetically-first spec). Paying it here, in untimed setup, makes the
-// first real test no longer special — and lets TIMEOUT_MS sit tight at 12s.
-//
-// The reset above only warms one API function; this warms the React/SSR
-// page pipeline + the public routes, then signs in once to warm the authed
-// landing the way every test reaches it. The sign-in is read-only (no
-// completeWelcome), so the welcome spec still sees a fresh user. Best-effort
-// throughout: a warm-up miss must never turn into a suite failure.
-setup("warm up the page-serving path", async ({ page }) => {
-  for (const path of ["/signin", "/", "/signup", "/forgot-password"]) {
-    await page.goto(path).catch(() => {});
+// Public routes whose first hit pays compile (local `next dev`) or
+// function spin-up (CI Vercel) cost.
+const WARMUP_ROUTES = ["/signin", "/", "/signup", "/forgot-password"];
+
+// Per-attempt navigation windows. The first hit gets a generous window so a
+// slow cold start still has room to respond — a cold function on a degraded CI
+// network (#368) can exceed 30s. The retry is deliberately short: a function
+// that's spinning up answers within a second or two, and a still-dead one
+// should fail fast rather than burn another full window. `domcontentloaded` is
+// the right signal — it fires once the route compiles and its HTML parses,
+// which is the cost being paid forward; waiting for full `load` only adds
+// fragility, since sub-resources warm on their own once the function is hot.
+const WARMUP_FIRST_NAV_TIMEOUT_MS = 30_000;
+const WARMUP_RETRY_NAV_TIMEOUT_MS = 8_000;
+const WARMUP_ATTEMPTS = 2;
+
+// Hard ceiling on the whole route-warming phase, shared across all routes:
+// once it's spent, warm-up gives up loudly instead of grinding through every
+// remaining route's retries. This — not the per-attempt windows — is what
+// bounds the worst case when the network browns out mid-run. A persistent
+// brownout still recovers via CI's project-level `retries: 2`, which re-runs
+// the whole setup test later.
+const WARMUP_ROUTES_BUDGET_MS = 75_000;
+
+// Generous backstop above the route budget + sign-in warm-up, so the named
+// budget/attempt errors below fire first. Playwright's 30s default test
+// timeout is far too tight for a cold first hit, and would trip with an
+// opaque message before the retry logic could run.
+const WARMUP_TEST_TIMEOUT_MS = 120_000;
+
+// Navigate to a route with one short retry, bounded by both its per-attempt
+// window and the shared deadline. Returns once the document parses; throws a
+// named error (which fails the setup project) once the attempts or the
+// deadline are spent.
+const warmRoute = async (page: Page, path: string, deadlineMs: number): Promise<void> => {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= WARMUP_ATTEMPTS; attempt++) {
+    const remaining = deadlineMs - Date.now();
+    if (remaining <= 0) {
+      throw new Error(`warm-up: routes budget spent before ${path} could warm`);
+    }
+    const perAttempt = attempt === 1 ? WARMUP_FIRST_NAV_TIMEOUT_MS : WARMUP_RETRY_NAV_TIMEOUT_MS;
+    try {
+      await page.goto(path, { waitUntil: "domcontentloaded", timeout: Math.min(perAttempt, remaining) });
+      return;
+    } catch (error) {
+      lastError = error;
+    }
   }
-  await signInAs(page, "regular").catch(() => {});
+  const reason = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(`warm-up: ${path} did not respond after ${WARMUP_ATTEMPTS} attempts: ${reason}`);
+};
+
+// Warm the page-serving path before any timed test runs. Paying cold-start
+// cost here, in untimed setup, means the first real test no longer pays it
+// inside signInAs's waitForURL budget — so TIMEOUT_MS can sit tight at 12s.
+// The reset above only warms one API function; this warms the React/SSR page
+// pipeline + the public routes, then signs in once to warm the authed landing
+// the way every test reaches it. The sign-in is read-only (no completeWelcome),
+// so the welcome spec still sees a fresh user.
+//
+// A warm-up that can't complete after its retries fails this setup project
+// loudly: a cold/brownout run becomes a clear "warm-up: X did not respond"
+// error rather than a confusing downstream first-test flake (#368). CI's
+// project-level `retries: 2` still re-runs the whole warm-up, so only a
+// persistent brownout fails the suite — a transient one recovers on retry.
+setup("warm up the page-serving path", async ({ page }) => {
+  setup.setTimeout(WARMUP_TEST_TIMEOUT_MS);
+
+  const routesDeadline = Date.now() + WARMUP_ROUTES_BUDGET_MS;
+  for (const path of WARMUP_ROUTES) {
+    await warmRoute(page, path, routesDeadline);
+  }
+
+  // Warm the authed landing through a real sign-in, retrying on the same
+  // cold/brownout terms. signInAs's own waitForURL runs on the 12s TIMEOUT_MS;
+  // a first attempt that misses a cold landing usually warms it enough for the
+  // retry to land.
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= WARMUP_ATTEMPTS; attempt++) {
+    try {
+      await signInAs(page, "regular");
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  const reason = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(`warm-up: sign-in did not complete after ${WARMUP_ATTEMPTS} attempts: ${reason}`);
 });


### PR DESCRIPTION
## Summary

Replace the e2e warm-up's swallowed `page.goto` calls with a retrying, deadline-bounded warm-up that fails the setup project loudly when a route or the sign-in can't warm.

## Why

#360 added a warm-up in `reset.setup.ts` to pay cold-start cost in untimed setup, but it navigated via `page.goto(path).catch(() => {})`. Under the cold-function + degraded-network brownout it exists to absorb, those gotos time out and are silently swallowed — so the routes aren't actually warm and the failure resurfaces as a confusing first-test flake (recurred on #367).

## Behavior

- Each route warms with one short retry and `waitUntil: "domcontentloaded"` (lighter than `"load"`); the sign-in warm-up retries on the same terms.
- A route or sign-in that can't warm after its retries throws a named error (`warm-up: /signin did not respond ...`), failing the setup project loudly instead of flaking downstream. CI's project-level `retries: 2` still rides out a transient brownout.
- A 75s deadline shared across all routes bounds the worst-case wait: a single hung route gives up at ~38s (was 90s), a full brownout at ~75s (was ~180s), with a 120s test-timeout backstop (was 240s).

## Test Plan

- ran `npm test` locally — lint, typecheck, Vitest functional, and 29 Playwright e2e all green
- confirmed the warm-up setup project warms fast on a healthy run; the new retry/deadline paths only engage on a cold/brownout miss

## Checklist

- [x] N/A — this PR changes no `.claude/skills/**/SKILL.md`.

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
