### PR TITLE
feat(signup): link-first copy and code-aware "Sign up" button

### DIFF
--- a/public/legacy-check.js
+++ b/public/legacy-check.js
@@ -7,7 +7,7 @@
  * (optional chaining, nullish coalescing), so on an older engine — Safari ≤10,
  * IE 11, legacy Edge, a dated Android/Chrome — the bundle throws a SyntaxError,
  * React never hydrates, and interactive controls silently fall back to native
- * behavior (e.g. the signup "Check code" button does a bare form submit that
+ * behavior (e.g. the signup "Sign up!" button does a bare form submit that
  * wipes the field). We can't catch that from inside the bundle, so we detect it
  * out here and reveal a plain-HTML notice instead.
  *

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -26,10 +26,7 @@ export default async function SignupPage({ searchParams }: SignupPageProps) {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
       <AppWordmark asLink />
-      <p className="max-w-sm text-center text-base text-muted-foreground">
-        Joining by invite? Enter the code a member shared with you.
-      </p>
-      <SignupForm initialCode={code ?? ""} />
+      <SignupForm initialCode={code ?? ""} intro="You've been invited to join the Intentional Society Web App." />
       <p className="text-base text-muted-foreground">
         Already a member?{" "}
         <Link href="/signin" className="underline text-muted-foreground hover:text-foreground">

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -26,7 +26,10 @@ export default async function SignupPage({ searchParams }: SignupPageProps) {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
       <AppWordmark asLink />
-      <SignupForm initialCode={code ?? ""} intro="You've been invited to join the Intentional Society Web App." />
+      <SignupForm
+        initialCode={code ?? ""}
+        intro="You've been invited to join! If your link has prefilled the code below, just hit the 'Sign up!' button to get going. Otherwise, paste in the invite code."
+      />
       <p className="text-base text-muted-foreground">
         Already a member?{" "}
         <Link href="/signin" className="underline text-muted-foreground hover:text-foreground">

--- a/src/app/signup/signup-form.tsx
+++ b/src/app/signup/signup-form.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { apiClient } from "@/lib/api";
+import { INVITE_CODE_LENGTH } from "@/lib/invite-limits";
 import { createClient } from "@/lib/supabase/client";
 
 type Step =
@@ -23,7 +24,7 @@ const REASON_MESSAGES: Record<string, string> = {
   redeemed: "That invite has already been used.",
 };
 
-export function SignupForm({ initialCode }: { initialCode: string }) {
+export function SignupForm({ initialCode, intro }: { initialCode: string; intro: string }) {
   const [step, setStep] = useState<Step>({ kind: "enter-code" });
   const [codeInput, setCodeInput] = useState(initialCode);
   const [email, setEmail] = useState("");
@@ -93,20 +94,19 @@ export function SignupForm({ initialCode }: { initialCode: string }) {
     }
   };
 
+  let content: React.ReactNode;
   if (step.kind === "sent") {
-    return (
+    content = (
       <p className="max-w-sm text-center text-base text-foreground">
         Check <span className="font-semibold">{step.email}</span> for a sign-in link. It expires in 15 minutes.
       </p>
     );
-  }
-
-  if (step.kind === "code-valid" || step.kind === "submitting" || step.kind === "error") {
+  } else if (step.kind === "code-valid" || step.kind === "submitting" || step.kind === "error") {
     const submitting = step.kind === "submitting";
-    return (
-      <form onSubmit={sendMagicLink} className="flex w-full max-w-sm flex-col gap-3">
+    content = (
+      <form onSubmit={sendMagicLink} className="flex w-full flex-col gap-3">
         <p className="rounded border border-border bg-muted p-3 text-base text-foreground">
-          <span className="block text-sm uppercase tracking-wide text-muted-foreground">Your invite note</span>
+          <span className="block text-sm uppercase tracking-wide text-muted-foreground">This invitation is for…</span>
           {step.note}
         </p>
         <Label htmlFor="displayName">Display name</Label>
@@ -130,7 +130,7 @@ export function SignupForm({ initialCode }: { initialCode: string }) {
           disabled={submitting}
         />
         <Button type="submit" disabled={submitting}>
-          {submitting ? "Sending…" : "Send sign-in link"}
+          {submitting ? "Sending…" : "Verify your email"}
         </Button>
         {step.kind === "error" && (
           <p role="alert" className="text-base text-destructive">
@@ -139,32 +139,40 @@ export function SignupForm({ initialCode }: { initialCode: string }) {
         )}
       </form>
     );
+  } else {
+    const checking = step.kind === "code-checking";
+    const ready = codeInput.trim().length === INVITE_CODE_LENGTH;
+    content = (
+      <form onSubmit={checkCode} className="flex w-full flex-col gap-3">
+        <Label htmlFor="code">Invite code</Label>
+        <Input
+          id="code"
+          type="text"
+          required
+          autoComplete="off"
+          autoCapitalize="characters"
+          spellCheck={false}
+          value={codeInput}
+          onChange={(event) => setCodeInput(event.target.value)}
+          disabled={checking}
+          className="font-mono uppercase"
+        />
+        <Button type="submit" disabled={checking || !ready}>
+          {checking ? "Checking…" : ready ? "Sign up!" : "Enter invite code…"}
+        </Button>
+        {step.kind === "enter-code" && step.error && (
+          <p role="alert" className="text-base text-destructive">
+            {step.error}
+          </p>
+        )}
+      </form>
+    );
   }
 
-  const checking = step.kind === "code-checking";
   return (
-    <form onSubmit={checkCode} className="flex w-full max-w-sm flex-col gap-3">
-      <Label htmlFor="code">Invite code</Label>
-      <Input
-        id="code"
-        type="text"
-        required
-        autoComplete="off"
-        autoCapitalize="characters"
-        spellCheck={false}
-        value={codeInput}
-        onChange={(event) => setCodeInput(event.target.value)}
-        disabled={checking}
-        className="font-mono uppercase"
-      />
-      <Button type="submit" disabled={checking}>
-        {checking ? "Checking…" : "Check code"}
-      </Button>
-      {step.kind === "enter-code" && step.error && (
-        <p role="alert" className="text-base text-destructive">
-          {step.error}
-        </p>
-      )}
-    </form>
+    <div className="flex w-full max-w-sm flex-col items-center gap-6">
+      {step.kind !== "sent" && <p className="text-center text-base text-muted-foreground">{intro}</p>}
+      {content}
+    </div>
   );
 }

--- a/src/lib/invite-limits.ts
+++ b/src/lib/invite-limits.ts
@@ -6,3 +6,8 @@
 
 export const MIN_NOTE_LENGTH = 5;
 export const HINTS_PER_INVITE_LIMIT = 20;
+
+// Characters in a generated invite code. The server uses it to generate
+// codes; the signup form uses it to gate the submit button until a full
+// code is present.
+export const INVITE_CODE_LENGTH = 10;

--- a/src/server/invites.ts
+++ b/src/server/invites.ts
@@ -2,7 +2,7 @@ import { randomInt } from "node:crypto";
 import { and, count, desc, eq, gt, isNull, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
-import { MIN_NOTE_LENGTH } from "@/lib/invite-limits";
+import { INVITE_CODE_LENGTH, MIN_NOTE_LENGTH } from "@/lib/invite-limits";
 import { isRelationValue, type RelationValue } from "@/lib/relation-value";
 
 import { db } from "./db";
@@ -12,7 +12,6 @@ import { invites, profiles } from "./schema";
 // Alphabet: 24 uppercase letters (no I, O — visually confusable with
 // 1/0) plus 8 digits (no 0, 1 — same reason). 32 chars.
 const CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-const CODE_LENGTH = 10;
 // 32^10 ≈ 1.1e15 — sparse enough that collisions are vanishingly rare;
 // the unique constraint is the real safety net.
 
@@ -37,7 +36,7 @@ export type InviteForCreator = {
 // random bytes, which is what CodeQL flags as a biasing operation.
 const generateInviteCode = (): string => {
   let out = "";
-  for (let i = 0; i < CODE_LENGTH; i++) {
+  for (let i = 0; i < INVITE_CODE_LENGTH; i++) {
     out += CODE_ALPHABET[randomInt(CODE_ALPHABET.length)];
   }
   return out;

--- a/tests/e2e/invites.spec.ts
+++ b/tests/e2e/invites.spec.ts
@@ -78,8 +78,14 @@ test.describe("invites — authed member flow", () => {
 test.describe("/signup — unauthed invite flow", () => {
   test("invalid code shows a specific error message", async ({ page }) => {
     await page.goto("/signup");
+
+    // Link-first intro, and the submit button stays disabled
+    // ("Enter invite code…") until a full-length code is present.
+    await expect(page.getByText("You've been invited to join the Intentional Society Web App.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Enter invite code…" })).toBeDisabled();
+
     await page.getByLabel("Invite code").fill("ZZZZZZZZZZ");
-    await page.getByRole("button", { name: "Check code" }).click();
+    await page.getByRole("button", { name: "Sign up!" }).click();
     await expect(page.getByText(/doesn't match any invite/)).toBeVisible();
   });
 
@@ -128,16 +134,18 @@ test.describe("/signup — unauthed invite flow", () => {
 
       await guestPage.goto("/signup");
       await guestPage.getByLabel("Invite code").fill(code);
-      await guestPage.getByRole("button", { name: "Check code" }).click();
+      await guestPage.getByRole("button", { name: "Sign up!" }).click();
 
       await expect(guestPage.getByText("e2e signup-flow invite — come on in")).toBeVisible();
 
       await guestPage.getByLabel("Display name").fill("Future Member");
       await guestPage.getByLabel("Email").fill("future-member@testfake.local");
-      await guestPage.getByRole("button", { name: "Send sign-in link" }).click();
+      await guestPage.getByRole("button", { name: "Verify your email" }).click();
 
       await expect(guestPage.getByText("future-member@testfake.local")).toBeVisible();
       await expect(guestPage.getByText(/Check.*for a sign-in link/)).toBeVisible();
+      // The intro line drops away once we switch to the "check your email" state.
+      await expect(guestPage.getByText("You've been invited to join the Intentional Society Web App.")).toBeHidden();
     } finally {
       await guestContext.close();
     }

--- a/tests/e2e/invites.spec.ts
+++ b/tests/e2e/invites.spec.ts
@@ -81,7 +81,7 @@ test.describe("/signup — unauthed invite flow", () => {
 
     // Link-first intro, and the submit button stays disabled
     // ("Enter invite code…") until a full-length code is present.
-    await expect(page.getByText("You've been invited to join the Intentional Society Web App.")).toBeVisible();
+    await expect(page.getByText("You've been invited to join!")).toBeVisible();
     await expect(page.getByRole("button", { name: "Enter invite code…" })).toBeDisabled();
 
     await page.getByLabel("Invite code").fill("ZZZZZZZZZZ");
@@ -145,7 +145,7 @@ test.describe("/signup — unauthed invite flow", () => {
       await expect(guestPage.getByText("future-member@testfake.local")).toBeVisible();
       await expect(guestPage.getByText(/Check.*for a sign-in link/)).toBeVisible();
       // The intro line drops away once we switch to the "check your email" state.
-      await expect(guestPage.getByText("You've been invited to join the Intentional Society Web App.")).toBeHidden();
+      await expect(guestPage.getByText("You've been invited to join!")).toBeHidden();
     } finally {
       await guestContext.close();
     }


### PR DESCRIPTION
Summary: Rework the /signup copy and primary button for visitors who arrive
via an invite link with the code already prefilled.

Why: User testing (2026-06-07) found the type-a-code framing no longer fits —
the primary arrival path is a link, not a raw code.

Behavior:
- Intro explains the link-vs-paste flow ("You've been invited to join! …just
  hit the 'Sign up!' button to get going. Otherwise, paste in the invite
  code.") and disappears once the "check your email" confirmation shows.
- Submit button stays disabled/greyed as "Enter invite code…" until a full
  10-char code is present, then enables as "Sign up!".
- Invite-note label: "Your invite note" → "This invitation is for…".
- Magic-link button: "Send sign-in link" → "Verify your email" (signup flow
  only; /signin is unchanged).
- INVITE_CODE_LENGTH now lives once in src/lib/invite-limits.ts, shared by the
  server code generator and the signup form.

Test Plan:
- ran `npm test` locally (Biome + tsc clean, 385 functional, 29 e2e — all green)
- invites.spec.ts now asserts the disabled "Enter invite code…" state and the
  intro hiding in the sent state

Closes #370

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
