### PR TITLE
test(e2e): reuse a running dev server for local runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Intentional Society web application — an authenticated app for a small, global
 - `npm run lint` — Biome
 - `npm test` — run all test suites (functional + e2e)
 - `npm run test:functional` — Vitest only
-- `npm run test:e2e` — Playwright only (Chromium, uses port 3093)
+- `npm run test:e2e` — Playwright only (Chromium); reuses a running dev server, else starts one on the dev port (3000, or the lane's `LANE_DEV_PORT`)
 - `npm run watch` — Vitest watch mode
 - `npm run dev:db:stop` — stop local Supabase containers
 - `npm run dev:db:reset` — wipe local DB and reapply migrations

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-08 | James | Local e2e reuses the running dev server (#372)
+
+Playwright now targets the dev port and reuses a running `npm run dev` (via `reuseExistingServer`), so you no longer stop your dev server to run e2e; lanes set only `LANE_DEV_PORT` and the separate `E2E_PORT` is retired (stale lines in existing lane `.env.local`s are ignored). Tradeoff: an e2e run resets and drives the seeded `@testfake.local` users in your dev DB. Reference: docs/strategy-worktree-lanes.md.
+
 ## 2026-06-08 | James | One-click dev sign-in as Aria Chen
 
 One-click sign-in as Aria Chen, now promoted to demo user in the dev-seed data.

--- a/docs/strategy-worktree-lanes.md
+++ b/docs/strategy-worktree-lanes.md
@@ -9,11 +9,11 @@ diffs.
 ## Why a "lane" is needed
 
 The local Supabase stack is a singleton: it's keyed by `project_id` in
-`supabase/config.toml` and binds fixed host ports, and the e2e suite binds a
-fixed web-server port (3093) and wipes the database via `/api/_test/reset`.
-Two checkouts pointed at one stack therefore clobber each other's data and
-ports. GoTrue (auth) and Storage can't be multi-tenanted, so the only real
-isolation is **one full Supabase stack per worktree** — a *lane*.
+`supabase/config.toml` and binds fixed host ports, and the e2e suite wipes the
+database via `/api/_test/reset`. Two checkouts pointed at one stack therefore
+clobber each other's data and ports. GoTrue (auth) and Storage can't be
+multi-tenanted, so the only real isolation is **one full Supabase stack per
+worktree** — a *lane*.
 
 A lane is just a port offset + a renamed Supabase project, derived from the
 worktree's directory name:
@@ -32,7 +32,9 @@ worktree's directory name:
 | Inbucket (email)     | 54324 | 54524  | 54624  |
 | shadow / analytics / pooler | 54320/54327/54329 | +200 | +300 |
 | `next dev`           | 3000  | 3200   | 3300   |
-| e2e web server       | 3093  | 3293   | 3393   |
+
+The e2e suite has no port of its own — it reuses the lane's `next dev` server
+(see [Running in a lane](#running-in-a-lane)).
 
 ## Creating a lane
 
@@ -57,10 +59,11 @@ this worktree only:
   then sets `git update-index --skip-worktree` so the edit never shows as a
   diff or gets committed;
 - rewrites `.env.local` — the Supabase API + `DATABASE_URL` ports — and adds
-  `E2E_PORT` (read by `playwright.config.ts`) + `LANE_DEV_PORT` (read by the
-  `npm run dev` wrapper, `scripts/dev-server.mjs`) so both servers land on this
-  lane's ports automatically. Next can't take the port from `.env` directly —
-  it binds before env files load — hence the wrapper.
+  `LANE_DEV_PORT`, read by both the `npm run dev` wrapper
+  (`scripts/dev-server.mjs`) and `playwright.config.ts`, so the dev server lands
+  on this lane's port and the e2e suite targets that same port. Next can't take
+  the port from `.env` directly — it binds before env files load — hence the
+  wrapper.
 
 Local Supabase keys are identical across stacks (fixed demo JWT secret), so
 only URLs/ports change. Preview a lane without writing anything:
@@ -72,16 +75,24 @@ After configuring, the normal commands "just work" against the lane's stack:
 
 ```sh
 npm run dev                     # interactive dev server on this lane's port
-npm run test:e2e                # auto-uses E2E_PORT; isolated DB + auth
+npm run test:e2e                # reuses the dev server if up, else starts one
 npm run test:functional         # isolated DB
 ```
 
-**One DB-touching activity per lane at a time.** A lane is a single Supabase
-stack = a single database. The two app ports keep the dev server and the e2e
-server from colliding, but they share the lane's DB — so running e2e *and* a
-manual dev session in the **same** lane at once lets e2e's reset wipe the DB
-under your session. Across lanes there's no interference at all; if you want a
-stable manual session *and* an e2e run simultaneously, use two lanes.
+**e2e reuses the dev server.** `playwright.config.ts` points its
+`webServer`/`baseURL` at the lane's `next dev` port (`LANE_DEV_PORT`), so
+`reuseExistingServer` runs the suite against a server you already have up — or
+starts its own `npm run dev` on that port when none is. Two `next dev` instances
+can't share one worktree's `.next` anyway, so a single server per lane is the
+only workable shape; concurrent isolated dev+e2e is what separate *lanes* are
+for. The base worktree (no lane vars) falls back to port 3000.
+
+**Tradeoff:** an e2e run resets and drives the seeded `@testfake.local` users in
+the lane's dev DB (not your real account), so a manual dev session's test-user
+state gets churned underneath it. This mirrors how CI runs against the
+prod-backed preview, so it's the same model — but if you want a stable manual
+session *and* an e2e run at once, use two lanes (each lane is one Supabase stack
+= one database).
 
 ## Reuse, teardown, caveats
 
@@ -91,12 +102,12 @@ stable manual session *and* an e2e run simultaneously, use two lanes.
 - **Footprint:** ~10 containers + ~2 GB RAM per lane. 2–4 lanes is comfortable
   on 16 GB+; beyond that, push e2e to CI (which already runs against per-branch
   Vercel previews) instead of adding local stacks.
-- **Looping e2e (running the suite many times):** pre-start ONE lane server and
-  reuse it — `npm run dev -- --port <E2E_PORT>`, which Playwright picks up via
-  `reuseExistingServer`. Don't let each `playwright test` cold-start the server:
-  that tree-kills `next dev` between runs, and repeated kill-mid-compile corrupts
-  the Turbopack `.next` cache until first-request route compilation outruns
-  Playwright's 60 s `webServer` timeout (socket bound, never serving — the run
+- **Looping e2e (running the suite many times):** keep ONE `npm run dev` up and
+  the loop reuses it automatically (that's the default now — see [Running in a
+  lane](#running-in-a-lane)). Don't loop in a way that cold-starts the server
+  each run: that tree-kills `next dev` between runs, and repeated kill-mid-compile
+  corrupts the Turbopack `.next` cache until first-request route compilation
+  outruns Playwright's `webServer` timeout (socket bound, never serving — the run
   fails before any test). One reused server ran 20 cycles clean; the cold-start
   loop cliffs after ~5. If a lane's `.next` wedges, delete it to rebuild.
 - **Stop a lane's stack:** `npm run dev:db:stop` from that worktree.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,10 +7,13 @@ import { config as loadEnv } from "dotenv";
 loadEnv({ path: ".env.local", quiet: true });
 
 const isCI = !!process.env.CI;
-// Lane-aware port: `npm run make_lane_inside_worktree` writes E2E_PORT into a
-// worktree's .env.local so parallel lanes don't collide on one web server.
-// Defaults to 3093 for the base worktree / CI. See docs/strategy-worktree-lanes.md.
-const e2ePort = process.env.E2E_PORT || "3093";
+// Target the local dev server's port so `reuseExistingServer` finds a running
+// `npm run dev` and runs against it, rather than starting a second `next dev`
+// (two can't coexist in one worktree — they'd share one `.next`). A lane writes
+// LANE_DEV_PORT into its .env.local; the base worktree has neither var and falls
+// back to 3000, matching plain `npm run dev`. E2E_PORT stays as an explicit
+// override. See docs/strategy-worktree-lanes.md.
+const e2ePort = process.env.LANE_DEV_PORT || process.env.E2E_PORT || "3000";
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://localhost:${e2ePort}`;
 
 export default defineConfig({
@@ -58,12 +61,18 @@ export default defineConfig({
       use: { browserName: "chromium" },
     },
   ],
-  // Local dev: spin up a Next.js server. CI: tests run against Vercel preview URL.
+  // Local dev: reuse a running dev server, or spin one up. CI: tests run
+  // against the Vercel preview URL.
   webServer: isCI
     ? undefined
     : {
         command: `npm run dev -- --port ${e2ePort}`,
         url: `http://localhost:${e2ePort}`,
         reuseExistingServer: true,
+        // Start-fresh path only: `npm run dev` runs dev:db (Supabase ensure +
+        // migrate + seed) then a Turbopack compile, which can exceed the 60s
+        // default and trip the "bound but not serving" timeout. The reuse path
+        // skips the command entirely, so this costs nothing when a server is up.
+        timeout: 180_000,
       },
 });

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -6,9 +6,9 @@
 // and this passes it through as --port.
 //
 // An explicit --port/-p always wins (e.g. Playwright's web server runs
-// `npm run dev -- --port <E2E_PORT>`); in that case we forward it untouched
-// and add nothing. The base worktree has no LANE_DEV_PORT, so plain
-// `npm run dev` behaves exactly as before (port 3000).
+// `npm run dev -- --port <dev port>` when it has to start a server itself);
+// in that case we forward it untouched and add nothing. The base worktree has
+// no LANE_DEV_PORT, so plain `npm run dev` behaves exactly as before (port 3000).
 
 import { spawn } from "node:child_process";
 import { config } from "dotenv";

--- a/scripts/make-lane-inside-worktree.mjs
+++ b/scripts/make-lane-inside-worktree.mjs
@@ -4,10 +4,10 @@
 // parallel without clobbering each other's database, auth, or ports.
 //
 // Background: the local Supabase stack is a singleton keyed by `project_id`
-// (config.toml) on fixed host ports, and e2e binds a fixed web-server port
-// and wipes the DB via /api/_test/reset. Two worktrees sharing one stack
-// therefore step on each other. GoTrue/Storage can't be multi-tenanted, so
-// the only true isolation is one full stack per worktree — that's a "lane".
+// (config.toml) on fixed host ports, and e2e wipes the DB via
+// /api/_test/reset. Two worktrees sharing one stack therefore step on each
+// other. GoTrue/Storage can't be multi-tenanted, so the only true isolation
+// is one full stack per worktree — that's a "lane".
 //
 // A lane is derived from the worktree directory name:
 //   is-app      -> lane 0 (the base worktree; left untouched)
@@ -24,8 +24,9 @@
 //     then `git update-index --skip-worktree` so the local edit never shows
 //     as a diff or gets committed. The base text is taken from `git show
 //     HEAD:supabase/config.toml`, so re-running always re-derives cleanly.
-//   - .env.local           : the Supabase API + DATABASE_URL ports, plus an
-//     E2E_PORT line that playwright.config.ts reads for its web server.
+//   - .env.local           : the Supabase API + DATABASE_URL ports, plus
+//     LANE_DEV_PORT — the port `npm run dev` binds, which the e2e suite reuses
+//     (playwright.config.ts targets it instead of starting a second server).
 //
 // Local Supabase keys are deterministic across stacks (fixed demo JWT
 // secret), so only URLs/ports change — never the keys.
@@ -44,7 +45,7 @@ const dryRun = args.includes("--dry-run");
 const nameOverride = args.find((a) => a.startsWith("--name="))?.slice("--name=".length);
 
 // Base port assignments straight out of supabase/config.toml + the app's
-// dev (3000) and Playwright web-server (3093) ports. Lane N adds N*100.
+// dev (3000) port. Lane N adds N*100.
 const SUPABASE_PORTS = {
   api: { key: "port", base: 54321 },
   db: { key: "port", base: 54322 },
@@ -55,7 +56,7 @@ const SUPABASE_PORTS = {
   analytics: { key: "port", base: 54327 },
   inspector: { key: "inspector_port", base: 8083 },
 };
-const APP_PORTS = { dev: 3000, e2e: 3093 };
+const APP_PORTS = { dev: 3000 };
 const LANE_STRIDE = 100;
 const MAX_LANE = 9; // N*100 keeps the 5432x block inside 543xx–544xx..552xx
 
@@ -103,7 +104,6 @@ const dbPort = port(SUPABASE_PORTS.db);
 const studioPort = port(SUPABASE_PORTS.studio);
 const inbucketPort = port(SUPABASE_PORTS.inbucket);
 const devPort = APP_PORTS.dev + off;
-const e2ePort = APP_PORTS.e2e + off;
 
 // --- supabase/config.toml -------------------------------------------------
 // Re-derive from the committed version so repeated runs are idempotent and
@@ -129,9 +129,9 @@ function buildConfig() {
   text = text.replace(/^(\s*project_id\s*=\s*)"[^"]*"/m, `$1"${worktreeName}"`);
   for (const def of Object.values(SUPABASE_PORTS)) text = setPort(text, def);
   // Auth redirect allow-list + site_url point at the dev server; shift them
-  // to this lane's dev port so interactive auth flows resolve. (e2e runs on
-  // e2ePort and, like the base stack on :3093, doesn't depend on the
-  // allow-list for the password-login flows the suite exercises.)
+  // to this lane's dev port so interactive auth flows resolve. (e2e reuses
+  // that same dev server and doesn't depend on the allow-list for the
+  // password-login flows the suite exercises.)
   text = text.replaceAll(":3000", `:${devPort}`);
   return text;
 }
@@ -153,7 +153,6 @@ function buildEnv() {
   let text = readFileSync(envPath, "utf8");
   text = setEnvLine(text, "NEXT_PUBLIC_SUPABASE_URL", `http://127.0.0.1:${apiPort}`);
   text = setEnvLine(text, "DATABASE_URL", `postgresql://postgres:postgres@127.0.0.1:${dbPort}/postgres`);
-  text = setEnvLine(text, "E2E_PORT", String(e2ePort));
   text = setEnvLine(text, "LANE_DEV_PORT", String(devPort));
   return { envPath, text };
 }
@@ -169,14 +168,13 @@ const portRows = [
   ["Studio", studioPort],
   ["Inbucket (email)", inbucketPort],
   ["next dev", devPort],
-  ["e2e web server", e2ePort],
 ];
 const summary =
   `Lane ${lane}  (project_id "${worktreeName}", port offset +${off})\n` +
   portRows.map(([label, p]) => `  ${label.padEnd(22)} ${p}`).join("\n") +
   `\n  Studio:        http://127.0.0.1:${studioPort}` +
   `\n  Interactive:   npm run dev        (auto-uses LANE_DEV_PORT=${devPort})` +
-  `\n  e2e:           npm run test:e2e   (auto-uses E2E_PORT=${e2ePort})`;
+  `\n  e2e:           npm run test:e2e   (reuses the dev server on ${devPort})`;
 
 if (dryRun) {
   process.stdout.write(`[dry-run] ${summary}\n\n[dry-run] would rewrite supabase/config.toml and ${envPath}\n`);


### PR DESCRIPTION
## Summary

Point the local Playwright `webServer`/`baseURL` at the dev-server port so a
running `npm run dev` is reused instead of starting a second `next dev`.

## Why

#372: running e2e locally while a dev server was up failed — Playwright probed
the lane's separate e2e port (`E2E_PORT`), found nothing there, and tried to
start a second `next dev`, which Next refuses inside one worktree (shared
`.next`). Two `next dev` can't coexist per worktree anyway, so the separate e2e
port could never enable concurrent dev+e2e; within a lane the correct move is to
reuse the single server — the same model as CI-against-preview.

## Behavior

- `playwright.config.ts` targets `LANE_DEV_PORT || E2E_PORT || 3000` (was
  `E2E_PORT || 3093`): dev server up → reused instantly; down → Playwright
  starts one on that port. Base worktree falls back to 3000.
- `webServer.timeout` raised to 180s for the start-fresh path (`npm run dev`
  runs Supabase ensure + migrate + seed then a Turbopack compile, which can
  exceed the 60s default). Costs nothing on the reuse path.
- `make_lane_inside_worktree` no longer assigns a separate e2e port; lanes write
  only `LANE_DEV_PORT`. `E2E_PORT` remains an explicit override.
- Docs updated (`strategy-worktree-lanes.md`, `CLAUDE.md`) with the reuse
  behavior and the tradeoff that an e2e run churns the seeded `@testfake.local`
  users in your dev DB.

## Test Plan

- ran `npm test` locally — lint, typecheck, 385 Vitest functional, and 29
  Playwright e2e all green
- reuse path: with `npm run dev` up on 3000, `playwright test about.spec.ts`
  ran in 14.3s with no "Another next dev server" error and left the dev server
  running
- start-fresh path: the `npm test` run above (no server up) cold-started its own
  dev server on 3000 and ran all 29 e2e green

## Checklist

- [x] N/A — this PR changes no `.claude/skills/**/SKILL.md`.

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
