### PR TITLE
feat(myweb): web graph depth filter, first-paint fixes, and refactor

### DIFF
--- a/scripts/seed-dev.ts
+++ b/scripts/seed-dev.ts
@@ -228,7 +228,7 @@ async function seedInvites(): Promise<SeedResult> {
 //     members Aria is NOT directly tied to (so the 2-hop view pulls them
 //     in), plus a rotating window of 6 inner first-degree peers (cross-links
 //     within the inner ring). Hubs are first-degree to Aria, so their
-//     relations surface as the second ring when the "2 hops" toggle is on.
+//     relations surface as the second ring when the "Friends-of-friends" toggle is on.
 //
 // All rows are confirmed relations (isHint=false, value 1..4) among seed
 // profiles only, so the e2e reset never disturbs them. Idempotent via

--- a/src/app/myweb/query-keys.ts
+++ b/src/app/myweb/query-keys.ts
@@ -1,3 +1,5 @@
+import { isRelationValue, RELATION_VALUES, type RelationValue } from "@/lib/relation-value";
+
 export const RELATION_CANDIDATES_QUERY_KEY = ["relations", "candidates"] as const;
 export const RELATION_SUBGRAPH_QUERY_KEY = ["relations", "subgraph"] as const;
 
@@ -28,6 +30,33 @@ export function parseStoredView(raw: string | null): SubgraphViewOptions | null 
     if (typeof parsed === "object" && parsed !== null && "hops" in parsed && (parsed.hops === 1 || parsed.hops === 2)) {
       return { hops: parsed.hops };
     }
+  } catch {
+    // fall through to null
+  }
+  return null;
+}
+
+// Which relation depths (1..4) the graph draws. A client-side cull over the
+// already-fetched subgraph — deliberately NOT part of SubgraphViewOptions (and
+// thus the query key), so toggling a depth re-filters the cached data instantly
+// rather than refetching. Persisted on its own key so the choice survives
+// reloads like hops does.
+export type RelationValueFilter = ReadonlySet<RelationValue>;
+
+export const VALUE_FILTER_STORAGE_KEY = "isweb-graph-value-filter";
+
+// Default is every depth shown. A factory rather than a shared Set so no caller
+// can mutate a module singleton.
+export const defaultValueFilter = (): Set<RelationValue> => new Set(RELATION_VALUES);
+
+// Permissive parser. An explicitly-stored empty array round-trips to an empty
+// set — the deliberate "show just me" state — which is distinct from a missing
+// or garbled value (null, so the caller keeps the all-shown default).
+export function parseStoredValueFilter(raw: string | null): Set<RelationValue> | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) return new Set(parsed.filter(isRelationValue));
   } catch {
     // fall through to null
   }

--- a/src/app/myweb/use-web-graph-simulation.ts
+++ b/src/app/myweb/use-web-graph-simulation.ts
@@ -1,0 +1,379 @@
+"use client";
+
+import { applyNodeChanges, type Edge, type Node, type NodeChange, type ReactFlowInstance } from "@xyflow/react";
+import { forceCollide, forceLink, forceManyBody, forceSimulation, type Simulation } from "d3-force";
+import { type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  computeNormalization,
+  edgeAvoidance,
+  linkDistance,
+  NORMALIZATION_TARGET,
+  radialSeed,
+} from "./web-graph-layout";
+import type { EdgeData, MemberNodeData, SubgraphNode } from "./web-graph-renderers";
+
+// d3-force mutates these objects in place; ReactFlow's Node objects are
+// derived from them at each tick. Keeping the two shapes separate makes
+// the boundary explicit.
+type SimNode = {
+  id: string;
+  x: number;
+  y: number;
+  vx?: number;
+  vy?: number;
+  fx?: number | null;
+  fy?: number | null;
+};
+
+type SimEdge = {
+  source: string | SimNode;
+  target: string | SimNode;
+  value: number;
+};
+
+// Fraction of the canvas left as breathing room around the graph on every
+// fitView. Shared by the initial fit, the per-paint settle fits, and the
+// mode-toggle refit so they all frame the web identically — a mismatch would
+// re-introduce a zoom shift between them. Exported so the parent's ReactFlow
+// fitView prop (initial fit + the Controls fit button) frames it the same way.
+export const FIT_VIEW_PADDING = 0.1;
+
+// The filtered subgraph the layout runs over: the center plus the nodes and
+// edges that survived the depth cull.
+type SimulationSubgraph = {
+  centerId: string;
+  nodes: readonly SubgraphNode[];
+  edges: readonly { relatorId: string; relateeId: string; value: number }[];
+};
+
+type FlowInstance = ReactFlowInstance<Node<MemberNodeData>, Edge<EdgeData>>;
+
+type WebGraphSimulation = {
+  nodes: Node<MemberNodeData>[];
+  onNodesChange: (changes: NodeChange<Node<MemberNodeData>>[]) => void;
+  onNodeDragStart: (event: MouseEvent, node: Node<MemberNodeData>) => void;
+  onNodeDrag: (event: MouseEvent, node: Node<MemberNodeData>) => void;
+  onNodeDragStop: (event: MouseEvent, node: Node<MemberNodeData>) => void;
+  // Register the ReactFlow instance (via onInit) so the layout can fit the
+  // viewport as it settles.
+  registerFlow: (instance: FlowInstance) => void;
+  // Flag a user pan/zoom so auto-fitting backs off and leaves their view alone.
+  markUserMoved: () => void;
+  // Fit the viewport to the current layout at the shared padding — driven from
+  // the parent during the view/edit mode height animation.
+  fitView: () => void;
+};
+
+// Owns the d3-force layout: builds (and rebuilds) the simulation over the
+// filtered subgraph, paints normalized render positions into `nodes`, fits the
+// viewport as the layout settles, and integrates node dragging. WebGraph hands
+// it the filtered subgraph and the ReactFlow instance (via registerFlow) and
+// renders the `nodes` it returns; everything stateful about the physics — the
+// sim, the normalization, the drag pins — lives here.
+export function useWebGraphSimulation(filtered: SimulationSubgraph | null): WebGraphSimulation {
+  const [nodes, setNodes] = useState<Node<MemberNodeData>[]>([]);
+  const simRef = useRef<Simulation<SimNode, SimEdge> | null>(null);
+  // Captured via ReactFlow's onInit so we can refit the viewport every
+  // time node positions change — fitView only auto-fires on first
+  // mount, so a settling simulation would otherwise overflow whatever
+  // scale the initial random positions happened to produce.
+  const flowRef = useRef<FlowInstance | null>(null);
+  // Shared between the d3-force sim and the drag handlers: drag needs
+  // to mutate fx/fy on the sim node directly, and drag-induced sim
+  // position changes shouldn't re-derive the render-coords scale (the
+  // dragged node would drift under your cursor as the bbox shifts).
+  const simNodesByIdRef = useRef<Map<string, SimNode>>(new Map());
+  const normRef = useRef<{ cx: number; cy: number; scale: number } | null>(null);
+  const draggedNodeIdRef = useRef<string | null>(null);
+  // True once the user pans/zooms — auto-fitView during sim ticks
+  // would otherwise yank the viewport back every ~250ms.
+  const userMovedViewportRef = useRef(false);
+  // True once the initial layout has fully relaxed (the sim's first "end").
+  // Until then paintFromSim refits every paint so the viewport tracks the
+  // settling graph at the right scale; after it, only explicit fits run, so a
+  // later drag-induced re-warm doesn't yank the viewport around.
+  const initialSettleDoneRef = useRef(false);
+
+  // Build (or rebuild) the d3-force simulation whenever the subgraph
+  // changes. The viewing member is pinned at the origin so the layout
+  // always orients around them.
+  useEffect(() => {
+    if (!filtered) return;
+    const { centerId, nodes: subNodes, edges: subEdges } = filtered;
+
+    // Preserve positions across data changes (a new relation, a hops toggle,
+    // a depth-filter toggle) so the web doesn't reshuffle. Existing nodes keep
+    // their last position; nodes the cull removed simply drop out of the sim;
+    // genuinely-new non-center nodes emerge from the center — where a
+    // just-related card flies to — and the sim eases them out. Only a true
+    // first layout (no prior nodes) gets the radial seed.
+    const prevById = simNodesByIdRef.current;
+    const isFirstLayout = prevById.size === 0;
+    // The first layout gets a deterministic radial seed (you at the origin, the
+    // first ring evenly around you, friends-of-friends nestled by their friend),
+    // so d3-force polishes a near-correct layout instead of untangling random
+    // scatter — same web every load, far fewer crossings. See radialSeed.
+    const seed = isFirstLayout
+      ? radialSeed(
+          subNodes.map((n) => n.id),
+          subEdges,
+          centerId,
+        )
+      : null;
+    const simNodes: SimNode[] = subNodes.map((n) => {
+      if (n.id === centerId) return { id: n.id, x: 0, y: 0, fx: 0, fy: 0 };
+      const prev = prevById.get(n.id);
+      if (prev) return { id: n.id, x: prev.x, y: prev.y, vx: prev.vx, vy: prev.vy, fx: null, fy: null };
+      const seeded = seed?.get(n.id);
+      if (seeded) return { id: n.id, x: seeded.x, y: seeded.y, fx: null, fy: null };
+      // A genuinely-new node on an incremental update emerges from the center —
+      // where the just-related card flies to — and the sim eases it out.
+      return { id: n.id, x: (Math.random() - 0.5) * 12, y: (Math.random() - 0.5) * 12, fx: null, fy: null };
+    });
+    // Lookup map kept around for paintFromSim — avoids an O(n²) .find
+    // scan on every tick. Also exposed via simNodesByIdRef so the
+    // node-drag handlers (outside this effect) can mutate fx/fy on
+    // the dragged node.
+    const simNodeById = new Map(simNodes.map((n) => [n.id, n]));
+    simNodesByIdRef.current = simNodeById;
+    const simEdges: SimEdge[] = subEdges.map((e) => ({
+      source: e.relatorId,
+      target: e.relateeId,
+      value: e.value,
+    }));
+
+    // Seed React node positions in render space (the same normalization
+    // paintFromSim applies), so preserved nodes start at their rendered spot
+    // rather than jumping to raw sim coords for a frame before the first tick.
+    const norm = normRef.current;
+    const toRender = (x: number, y: number) =>
+      norm ? { x: (x - norm.cx) * norm.scale, y: (y - norm.cy) * norm.scale } : { x, y };
+    setNodes(
+      subNodes.map((n) => {
+        const sn = simNodeById.get(n.id);
+        return {
+          id: n.id,
+          type: "member",
+          position: toRender(sn?.x ?? 0, sn?.y ?? 0),
+          data: { ...n, isCenter: n.id === centerId },
+          // Center node is fx/fy-pinned at the origin; letting the user
+          // drag it would either fight the pin or move "yourself" on
+          // your own web, neither of which is the intent.
+          draggable: n.id !== centerId,
+          // Override ReactFlow's default ".react-flow__node{pointer-events: all}"
+          // so only the Avatar (pointer-events-auto + clip-path:circle) is a
+          // click target. The corners around the round avatar no longer count
+          // as the node, so clicking outside the circle doesn't fire onNodeClick.
+          className: "!pointer-events-none",
+        };
+      }),
+    );
+
+    // d3 ticks at ~60fps internally. We push to React state at most once
+    // per FRAME_MS so ReactFlow only re-renders ~20 times/sec — physics
+    // stays accurate, render budget is 3× cheaper, motion stays visible.
+    // Without this throttle a dev build can render-storm so hard the
+    // browser never paints between frames and the simulation looks blank.
+    const FRAME_MS = 50;
+    let lastUpdate = 0;
+    // No forceCenter — the viewing member is already pinned at the
+    // origin via fx/fy, so forceCenter would only pull the other nodes
+    // toward the pinned center, fighting the link-distance equilibrium
+    // and causing them to bunch on top of the center.
+    //
+    // Custom force: push nodes off the segments of edges they don't belong to,
+    // so one doesn't settle straight on top of someone else's line (stock
+    // forceCollide only knows node-on-node overlap). edgeAvoidance computes the
+    // per-edge delta — scaled by alpha (d3's "heat") so it fades as the layout
+    // cools — and we accumulate it into the node's velocity.
+    const forceAvoidEdges = (alpha: number) => {
+      for (const n of simNodes) {
+        for (const e of simEdges) {
+          const a = e.source as SimNode;
+          const b = e.target as SimNode;
+          if (n === a || n === b) continue;
+          const delta = edgeAvoidance(n.x, n.y, a.x, a.y, b.x, b.y, alpha);
+          if (!delta) continue;
+          n.vx = (n.vx ?? 0) + delta.dvx;
+          n.vy = (n.vy ?? 0) + delta.dvy;
+        }
+      }
+    };
+
+    const sim = forceSimulation(simNodes)
+      // Gentle re-warm on an incremental update (existing nodes are already at
+      // rest, so they barely move); full heat only for a fresh first layout.
+      .alpha(isFirstLayout ? 1 : 0.6)
+      // Default alphaMin is 0.001, which combined with the default
+      // alphaDecay drags the sim out to ~5s with the last ~3.2s being
+      // sub-pixel motion no one can see. Bumping alphaMin cuts the
+      // trailing tail off (~1.8s end) without speeding up the
+      // perceptible early settling.
+      .alphaMin(0.08)
+      .force("charge", forceManyBody().strength(-800))
+      .force(
+        "link",
+        forceLink<SimNode, SimEdge>(simEdges)
+          .id((d) => d.id)
+          .distance((link) => linkDistance(link.value)),
+      )
+      .force("collide", forceCollide(60))
+      .force("avoid-edges", forceAvoidEdges)
+      .on("tick", () => {
+        const now = performance.now();
+        if (now - lastUpdate < FRAME_MS) return;
+        lastUpdate = now;
+        paintFromSim();
+      })
+      .on("end", () => {
+        // Final paint while per-paint fitting is still armed, so the last
+        // positions are fit before we latch the initial settle closed. After
+        // this, paintFromSim stops refitting; the explicit fit below covers a
+        // later drag-induced re-warm settling.
+        paintFromSim();
+        initialSettleDoneRef.current = true;
+        // Refit once the layout has fully relaxed, unless the user has already
+        // taken over the viewport.
+        if (!userMovedViewportRef.current) {
+          requestAnimationFrame(() => {
+            flowRef.current?.fitView({ padding: FIT_VIEW_PADDING, duration: 200 });
+          });
+        }
+      });
+
+    // Paints React node positions from the live simNodes, normalized so
+    // the layout's longer axis spans NORMALIZATION_TARGET sim units and is
+    // centered on the origin (see computeNormalization). Combined with a manual
+    // fitView refit, this makes the rendered graph fill the viewport regardless
+    // of node count.
+    function paintFromSim() {
+      if (simNodes.length === 0) return;
+      // During a drag, freeze the normalization. Recomputing it would
+      // shift cx/cy/scale based on the moving bbox, which makes the
+      // dragged node visually drift away from the cursor.
+      let cx: number;
+      let cy: number;
+      let scale: number;
+      if (draggedNodeIdRef.current && normRef.current) {
+        ({ cx, cy, scale } = normRef.current);
+      } else {
+        const norm = computeNormalization(simNodes, NORMALIZATION_TARGET);
+        if (!norm) return;
+        ({ cx, cy, scale } = norm);
+        normRef.current = norm;
+      }
+
+      setNodes((prev) => {
+        let changed = false;
+        const next = prev.map((node) => {
+          const sn = simNodeById.get(node.id);
+          if (!sn) return node;
+          const x = (sn.x - cx) * scale;
+          const y = (sn.y - cy) * scale;
+          // Sub-pixel changes don't move anything visually; returning
+          // the same array (prev) lets React skip the re-render entirely.
+          if (Math.abs(x - node.position.x) < 0.5 && Math.abs(y - node.position.y) < 0.5) {
+            return node;
+          }
+          changed = true;
+          return { ...node, position: { x, y } };
+        });
+        return changed ? next : prev;
+      });
+
+      // Refit every paint while the initial layout settles. Normalization pins
+      // the longer axis to NORMALIZATION_TARGET, so the fit is stable from the
+      // first painted frame — the viewport tracks the settling graph rather
+      // than snapping once at the end. A one-shot fit here used to fire (via
+      // rAF) before the normalized nodes reached ReactFlow's store, fitting the
+      // raw seed instead, which left the graph zoomed-out until the "end" fit
+      // visibly zoomed in. Skipped during a drag (we freeze normalization then)
+      // and once the user takes over the viewport; stops at initialSettleDone.
+      if (!initialSettleDoneRef.current && !userMovedViewportRef.current && !draggedNodeIdRef.current) {
+        flowRef.current?.fitView({ padding: FIT_VIEW_PADDING, duration: 0 });
+      }
+    }
+
+    simRef.current?.stop();
+    simRef.current = sim;
+
+    return () => {
+      sim.stop();
+    };
+  }, [filtered]);
+
+  // Required for ReactFlow's drag to actually update positions in our
+  // controlled `nodes` state; without it, drag fires events that go
+  // nowhere and the node visually doesn't move.
+  const onNodesChange = useCallback((changes: NodeChange<Node<MemberNodeData>>[]) => {
+    setNodes((nds) => applyNodeChanges(changes, nds));
+  }, []);
+
+  // Drag handlers integrate the user with the d3-force sim: pinning
+  // the dragged node via fx/fy lets the rest of the graph relax
+  // around the new position. On release, fx/fy is cleared so the node
+  // re-enters the sim's normal physics.
+  const flowPositionToSim = useCallback((flow: { x: number; y: number }) => {
+    const norm = normRef.current;
+    if (!norm) return null;
+    return { x: flow.x / norm.scale + norm.cx, y: flow.y / norm.scale + norm.cy };
+  }, []);
+  const onNodeDragStart = useCallback(
+    (_event: MouseEvent, node: Node<MemberNodeData>) => {
+      const simNode = simNodesByIdRef.current.get(node.id);
+      const sim = flowPositionToSim(node.position);
+      if (!simNode || !sim) return;
+      draggedNodeIdRef.current = node.id;
+      simNode.fx = sim.x;
+      simNode.fy = sim.y;
+      // alphaTarget keeps the sim warm for the duration of the drag —
+      // without it, alpha decays past alphaMin (~5s on defaults) and
+      // ticks stop firing, freezing the layout mid-pull. alpha(0.3)
+      // gives an immediate burst, alphaTarget(0.3) keeps it there.
+      simRef.current?.alphaTarget(0.3).alpha(0.3).restart();
+    },
+    [flowPositionToSim],
+  );
+  const onNodeDrag = useCallback(
+    (_event: MouseEvent, node: Node<MemberNodeData>) => {
+      const simNode = simNodesByIdRef.current.get(node.id);
+      const sim = flowPositionToSim(node.position);
+      if (!simNode || !sim) return;
+      simNode.fx = sim.x;
+      simNode.fy = sim.y;
+    },
+    [flowPositionToSim],
+  );
+  const onNodeDragStop = useCallback((_event: MouseEvent, node: Node<MemberNodeData>) => {
+    const simNode = simNodesByIdRef.current.get(node.id);
+    if (simNode) {
+      simNode.fx = null;
+      simNode.fy = null;
+    }
+    // Release the alpha target so the sim cools normally back to rest.
+    simRef.current?.alphaTarget(0);
+    draggedNodeIdRef.current = null;
+  }, []);
+
+  const registerFlow = useCallback((instance: FlowInstance) => {
+    flowRef.current = instance;
+  }, []);
+  const markUserMoved = useCallback(() => {
+    userMovedViewportRef.current = true;
+  }, []);
+  const fitView = useCallback(() => {
+    flowRef.current?.fitView({ padding: FIT_VIEW_PADDING, duration: 0 });
+  }, []);
+
+  return {
+    nodes,
+    onNodesChange,
+    onNodeDragStart,
+    onNodeDrag,
+    onNodeDragStop,
+    registerFlow,
+    markUserMoved,
+    fitView,
+  };
+}

--- a/src/app/myweb/web-graph-controls.tsx
+++ b/src/app/myweb/web-graph-controls.tsx
@@ -1,0 +1,59 @@
+import { Panel } from "@xyflow/react";
+
+import { RELATION_VALUE_LABELS, RELATION_VALUES, type RelationValue } from "@/lib/relation-value";
+
+import type { RelationValueFilter } from "./query-keys";
+
+// The in-canvas view controls: the hops toggle and the relation-depth filter
+// pills. Presentational — all state lives in WebGraph, which owns the query and
+// the cull; this just renders it and reports intent back through the callbacks.
+export function WebGraphControls({
+  hops,
+  onHopsChange,
+  valueFilter,
+  onToggleValue,
+}: {
+  hops: 1 | 2;
+  onHopsChange: (hops: 1 | 2) => void;
+  valueFilter: RelationValueFilter;
+  onToggleValue: (value: RelationValue) => void;
+}) {
+  return (
+    <Panel
+      position="top-right"
+      className="flex flex-col gap-2 rounded border border-border bg-background/90 p-2 text-sm"
+    >
+      <label className="flex cursor-pointer items-center gap-2">
+        <input type="checkbox" checked={hops === 2} onChange={(e) => onHopsChange(e.target.checked ? 2 : 1)} />2 hops
+      </label>
+      {/* Independent depth toggles (filled = shown). Reuses the 1–4 vocabulary
+       * from the relating dialog; culling a depth thins the web to the ties
+       * that matter. */}
+      <fieldset className="m-0 flex flex-col gap-1 border-0 p-0">
+        <legend className="p-0 text-xs text-muted-foreground">Relationship depth</legend>
+        <div className="flex gap-1">
+          {RELATION_VALUES.map((v) => {
+            const on = valueFilter.has(v);
+            return (
+              <button
+                key={v}
+                type="button"
+                aria-pressed={on}
+                aria-label={`Depth ${v}: ${RELATION_VALUE_LABELS[v].headline}`}
+                title={RELATION_VALUE_LABELS[v].headline}
+                onClick={() => onToggleValue(v)}
+                className={`flex h-6 w-6 items-center justify-center rounded-full border text-xs font-semibold transition-colors ${
+                  on
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-transparent text-muted-foreground hover:border-foreground"
+                }`}
+              >
+                {v}
+              </button>
+            );
+          })}
+        </div>
+      </fieldset>
+    </Panel>
+  );
+}

--- a/src/app/myweb/web-graph-controls.tsx
+++ b/src/app/myweb/web-graph-controls.tsx
@@ -24,7 +24,8 @@ export function WebGraphControls({
       className="flex flex-col gap-2 rounded border border-border bg-background/90 p-2 text-sm"
     >
       <label className="flex cursor-pointer items-center gap-2">
-        <input type="checkbox" checked={hops === 2} onChange={(e) => onHopsChange(e.target.checked ? 2 : 1)} />2 hops
+        <input type="checkbox" checked={hops === 2} onChange={(e) => onHopsChange(e.target.checked ? 2 : 1)} />
+        Friends-of-friends
       </label>
       {/* Independent depth toggles (filled = shown). Reuses the 1–4 vocabulary
        * from the relating dialog; culling a depth thins the web to the ties

--- a/src/app/myweb/web-graph-filtering.ts
+++ b/src/app/myweb/web-graph-filtering.ts
@@ -1,0 +1,49 @@
+// Relation-depth filtering for the WebGraph: cull the fetched subgraph to the
+// depths the viewer wants to see. Pure functions over plain data — see
+// web-graph-filtering.test.ts. Kept separate from web-graph-selection (which
+// derives a highlight from a click) because filtering is its own growing
+// concern; further dimensions (incoming edges, hint status, …) will land here.
+
+// Cull the subgraph to the relation depths the viewer wants to see. Edges whose
+// value is excluded are dropped; then a BFS from the center over what remains
+// keeps only the nodes still connected to the viewer — so hiding the edge that
+// linked a friend-of-friend also drops that friend-of-friend instead of leaving
+// it floating. The center is always kept, so clearing every depth leaves a lone
+// you. Generic so callers pass their concrete node/edge types straight through.
+export function filterSubgraphByValue<
+  N extends { id: string },
+  E extends { relatorId: string; relateeId: string; value: number },
+>(
+  nodes: readonly N[],
+  edges: readonly E[],
+  centerId: string,
+  includedValues: ReadonlySet<number>,
+): { nodes: N[]; edges: E[] } {
+  const keptEdges = edges.filter((e) => includedValues.has(e.value));
+  const adj = new Map<string, string[]>();
+  const link = (a: string, b: string) => {
+    const list = adj.get(a);
+    if (list) list.push(b);
+    else adj.set(a, [b]);
+  };
+  for (const e of keptEdges) {
+    link(e.relatorId, e.relateeId);
+    link(e.relateeId, e.relatorId);
+  }
+  // Reachable-from-center set over the kept edges; the center seeds it so a fully
+  // cleared filter still returns just you.
+  const reachable = new Set<string>([centerId]);
+  const queue = [centerId];
+  for (let i = 0; i < queue.length; i++) {
+    for (const nb of adj.get(queue[i]) ?? []) {
+      if (!reachable.has(nb)) {
+        reachable.add(nb);
+        queue.push(nb);
+      }
+    }
+  }
+  return {
+    nodes: nodes.filter((n) => reachable.has(n.id)),
+    edges: keptEdges.filter((e) => reachable.has(e.relatorId) && reachable.has(e.relateeId)),
+  };
+}

--- a/src/app/myweb/web-graph-layout.ts
+++ b/src/app/myweb/web-graph-layout.ts
@@ -82,3 +82,112 @@ export function computeNormalization(
   const scale = longer > 1 ? target / longer : 1;
   return { cx: (maxX + minX) / 2, cy: (maxY + minY) / 2, scale };
 }
+
+// First-hop ring radius (sim units) and the gap added per additional hop. The
+// first ring sits near linkDistance's range (110..230) so the force layout
+// barely has to move it; normalization rescales the whole cloud to the viewport
+// afterward, so only the *relative* spacing here matters.
+export const SEED_FIRST_HOP_RADIUS = 220;
+export const SEED_RING_GAP = 200;
+
+// Deterministic radial seed for the force layout. A breadth-first walk from the
+// center assigns each node a hop depth and the parent it connects through; the
+// first ring is spaced evenly around you, and each deeper node is nestled into a
+// shrinking arc around its parent — so friends-of-friends cluster by the friend
+// they share rather than scattering. d3-force then only polishes a roughly-right
+// layout instead of untangling random noise, which kills edge crossings and
+// (because no Math.random feeds the first layout) renders the same web on every
+// load.
+//
+// Every level is ordered by id, so the result is independent of edge order. The
+// center lands at the origin. Nodes unreachable from the center (no edge path to
+// it) are spread on an outer ring, so they still get a finite, deterministic
+// spot rather than an undefined position.
+export function radialSeed(
+  nodeIds: ReadonlyArray<string>,
+  edges: ReadonlyArray<{ relatorId: string; relateeId: string }>,
+  centerId: string,
+  options?: { firstHopRadius?: number; ringGap?: number },
+): Map<string, { x: number; y: number }> {
+  const firstHopRadius = options?.firstHopRadius ?? SEED_FIRST_HOP_RADIUS;
+  const ringGap = options?.ringGap ?? SEED_RING_GAP;
+
+  // Undirected adjacency.
+  const adj = new Map<string, string[]>();
+  const link = (a: string, b: string) => {
+    const list = adj.get(a);
+    if (list) list.push(b);
+    else adj.set(a, [b]);
+  };
+  for (const e of edges) {
+    link(e.relatorId, e.relateeId);
+    link(e.relateeId, e.relatorId);
+  }
+
+  // BFS from the center → depth, parent, and each parent's children. Neighbors
+  // are visited in id order so the tree (and thus the angles) don't depend on
+  // edge order.
+  const depth = new Map<string, number>([[centerId, 0]]);
+  const childrenOf = new Map<string, string[]>();
+  const queue = [centerId];
+  for (let i = 0; i < queue.length; i++) {
+    const cur = queue[i];
+    const neighbors = (adj.get(cur) ?? []).slice().sort();
+    for (const nb of neighbors) {
+      if (depth.has(nb)) continue;
+      depth.set(nb, (depth.get(cur) ?? 0) + 1);
+      const kids = childrenOf.get(cur);
+      if (kids) kids.push(nb);
+      else childrenOf.set(cur, [nb]);
+      queue.push(nb);
+    }
+  }
+
+  // Angle + the angular wedge each node owns for its own children. The center
+  // spreads its children evenly over the full circle; every deeper parent fans
+  // its children within a shrunk arc centered on its own angle, so each subtree
+  // stays clustered.
+  const angle = new Map<string, number>([[centerId, 0]]);
+  const wedge = new Map<string, number>([[centerId, Math.PI * 2]]);
+  const rootKids = childrenOf.get(centerId) ?? [];
+  rootKids.forEach((id, j) => {
+    angle.set(id, (j * Math.PI * 2) / rootKids.length);
+    wedge.set(id, (Math.PI * 2) / rootKids.length);
+  });
+  // queue is in BFS order, so a parent's angle/wedge is always set before its
+  // children are reached. Depth 0 (center) and depth 1 (handled above) are
+  // skipped; this fans depth ≥ 2.
+  for (const cur of queue) {
+    if ((depth.get(cur) ?? 0) < 1) continue;
+    const kids = childrenOf.get(cur);
+    if (!kids?.length) continue;
+    const parentAngle = angle.get(cur) ?? 0;
+    const arc = (wedge.get(cur) ?? Math.PI / 2) * 0.6;
+    kids.forEach((id, j) => {
+      const offset = kids.length === 1 ? 0 : (j / (kids.length - 1) - 0.5) * arc;
+      angle.set(id, parentAngle + offset);
+      wedge.set(id, arc / kids.length);
+    });
+  }
+
+  const pos = new Map<string, { x: number; y: number }>([[centerId, { x: 0, y: 0 }]]);
+  let maxDepth = 0;
+  for (const [id, d] of depth) {
+    if (id === centerId) continue;
+    if (d > maxDepth) maxDepth = d;
+    const r = firstHopRadius + (d - 1) * ringGap;
+    const a = angle.get(id) ?? 0;
+    pos.set(id, { x: Math.cos(a) * r, y: Math.sin(a) * r });
+  }
+
+  // Anything the BFS never reached (an isolated node with no edges) lands on a
+  // ring just outside the deepest hop, id-ordered so it stays deterministic.
+  const unreached = nodeIds.filter((id) => !depth.has(id)).sort();
+  const outerR = firstHopRadius + maxDepth * ringGap;
+  unreached.forEach((id, j) => {
+    const a = (j * Math.PI * 2) / unreached.length;
+    pos.set(id, { x: Math.cos(a) * outerR, y: Math.sin(a) * outerR });
+  });
+
+  return pos;
+}

--- a/src/app/myweb/web-graph-renderers.tsx
+++ b/src/app/myweb/web-graph-renderers.tsx
@@ -26,7 +26,7 @@ import { DIM_KEEP } from "./web-graph-selection";
 // which keeps per-selection / per-hover state out of the node/edge data objects
 // (and so out of the memos that build them).
 
-type SubgraphNode = RelationSubgraph["nodes"][number];
+export type SubgraphNode = RelationSubgraph["nodes"][number];
 
 export type MemberNodeData = SubgraphNode & {
   isCenter: boolean;

--- a/src/app/myweb/web-graph-renderers.tsx
+++ b/src/app/myweb/web-graph-renderers.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import {
+  BaseEdge,
+  type Edge,
+  EdgeLabelRenderer,
+  type EdgeProps,
+  getStraightPath,
+  Handle,
+  type Node,
+  type NodeProps,
+  Position,
+} from "@xyflow/react";
+import { createContext, useContext } from "react";
+
+import { Avatar } from "@/components/avatar";
+import type { RelationSubgraph } from "@/lib/api-types";
+import { isRelationValue } from "@/lib/relation-value";
+
+import type { RelatingTarget } from "./relating-dialog";
+import { DIM_KEEP } from "./web-graph-selection";
+
+// The two custom ReactFlow renderers — the member node and the numbered edge —
+// plus the data shapes they read and the interaction contexts WebGraph fills.
+// Node and edge mirror each other: each consumes a context the parent provides,
+// which keeps per-selection / per-hover state out of the node/edge data objects
+// (and so out of the memos that build them).
+
+type SubgraphNode = RelationSubgraph["nodes"][number];
+
+export type MemberNodeData = SubgraphNode & {
+  isCenter: boolean;
+};
+
+export type EdgeData = {
+  isOutgoing: boolean;
+  value: number;
+  relateeId: string;
+  relateeName: string | null;
+};
+
+// Handles are required for ReactFlow to anchor edges; rendering both at
+// the same vertically-centered position with opacity 0 makes edges read
+// as center-to-center lines without showing connector dots.
+const HANDLE_STYLE = { opacity: 0, top: "50%", pointerEvents: "none" as const };
+
+// DIM_KEEP (the fraction a dimmed element keeps) lives in web-graph-selection
+// alongside the decoration that applies it; MemberNode reuses it for the avatar
+// and name washes so a node dims by the same amount as its edges.
+
+// Carries the node selection to MemberNode (rendered via nodeTypes) without
+// baking it into node.data — that would force a setNodes pass per selection and
+// tangle with the sim's position updates. Mirrors EdgeInteractionContext.
+export type NodeInteraction = {
+  selectedNodeId: string | null;
+  // Node ids on the selected node's path back to the center; these stay lit.
+  pathNodeIds: Set<string>;
+};
+export const NodeInteractionContext = createContext<NodeInteraction | null>(null);
+
+function MemberNode({ id, data }: NodeProps<Node<MemberNodeData>>) {
+  const selection = useContext(NodeInteractionContext);
+  const isSelected = selection?.selectedNodeId === id;
+  // With a selection active, every node off the lit path dims (see DIM_KEEP);
+  // the selected node keeps the hover size so the click reads as "this one's it."
+  const isDimmed = selection != null && selection.selectedNodeId !== null && !selection.pathNodeIds.has(id);
+  // Every node on the lit path (selected, the steps, the root) gets the green
+  // border to match the links; otherwise the center is primary-teal, rest default.
+  const onLitPath = selection != null && selection.selectedNodeId !== null && selection.pathNodeIds.has(id);
+  const borderClass = onLitPath ? "border-success" : data.isCenter ? "border-primary" : "border-border";
+  return (
+    // Only the Avatar is a click target: the wrapper is pointer-events-none and
+    // .react-flow__node is !pointer-events-none (set per-node above), so clicks on
+    // the name and the corners around the round avatar fall through as inert.
+    <div className="pointer-events-none flex flex-col items-center gap-1">
+      <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
+      <Handle type="source" position={Position.Top} style={HANDLE_STYLE} />
+      {/* Avatar + its dim wash share this box so they scale together on
+          hover/select (no half-dimmed ring). */}
+      <div className={`relative transition-transform duration-150 hover:scale-110 ${isSelected ? "scale-110" : ""}`}>
+        <Avatar
+          name={data.displayName}
+          url={data.avatarUrl}
+          className={`pointer-events-auto flex cursor-pointer items-center justify-center overflow-hidden rounded-full border-2 [clip-path:circle()] ${
+            data.isCenter ? "h-16 w-16" : "h-12 w-12"
+          } ${borderClass} bg-muted text-base font-semibold text-muted-foreground`}
+        />
+        {/* Dim wash clipped to the avatar circle (rounded-full, never a square
+            over the edges behind), blended over the opaque avatar so endpoints
+            behind it stay hidden. pointer-events-none lets clicks reach it. */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 rounded-full bg-canvas transition-opacity duration-150"
+          style={{ opacity: isDimmed ? 1 - DIM_KEEP : 0 }}
+        />
+      </div>
+      {/* The name dims by mixing its text color toward the canvas — color paints
+          only the glyphs, so no covering box (square) and no bleed-through. */}
+      <div
+        className="pointer-events-none max-w-[8rem] truncate text-sm font-medium transition-colors duration-150"
+        style={
+          isDimmed ? { color: `color-mix(in srgb, currentColor ${DIM_KEEP * 100}%, var(--color-canvas))` } : undefined
+        }
+      >
+        {data.displayName ?? "—"}
+      </div>
+    </div>
+  );
+}
+
+export const nodeTypes = { member: MemberNode };
+
+// Carries edge-number reveal state + the relating callback to the
+// NumberedEdge instances without threading them through the edge data object
+// (which would defeat the edges useMemo). The Provider wraps ReactFlow so
+// context still reaches the edges registered via the edgeTypes prop.
+export type EdgeInteraction = {
+  openRelating: (target: RelatingTarget) => void;
+  // Transient hover preview (desktop) and the selected edge (click/tap). A
+  // number shows when its id matches either.
+  hoverEdgeId: string | null;
+  selectedEdgeId: string | null;
+  previewEdge: (id: string) => void;
+  endPreviewSoon: () => void;
+};
+export const EdgeInteractionContext = createContext<EdgeInteraction | null>(null);
+
+// Straight-line edge with an HTML circle label at the geometric midpoint
+// of the line between source and target. ReactFlow's default bezier
+// edges arc upward (both ends are Position.Top), so their parametric
+// midpoint sits above the visual line — using a straight edge keeps the
+// label on the line, and HTML labels (via EdgeLabelRenderer) give us a
+// real circular pill that an SVG <rect> can't.
+//
+// The number is hidden until its edge is active (hovered, or tapped within
+// the edge's interactionWidth). While hidden it's pointer-events-none so the
+// hover/tap falls through to the line; while shown it captures clicks to open
+// the relating dialog. onMouseEnter/Leave bridge the pointer's trip from the
+// line onto the number (paired with the parent's short hide delay).
+
+function NumberedEdge({ id, sourceX, sourceY, targetX, targetY, style, data }: EdgeProps<Edge<EdgeData>>) {
+  const [edgePath, labelX, labelY] = getStraightPath({ sourceX, sourceY, targetX, targetY });
+  const interaction = useContext(EdgeInteractionContext);
+  const isClickable = data?.isOutgoing === true && interaction !== null;
+  const isVisible = interaction !== null && (interaction.hoverEdgeId === id || interaction.selectedEdgeId === id);
+  const handleClick = isClickable
+    ? () =>
+        interaction?.openRelating({
+          id: data.relateeId,
+          displayName: data.relateeName,
+          currentValue: isRelationValue(data.value) ? data.value : null,
+        })
+    : undefined;
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} style={style} />
+      <EdgeLabelRenderer>
+        <button
+          type="button"
+          onClick={handleClick}
+          onMouseEnter={() => interaction?.previewEdge(id)}
+          onMouseLeave={() => interaction?.endPreviewSoon()}
+          disabled={!isClickable}
+          aria-hidden={!isVisible}
+          aria-label={isClickable ? "Adjust this relationship" : undefined}
+          style={{
+            position: "absolute",
+            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+          }}
+          className={`flex h-5 w-5 items-center justify-center rounded-full bg-canvas/80 text-xs font-semibold text-canvas-foreground transition-opacity duration-150 ${
+            isVisible ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"
+          } ${isClickable ? "cursor-pointer hover:bg-canvas" : "cursor-default"}`}
+        >
+          {data?.value}
+        </button>
+      </EdgeLabelRenderer>
+    </>
+  );
+}
+
+export const edgeTypes = { numbered: NumberedEdge };

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -5,29 +5,20 @@ import "@xyflow/react/dist/style.css";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
   applyNodeChanges,
-  BaseEdge,
   Controls,
   type Edge,
-  EdgeLabelRenderer,
-  type EdgeProps,
-  getStraightPath,
-  Handle,
   type Node,
   type NodeChange,
-  type NodeProps,
   Panel,
-  Position,
   ReactFlow,
   type ReactFlowInstance,
 } from "@xyflow/react";
 import { forceCollide, forceLink, forceManyBody, forceSimulation, type Simulation } from "d3-force";
 import { useRouter } from "next/navigation";
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { Avatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api";
-import type { RelationSubgraph } from "@/lib/api-types";
 import { isRelationValue, type RelationValue } from "@/lib/relation-value";
 
 import {
@@ -53,13 +44,17 @@ import {
   NORMALIZATION_TARGET,
   radialSeed,
 } from "./web-graph-layout";
-import { DIM_KEEP, decorateEdges, decorateNodes, pathToCenter, shortestPathTree } from "./web-graph-selection";
-
-type SubgraphNode = RelationSubgraph["nodes"][number];
-
-type MemberNodeData = SubgraphNode & {
-  isCenter: boolean;
-};
+import {
+  type EdgeData,
+  type EdgeInteraction,
+  EdgeInteractionContext,
+  edgeTypes,
+  type MemberNodeData,
+  type NodeInteraction,
+  NodeInteractionContext,
+  nodeTypes,
+} from "./web-graph-renderers";
+import { decorateEdges, decorateNodes, pathToCenter, shortestPathTree } from "./web-graph-selection";
 
 // d3-force mutates these objects in place; ReactFlow's Node objects are
 // derived from them at each tick. Keeping the two shapes separate makes
@@ -80,13 +75,6 @@ type SimEdge = {
   value: number;
 };
 
-type EdgeData = {
-  isOutgoing: boolean;
-  value: number;
-  relateeId: string;
-  relateeName: string | null;
-};
-
 const fetchSubgraph = async (opts: SubgraphViewOptions) => {
   const res = await apiClient.api.relations.subgraph.$get({
     query: {
@@ -96,147 +84,6 @@ const fetchSubgraph = async (opts: SubgraphViewOptions) => {
   if (!res.ok) throw new Error(`relations/subgraph: ${res.status}`);
   return res.json();
 };
-
-// Handles are required for ReactFlow to anchor edges; rendering both at
-// the same vertically-centered position with opacity 0 makes edges read
-// as center-to-center lines without showing connector dots.
-const HANDLE_STYLE = { opacity: 0, top: "50%", pointerEvents: "none" as const };
-
-// DIM_KEEP (the fraction a dimmed element keeps) lives in web-graph-selection
-// alongside the decoration that applies it; MemberNode reuses it for the avatar
-// and name washes so the whole node dims by the same amount as its edges.
-
-// Carries the node selection to MemberNode (rendered via nodeTypes) without
-// baking it into node.data — that would force a setNodes pass per selection and
-// tangle with the sim's position updates. Mirrors EdgeInteractionContext.
-type NodeInteraction = {
-  selectedNodeId: string | null;
-  // Node ids on the selected node's path back to the center; these stay lit.
-  pathNodeIds: Set<string>;
-};
-const NodeInteractionContext = createContext<NodeInteraction | null>(null);
-
-function MemberNode({ id, data }: NodeProps<Node<MemberNodeData>>) {
-  const selection = useContext(NodeInteractionContext);
-  const isSelected = selection?.selectedNodeId === id;
-  // With a selection active, every node off the lit path dims (see DIM_KEEP);
-  // the selected node keeps the hover size so the click reads as "this one's it."
-  const isDimmed = selection != null && selection.selectedNodeId !== null && !selection.pathNodeIds.has(id);
-  // Every node on the lit path (selected, the steps, the root) gets the green
-  // border to match the links; otherwise the center is primary-teal, rest default.
-  const onLitPath = selection != null && selection.selectedNodeId !== null && selection.pathNodeIds.has(id);
-  const borderClass = onLitPath ? "border-success" : data.isCenter ? "border-primary" : "border-border";
-  return (
-    // Only the Avatar is a click target: the wrapper is pointer-events-none and
-    // .react-flow__node is !pointer-events-none (set per-node above), so clicks on
-    // the name and the corners around the round avatar fall through as inert.
-    <div className="pointer-events-none flex flex-col items-center gap-1">
-      <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
-      <Handle type="source" position={Position.Top} style={HANDLE_STYLE} />
-      {/* Avatar + its dim wash share this box so they scale together on
-          hover/select (no half-dimmed ring). */}
-      <div className={`relative transition-transform duration-150 hover:scale-110 ${isSelected ? "scale-110" : ""}`}>
-        <Avatar
-          name={data.displayName}
-          url={data.avatarUrl}
-          className={`pointer-events-auto flex cursor-pointer items-center justify-center overflow-hidden rounded-full border-2 [clip-path:circle()] ${
-            data.isCenter ? "h-16 w-16" : "h-12 w-12"
-          } ${borderClass} bg-muted text-base font-semibold text-muted-foreground`}
-        />
-        {/* Dim wash clipped to the avatar circle (rounded-full, never a square
-            over the edges behind), blended over the opaque avatar so endpoints
-            behind it stay hidden. pointer-events-none lets clicks reach it. */}
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 rounded-full bg-canvas transition-opacity duration-150"
-          style={{ opacity: isDimmed ? 1 - DIM_KEEP : 0 }}
-        />
-      </div>
-      {/* The name dims by mixing its text color toward the canvas — color paints
-          only the glyphs, so no covering box (square) and no bleed-through. */}
-      <div
-        className="pointer-events-none max-w-[8rem] truncate text-sm font-medium transition-colors duration-150"
-        style={
-          isDimmed ? { color: `color-mix(in srgb, currentColor ${DIM_KEEP * 100}%, var(--color-canvas))` } : undefined
-        }
-      >
-        {data.displayName ?? "—"}
-      </div>
-    </div>
-  );
-}
-
-const nodeTypes = { member: MemberNode };
-
-// Carries edge-number reveal state + the relating callback to the
-// NumberedEdge instances without threading them through the edge data object
-// (which would defeat the edges useMemo). The Provider wraps ReactFlow so
-// context still reaches the edges registered via the edgeTypes prop.
-type EdgeInteraction = {
-  openRelating: (target: RelatingTarget) => void;
-  // Transient hover preview (desktop) and the selected edge (click/tap). A
-  // number shows when its id matches either.
-  hoverEdgeId: string | null;
-  selectedEdgeId: string | null;
-  previewEdge: (id: string) => void;
-  endPreviewSoon: () => void;
-};
-const EdgeInteractionContext = createContext<EdgeInteraction | null>(null);
-
-// Straight-line edge with an HTML circle label at the geometric midpoint
-// of the line between source and target. ReactFlow's default bezier
-// edges arc upward (both ends are Position.Top), so their parametric
-// midpoint sits above the visual line — using a straight edge keeps the
-// label on the line, and HTML labels (via EdgeLabelRenderer) give us a
-// real circular pill that an SVG <rect> can't.
-//
-// The number is hidden until its edge is active (hovered, or tapped within
-// the edge's interactionWidth). While hidden it's pointer-events-none so the
-// hover/tap falls through to the line; while shown it captures clicks to open
-// the relating dialog. onMouseEnter/Leave bridge the pointer's trip from the
-// line onto the number (paired with the parent's short hide delay).
-
-function NumberedEdge({ id, sourceX, sourceY, targetX, targetY, style, data }: EdgeProps<Edge<EdgeData>>) {
-  const [edgePath, labelX, labelY] = getStraightPath({ sourceX, sourceY, targetX, targetY });
-  const interaction = useContext(EdgeInteractionContext);
-  const isClickable = data?.isOutgoing === true && interaction !== null;
-  const isVisible = interaction !== null && (interaction.hoverEdgeId === id || interaction.selectedEdgeId === id);
-  const handleClick = isClickable
-    ? () =>
-        interaction?.openRelating({
-          id: data.relateeId,
-          displayName: data.relateeName,
-          currentValue: isRelationValue(data.value) ? data.value : null,
-        })
-    : undefined;
-  return (
-    <>
-      <BaseEdge id={id} path={edgePath} style={style} />
-      <EdgeLabelRenderer>
-        <button
-          type="button"
-          onClick={handleClick}
-          onMouseEnter={() => interaction?.previewEdge(id)}
-          onMouseLeave={() => interaction?.endPreviewSoon()}
-          disabled={!isClickable}
-          aria-hidden={!isVisible}
-          aria-label={isClickable ? "Adjust this relationship" : undefined}
-          style={{
-            position: "absolute",
-            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-          }}
-          className={`flex h-5 w-5 items-center justify-center rounded-full bg-canvas/80 text-xs font-semibold text-canvas-foreground transition-opacity duration-150 ${
-            isVisible ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"
-          } ${isClickable ? "cursor-pointer hover:bg-canvas" : "cursor-default"}`}
-        >
-          {data?.value}
-        </button>
-      </EdgeLabelRenderer>
-    </>
-  );
-}
-
-const edgeTypes = { numbered: NumberedEdge };
 
 // View<->edit canvas animation. View is a square whose height tracks the
 // measured width; edit collapses to EDIT_HEIGHT. Width never changes between

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -240,6 +240,12 @@ const EDIT_HEIGHT = 500;
 const MODE_ANIM_MS = 1000;
 const MODE_ANIM_EASE = "cubic-bezier(0.45, 0, 0.55, 1)"; // accelerate + decelerate
 
+// Fraction of the canvas left as breathing room around the graph on every
+// fitView. Shared by the initial fit, the per-paint settle fits, and the
+// mode-toggle refit so they all frame the web identically — a mismatch would
+// re-introduce a zoom shift between them.
+const FIT_VIEW_PADDING = 0.1;
+
 export function WebGraph({
   square,
   onOpenRelating,
@@ -500,7 +506,7 @@ export function WebGraph({
         // taken over the viewport.
         if (!userMovedViewportRef.current) {
           requestAnimationFrame(() => {
-            flowRef.current?.fitView({ padding: 0.15, duration: 200 });
+            flowRef.current?.fitView({ padding: FIT_VIEW_PADDING, duration: 200 });
           });
         }
       });
@@ -554,7 +560,7 @@ export function WebGraph({
       // visibly zoomed in. Skipped during a drag (we freeze normalization then)
       // and once the user takes over the viewport; stops at initialSettleDone.
       if (!initialSettleDoneRef.current && !userMovedViewportRef.current && !draggedNodeIdRef.current) {
-        flowRef.current?.fitView({ padding: 0.15, duration: 0 });
+        flowRef.current?.fitView({ padding: FIT_VIEW_PADDING, duration: 0 });
       }
     }
 
@@ -673,7 +679,7 @@ export function WebGraph({
     }
     const start = performance.now();
     let raf = requestAnimationFrame(function tick(now: number) {
-      flowRef.current?.fitView({ padding: 0.15, duration: 0 });
+      flowRef.current?.fitView({ padding: FIT_VIEW_PADDING, duration: 0 });
       raf = now - start < MODE_ANIM_MS + 60 ? requestAnimationFrame(tick) : 0;
     });
     return () => {
@@ -819,7 +825,7 @@ export function WebGraph({
             nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}
             fitView
-            fitViewOptions={{ padding: 0.15 }}
+            fitViewOptions={{ padding: FIT_VIEW_PADDING }}
             onInit={(instance) => {
               flowRef.current = instance;
             }}

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -472,7 +472,8 @@ export function WebGraph({
                     <li>Single-click a circle to highlight its path to you.</li>
                     <li>Double-click a circle to open their profile.</li>
                     <li>
-                      <span className="font-medium text-foreground">2 hops</span> adds friends-of-friends.
+                      <span className="font-medium text-foreground">Friends-of-friends</span> adds your
+                      connections&apos; connections.
                     </li>
                     <li>
                       Toggle <span className="font-medium text-foreground">1–4</span> to show only those relationship

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -254,6 +254,11 @@ export function WebGraph({
   const router = useRouter();
   const [view, setView] = useState<SubgraphViewOptions>(DEFAULT_SUBGRAPH_VIEW);
   const [hintOpen, setHintOpen] = useState(false);
+  // True once the mount effect has reconciled `view` with localStorage, and
+  // true once the reconciled view's real data has landed — together they gate
+  // the first paint (see the initialReady latch below).
+  const [viewHydrated, setViewHydrated] = useState(false);
+  const [initialReady, setInitialReady] = useState(false);
 
   // Restore the user's last filter choice across reloads. Done in an
   // effect rather than the useState initializer so SSR-rendered markup
@@ -263,6 +268,7 @@ export function WebGraph({
   useEffect(() => {
     const stored = parseStoredView(window.localStorage.getItem(VIEW_STORAGE_KEY));
     if (stored && stored.hops !== DEFAULT_SUBGRAPH_VIEW.hops) setView(stored);
+    setViewHydrated(true);
   }, []);
 
   useEffect(() => {
@@ -271,7 +277,7 @@ export function WebGraph({
   // The view options become part of the query key so toggling refetches
   // automatically and the relating-dialog's mutation invalidator (which uses the
   // bare ["relations", "subgraph"] key) still hits every variant.
-  const { data, isPending, isError } = useQuery({
+  const { data, isPending, isError, isPlaceholderData } = useQuery({
     queryKey: [...RELATION_SUBGRAPH_QUERY_KEY, view] as const,
     queryFn: () => fetchSubgraph(view),
     // The default view is prefetched server-side and dehydrated into
@@ -283,6 +289,17 @@ export function WebGraph({
     // the graph to the loading placeholder while the new key fetches.
     placeholderData: keepPreviousData,
   });
+
+  // Hold the first paint until the view reconciled from localStorage has its
+  // own data — otherwise the prefetched default (2 hops) flashes for a beat
+  // before a stored "1 hop" preference refetches and replaces it. isPlaceholderData
+  // is true while keepPreviousData is showing the stale 2-hop result, so we wait
+  // it out: a little extra latency in exchange for landing on the right layout.
+  // One-way latch — once the initial load settles it never re-gates, so later
+  // user toggles still get keepPreviousData's seamless swap.
+  useEffect(() => {
+    if (viewHydrated && !isPending && !isPlaceholderData) setInitialReady(true);
+  }, [viewHydrated, isPending, isPlaceholderData]);
 
   const [nodes, setNodes] = useState<Node<MemberNodeData>[]>([]);
   const simRef = useRef<Simulation<SimNode, SimEdge> | null>(null);
@@ -301,11 +318,11 @@ export function WebGraph({
   // True once the user pans/zooms — auto-fitView during sim ticks
   // would otherwise yank the viewport back every ~250ms.
   const userMovedViewportRef = useRef(false);
-  // True once paintFromSim has run a one-shot fit against the
-  // normalized layout. ReactFlow's `fitView` prop fires too early
-  // (before the first paint) and would otherwise leave the viewport
-  // sized for the unnormalized random positions.
-  const initialPaintFittedRef = useRef(false);
+  // True once the initial layout has fully relaxed (the sim's first "end").
+  // Until then paintFromSim refits every paint so the viewport tracks the
+  // settling graph at the right scale; after it, only explicit fits run, so a
+  // later drag-induced re-warm doesn't yank the viewport around.
+  const initialSettleDoneRef = useRef(false);
 
   // Edges never change after the subgraph loads — derive instead of
   // duplicating into React state.
@@ -473,9 +490,14 @@ export function WebGraph({
         paintFromSim();
       })
       .on("end", () => {
+        // Final paint while per-paint fitting is still armed, so the last
+        // positions are fit before we latch the initial settle closed. After
+        // this, paintFromSim stops refitting; the explicit fit below covers a
+        // later drag-induced re-warm settling.
         paintFromSim();
-        // One-shot refit once the layout has fully relaxed, unless the
-        // user has already taken over the viewport.
+        initialSettleDoneRef.current = true;
+        // Refit once the layout has fully relaxed, unless the user has already
+        // taken over the viewport.
         if (!userMovedViewportRef.current) {
           requestAnimationFrame(() => {
             flowRef.current?.fitView({ padding: 0.15, duration: 200 });
@@ -523,19 +545,16 @@ export function WebGraph({
         return changed ? next : prev;
       });
 
-      // One-shot fit on the first normalized paint — ReactFlow's
-      // `fitView` prop fires before this runs, against the unnormalized
-      // 200-unit random layout, so without this the viewport stays
-      // zoomed in for the entire settling phase. After this initial
-      // fit, no periodic refits during settling (the normalization
-      // keeps the layout at a stable ~TARGET sim units). The sim's
-      // "end" handler does one more fit when the layout has fully
-      // relaxed.
-      if (!initialPaintFittedRef.current && !userMovedViewportRef.current) {
-        initialPaintFittedRef.current = true;
-        requestAnimationFrame(() => {
-          flowRef.current?.fitView({ padding: 0.15, duration: 0 });
-        });
+      // Refit every paint while the initial layout settles. Normalization pins
+      // the longer axis to NORMALIZATION_TARGET, so the fit is stable from the
+      // first painted frame — the viewport tracks the settling graph rather
+      // than snapping once at the end. A one-shot fit here used to fire (via
+      // rAF) before the normalized nodes reached ReactFlow's store, fitting the
+      // raw seed instead, which left the graph zoomed-out until the "end" fit
+      // visibly zoomed in. Skipped during a drag (we freeze normalization then)
+      // and once the user takes over the viewport; stops at initialSettleDone.
+      if (!initialSettleDoneRef.current && !userMovedViewportRef.current && !draggedNodeIdRef.current) {
+        flowRef.current?.fitView({ padding: 0.15, duration: 0 });
       }
     }
 
@@ -753,15 +772,18 @@ export function WebGraph({
 
   const empty = !data || data.nodes.length === 0;
 
-  if (isPending) {
-    return <p className="text-base text-muted-foreground">Loading your web…</p>;
-  }
   if (isError) {
     return (
       <p role="alert" className="text-base text-destructive">
         Couldn&apos;t load your web.
       </p>
     );
+  }
+  // !initialReady covers the first-load hold above; isPending covers a genuine
+  // empty cache. Errors are checked first so a failed refetch surfaces instead
+  // of latching here forever.
+  if (isPending || !initialReady) {
+    return <p className="text-base text-muted-foreground">Loading your web…</p>;
   }
   if (empty) {
     return (

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -3,17 +3,7 @@
 import "@xyflow/react/dist/style.css";
 
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import {
-  applyNodeChanges,
-  Controls,
-  type Edge,
-  type Node,
-  type NodeChange,
-  Panel,
-  ReactFlow,
-  type ReactFlowInstance,
-} from "@xyflow/react";
-import { forceCollide, forceLink, forceManyBody, forceSimulation, type Simulation } from "d3-force";
+import { Controls, type Edge, Panel, ReactFlow } from "@xyflow/react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -33,47 +23,20 @@ import {
   VIEW_STORAGE_KEY,
 } from "./query-keys";
 import type { RelatingTarget } from "./relating-dialog";
+import { FIT_VIEW_PADDING, useWebGraphSimulation } from "./use-web-graph-simulation";
 import { WebGraphControls } from "./web-graph-controls";
 import { filterSubgraphByValue } from "./web-graph-filtering";
-import {
-  computeNormalization,
-  edgeAvoidance,
-  edgeStrokeOpacity,
-  edgeStrokeWidth,
-  linkDistance,
-  NORMALIZATION_TARGET,
-  radialSeed,
-} from "./web-graph-layout";
+import { edgeStrokeOpacity, edgeStrokeWidth } from "./web-graph-layout";
 import {
   type EdgeData,
   type EdgeInteraction,
   EdgeInteractionContext,
   edgeTypes,
-  type MemberNodeData,
   type NodeInteraction,
   NodeInteractionContext,
   nodeTypes,
 } from "./web-graph-renderers";
 import { decorateEdges, decorateNodes, pathToCenter, shortestPathTree } from "./web-graph-selection";
-
-// d3-force mutates these objects in place; ReactFlow's Node objects are
-// derived from them at each tick. Keeping the two shapes separate makes
-// the boundary explicit.
-type SimNode = {
-  id: string;
-  x: number;
-  y: number;
-  vx?: number;
-  vy?: number;
-  fx?: number | null;
-  fy?: number | null;
-};
-
-type SimEdge = {
-  source: string | SimNode;
-  target: string | SimNode;
-  value: number;
-};
 
 const fetchSubgraph = async (opts: SubgraphViewOptions) => {
   const res = await apiClient.api.relations.subgraph.$get({
@@ -92,12 +55,6 @@ const fetchSubgraph = async (opts: SubgraphViewOptions) => {
 const EDIT_HEIGHT = 500;
 const MODE_ANIM_MS = 1000;
 const MODE_ANIM_EASE = "cubic-bezier(0.45, 0, 0.55, 1)"; // accelerate + decelerate
-
-// Fraction of the canvas left as breathing room around the graph on every
-// fitView. Shared by the initial fit, the per-paint settle fits, and the
-// mode-toggle refit so they all frame the web identically — a mismatch would
-// re-introduce a zoom shift between them.
-const FIT_VIEW_PADDING = 0.1;
 
 export function WebGraph({
   square,
@@ -170,29 +127,6 @@ export function WebGraph({
     if (viewHydrated && !isPending && !isPlaceholderData) setInitialReady(true);
   }, [viewHydrated, isPending, isPlaceholderData]);
 
-  const [nodes, setNodes] = useState<Node<MemberNodeData>[]>([]);
-  const simRef = useRef<Simulation<SimNode, SimEdge> | null>(null);
-  // Captured via ReactFlow's onInit so we can refit the viewport every
-  // time node positions change — fitView only auto-fires on first
-  // mount, so a settling simulation would otherwise overflow whatever
-  // scale the initial random positions happened to produce.
-  const flowRef = useRef<ReactFlowInstance<Node<MemberNodeData>, Edge<EdgeData>> | null>(null);
-  // Shared between the d3-force sim and the drag handlers: drag needs
-  // to mutate fx/fy on the sim node directly, and drag-induced sim
-  // position changes shouldn't re-derive the render-coords scale (the
-  // dragged node would drift under your cursor as the bbox shifts).
-  const simNodesByIdRef = useRef<Map<string, SimNode>>(new Map());
-  const normRef = useRef<{ cx: number; cy: number; scale: number } | null>(null);
-  const draggedNodeIdRef = useRef<string | null>(null);
-  // True once the user pans/zooms — auto-fitView during sim ticks
-  // would otherwise yank the viewport back every ~250ms.
-  const userMovedViewportRef = useRef(false);
-  // True once the initial layout has fully relaxed (the sim's first "end").
-  // Until then paintFromSim refits every paint so the viewport tracks the
-  // settling graph at the right scale; after it, only explicit fits run, so a
-  // later drag-induced re-warm doesn't yank the viewport around.
-  const initialSettleDoneRef = useRef(false);
-
   // The relation-depth cull, applied before anything downstream reads the
   // subgraph: the layout, the rendered edges, and the selection path tree all
   // operate on this filtered view, so hiding a depth genuinely thins the web
@@ -249,266 +183,11 @@ export function WebGraph({
     });
   }, [filtered]);
 
-  // Build (or rebuild) the d3-force simulation whenever the subgraph
-  // changes. The viewing member is pinned at the origin so the layout
-  // always orients around them.
-  useEffect(() => {
-    if (!filtered) return;
-    const { centerId, nodes: subNodes, edges: subEdges } = filtered;
-
-    // Preserve positions across data changes (a new relation, a hops toggle,
-    // a depth-filter toggle) so the web doesn't reshuffle. Existing nodes keep
-    // their last position; nodes the cull removed simply drop out of the sim;
-    // genuinely-new non-center nodes emerge from the center — where a
-    // just-related card flies to — and the sim eases them out. Only a true
-    // first layout (no prior nodes) gets the radial seed.
-    const prevById = simNodesByIdRef.current;
-    const isFirstLayout = prevById.size === 0;
-    // The first layout gets a deterministic radial seed (you at the origin, the
-    // first ring evenly around you, friends-of-friends nestled by their friend),
-    // so d3-force polishes a near-correct layout instead of untangling random
-    // scatter — same web every load, far fewer crossings. See radialSeed.
-    const seed = isFirstLayout
-      ? radialSeed(
-          subNodes.map((n) => n.id),
-          subEdges,
-          centerId,
-        )
-      : null;
-    const simNodes: SimNode[] = subNodes.map((n) => {
-      if (n.id === centerId) return { id: n.id, x: 0, y: 0, fx: 0, fy: 0 };
-      const prev = prevById.get(n.id);
-      if (prev) return { id: n.id, x: prev.x, y: prev.y, vx: prev.vx, vy: prev.vy, fx: null, fy: null };
-      const seeded = seed?.get(n.id);
-      if (seeded) return { id: n.id, x: seeded.x, y: seeded.y, fx: null, fy: null };
-      // A genuinely-new node on an incremental update emerges from the center —
-      // where the just-related card flies to — and the sim eases it out.
-      return { id: n.id, x: (Math.random() - 0.5) * 12, y: (Math.random() - 0.5) * 12, fx: null, fy: null };
-    });
-    // Lookup map kept around for paintFromSim — avoids an O(n²) .find
-    // scan on every tick. Also exposed via simNodesByIdRef so the
-    // node-drag handlers (outside this effect) can mutate fx/fy on
-    // the dragged node.
-    const simNodeById = new Map(simNodes.map((n) => [n.id, n]));
-    simNodesByIdRef.current = simNodeById;
-    const simEdges: SimEdge[] = subEdges.map((e) => ({
-      source: e.relatorId,
-      target: e.relateeId,
-      value: e.value,
-    }));
-
-    // Seed React node positions in render space (the same normalization
-    // paintFromSim applies), so preserved nodes start at their rendered spot
-    // rather than jumping to raw sim coords for a frame before the first tick.
-    const norm = normRef.current;
-    const toRender = (x: number, y: number) =>
-      norm ? { x: (x - norm.cx) * norm.scale, y: (y - norm.cy) * norm.scale } : { x, y };
-    setNodes(
-      subNodes.map((n) => {
-        const sn = simNodeById.get(n.id);
-        return {
-          id: n.id,
-          type: "member",
-          position: toRender(sn?.x ?? 0, sn?.y ?? 0),
-          data: { ...n, isCenter: n.id === centerId },
-          // Center node is fx/fy-pinned at the origin; letting the user
-          // drag it would either fight the pin or move "yourself" on
-          // your own web, neither of which is the intent.
-          draggable: n.id !== centerId,
-          // Override ReactFlow's default ".react-flow__node{pointer-events: all}"
-          // so only the Avatar (pointer-events-auto + clip-path:circle) is a
-          // click target. The corners around the round avatar no longer count
-          // as the node, so clicking outside the circle doesn't fire onNodeClick.
-          className: "!pointer-events-none",
-        };
-      }),
-    );
-
-    // d3 ticks at ~60fps internally. We push to React state at most once
-    // per FRAME_MS so ReactFlow only re-renders ~20 times/sec — physics
-    // stays accurate, render budget is 3× cheaper, motion stays visible.
-    // Without this throttle a dev build can render-storm so hard the
-    // browser never paints between frames and the simulation looks blank.
-    const FRAME_MS = 50;
-    let lastUpdate = 0;
-    // No forceCenter — the viewing member is already pinned at the
-    // origin via fx/fy, so forceCenter would only pull the other nodes
-    // toward the pinned center, fighting the link-distance equilibrium
-    // and causing them to bunch on top of the center.
-    //
-    // Custom force: push nodes off the segments of edges they don't belong to,
-    // so one doesn't settle straight on top of someone else's line (stock
-    // forceCollide only knows node-on-node overlap). edgeAvoidance computes the
-    // per-edge delta — scaled by alpha (d3's "heat") so it fades as the layout
-    // cools — and we accumulate it into the node's velocity.
-    const forceAvoidEdges = (alpha: number) => {
-      for (const n of simNodes) {
-        for (const e of simEdges) {
-          const a = e.source as SimNode;
-          const b = e.target as SimNode;
-          if (n === a || n === b) continue;
-          const delta = edgeAvoidance(n.x, n.y, a.x, a.y, b.x, b.y, alpha);
-          if (!delta) continue;
-          n.vx = (n.vx ?? 0) + delta.dvx;
-          n.vy = (n.vy ?? 0) + delta.dvy;
-        }
-      }
-    };
-
-    const sim = forceSimulation(simNodes)
-      // Gentle re-warm on an incremental update (existing nodes are already at
-      // rest, so they barely move); full heat only for a fresh first layout.
-      .alpha(isFirstLayout ? 1 : 0.6)
-      // Default alphaMin is 0.001, which combined with the default
-      // alphaDecay drags the sim out to ~5s with the last ~3.2s being
-      // sub-pixel motion no one can see. Bumping alphaMin cuts the
-      // trailing tail off (~1.8s end) without speeding up the
-      // perceptible early settling.
-      .alphaMin(0.08)
-      .force("charge", forceManyBody().strength(-800))
-      .force(
-        "link",
-        forceLink<SimNode, SimEdge>(simEdges)
-          .id((d) => d.id)
-          .distance((link) => linkDistance(link.value)),
-      )
-      .force("collide", forceCollide(60))
-      .force("avoid-edges", forceAvoidEdges)
-      .on("tick", () => {
-        const now = performance.now();
-        if (now - lastUpdate < FRAME_MS) return;
-        lastUpdate = now;
-        paintFromSim();
-      })
-      .on("end", () => {
-        // Final paint while per-paint fitting is still armed, so the last
-        // positions are fit before we latch the initial settle closed. After
-        // this, paintFromSim stops refitting; the explicit fit below covers a
-        // later drag-induced re-warm settling.
-        paintFromSim();
-        initialSettleDoneRef.current = true;
-        // Refit once the layout has fully relaxed, unless the user has already
-        // taken over the viewport.
-        if (!userMovedViewportRef.current) {
-          requestAnimationFrame(() => {
-            flowRef.current?.fitView({ padding: FIT_VIEW_PADDING, duration: 200 });
-          });
-        }
-      });
-
-    // Paints React node positions from the live simNodes, normalized so
-    // the layout's longer axis spans NORMALIZATION_TARGET sim units and is
-    // centered on the origin (see computeNormalization). Combined with a manual
-    // fitView refit, this makes the rendered graph fill the viewport regardless
-    // of node count.
-    function paintFromSim() {
-      if (simNodes.length === 0) return;
-      // During a drag, freeze the normalization. Recomputing it would
-      // shift cx/cy/scale based on the moving bbox, which makes the
-      // dragged node visually drift away from the cursor.
-      let cx: number;
-      let cy: number;
-      let scale: number;
-      if (draggedNodeIdRef.current && normRef.current) {
-        ({ cx, cy, scale } = normRef.current);
-      } else {
-        const norm = computeNormalization(simNodes, NORMALIZATION_TARGET);
-        if (!norm) return;
-        ({ cx, cy, scale } = norm);
-        normRef.current = norm;
-      }
-
-      setNodes((prev) => {
-        let changed = false;
-        const next = prev.map((node) => {
-          const sn = simNodeById.get(node.id);
-          if (!sn) return node;
-          const x = (sn.x - cx) * scale;
-          const y = (sn.y - cy) * scale;
-          // Sub-pixel changes don't move anything visually; returning
-          // the same array (prev) lets React skip the re-render entirely.
-          if (Math.abs(x - node.position.x) < 0.5 && Math.abs(y - node.position.y) < 0.5) {
-            return node;
-          }
-          changed = true;
-          return { ...node, position: { x, y } };
-        });
-        return changed ? next : prev;
-      });
-
-      // Refit every paint while the initial layout settles. Normalization pins
-      // the longer axis to NORMALIZATION_TARGET, so the fit is stable from the
-      // first painted frame — the viewport tracks the settling graph rather
-      // than snapping once at the end. A one-shot fit here used to fire (via
-      // rAF) before the normalized nodes reached ReactFlow's store, fitting the
-      // raw seed instead, which left the graph zoomed-out until the "end" fit
-      // visibly zoomed in. Skipped during a drag (we freeze normalization then)
-      // and once the user takes over the viewport; stops at initialSettleDone.
-      if (!initialSettleDoneRef.current && !userMovedViewportRef.current && !draggedNodeIdRef.current) {
-        flowRef.current?.fitView({ padding: FIT_VIEW_PADDING, duration: 0 });
-      }
-    }
-
-    simRef.current?.stop();
-    simRef.current = sim;
-
-    return () => {
-      sim.stop();
-    };
-  }, [filtered]);
-
-  // Required for ReactFlow's drag to actually update positions in our
-  // controlled `nodes` state; without it, drag fires events that go
-  // nowhere and the node visually doesn't move.
-  const onNodesChange = useCallback((changes: NodeChange<Node<MemberNodeData>>[]) => {
-    setNodes((nds) => applyNodeChanges(changes, nds));
-  }, []);
-
-  // Drag handlers integrate the user with the d3-force sim: pinning
-  // the dragged node via fx/fy lets the rest of the graph relax
-  // around the new position. On release, fx/fy is cleared so the node
-  // re-enters the sim's normal physics.
-  const flowPositionToSim = useCallback((flow: { x: number; y: number }) => {
-    const norm = normRef.current;
-    if (!norm) return null;
-    return { x: flow.x / norm.scale + norm.cx, y: flow.y / norm.scale + norm.cy };
-  }, []);
-  const onNodeDragStart = useCallback(
-    (_event: React.MouseEvent, node: Node<MemberNodeData>) => {
-      const simNode = simNodesByIdRef.current.get(node.id);
-      const sim = flowPositionToSim(node.position);
-      if (!simNode || !sim) return;
-      draggedNodeIdRef.current = node.id;
-      simNode.fx = sim.x;
-      simNode.fy = sim.y;
-      // alphaTarget keeps the sim warm for the duration of the drag —
-      // without it, alpha decays past alphaMin (~5s on defaults) and
-      // ticks stop firing, freezing the layout mid-pull. alpha(0.3)
-      // gives an immediate burst, alphaTarget(0.3) keeps it there.
-      simRef.current?.alphaTarget(0.3).alpha(0.3).restart();
-    },
-    [flowPositionToSim],
-  );
-  const onNodeDrag = useCallback(
-    (_event: React.MouseEvent, node: Node<MemberNodeData>) => {
-      const simNode = simNodesByIdRef.current.get(node.id);
-      const sim = flowPositionToSim(node.position);
-      if (!simNode || !sim) return;
-      simNode.fx = sim.x;
-      simNode.fy = sim.y;
-    },
-    [flowPositionToSim],
-  );
-  const onNodeDragStop = useCallback((_event: React.MouseEvent, node: Node<MemberNodeData>) => {
-    const simNode = simNodesByIdRef.current.get(node.id);
-    if (simNode) {
-      simNode.fx = null;
-      simNode.fy = null;
-    }
-    // Release the alpha target so the sim cools normally back to rest.
-    simRef.current?.alphaTarget(0);
-    draggedNodeIdRef.current = null;
-  }, []);
+  // The d3-force layout: builds the simulation over the filtered subgraph,
+  // paints normalized render positions into `nodes`, fits the viewport as it
+  // settles, and integrates node dragging. See useWebGraphSimulation.
+  const { nodes, onNodesChange, onNodeDragStart, onNodeDrag, onNodeDragStop, registerFlow, markUserMoved, fitView } =
+    useWebGraphSimulation(filtered);
 
   // Canvas height animation. Width is CSS-driven (w-full, capped to the
   // viewport height); we measure the resulting width and use it as the
@@ -564,7 +243,7 @@ export function WebGraph({
     }
     const start = performance.now();
     let raf = requestAnimationFrame(function tick(now: number) {
-      flowRef.current?.fitView({ padding: FIT_VIEW_PADDING, duration: 0 });
+      fitView();
       raf = now - start < MODE_ANIM_MS + 60 ? requestAnimationFrame(tick) : 0;
     });
     return () => {
@@ -711,9 +390,7 @@ export function WebGraph({
             edgeTypes={edgeTypes}
             fitView
             fitViewOptions={{ padding: FIT_VIEW_PADDING }}
-            onInit={(instance) => {
-              flowRef.current = instance;
-            }}
+            onInit={registerFlow}
             // Hover previews a number on desktop (off while an edge is selected).
             onEdgeMouseEnter={(_event, edge) => previewEdge(edge.id)}
             onEdgeMouseLeave={() => endPreviewSoon()}
@@ -739,9 +416,9 @@ export function WebGraph({
             }}
             onPaneClick={() => clearSelection()}
             onMove={(event) => {
-              // Programmatic fitView calls pass event=null; only flip the
-              // flag on user gestures (MouseEvent / TouchEvent / Wheel).
-              if (event !== null) userMovedViewportRef.current = true;
+              // Programmatic fitView calls pass event=null; only flag a user
+              // gesture (MouseEvent / TouchEvent / Wheel).
+              if (event !== null) markUserMoved();
             }}
             onNodesChange={onNodesChange}
             onNodeDragStart={onNodeDragStart}

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -28,7 +28,7 @@ import { Avatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api";
 import type { RelationSubgraph } from "@/lib/api-types";
-import { isRelationValue, RELATION_VALUE_LABELS, RELATION_VALUES, type RelationValue } from "@/lib/relation-value";
+import { isRelationValue, type RelationValue } from "@/lib/relation-value";
 
 import {
   DEFAULT_SUBGRAPH_VIEW,
@@ -42,6 +42,7 @@ import {
   VIEW_STORAGE_KEY,
 } from "./query-keys";
 import type { RelatingTarget } from "./relating-dialog";
+import { WebGraphControls } from "./web-graph-controls";
 import { filterSubgraphByValue } from "./web-graph-filtering";
 import {
   computeNormalization,
@@ -967,47 +968,12 @@ export function WebGraph({
                 </div>
               )}
             </Panel>
-            <Panel
-              position="top-right"
-              className="flex flex-col gap-2 rounded border border-border bg-background/90 p-2 text-sm"
-            >
-              <label className="flex cursor-pointer items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={view.hops === 2}
-                  onChange={(e) => setView((v) => ({ ...v, hops: e.target.checked ? 2 : 1 }))}
-                />
-                2 hops
-              </label>
-              {/* Independent depth toggles (filled = shown). Reuses the 1–4
-               * vocabulary from the relating dialog; culling a depth thins the
-               * web to the ties that matter. */}
-              <fieldset className="m-0 flex flex-col gap-1 border-0 p-0">
-                <legend className="p-0 text-xs text-muted-foreground">Relationship depth</legend>
-                <div className="flex gap-1">
-                  {RELATION_VALUES.map((v) => {
-                    const on = valueFilter.has(v);
-                    return (
-                      <button
-                        key={v}
-                        type="button"
-                        aria-pressed={on}
-                        aria-label={`Depth ${v}: ${RELATION_VALUE_LABELS[v].headline}`}
-                        title={RELATION_VALUE_LABELS[v].headline}
-                        onClick={() => toggleValue(v)}
-                        className={`flex h-6 w-6 items-center justify-center rounded-full border text-xs font-semibold transition-colors ${
-                          on
-                            ? "border-primary bg-primary text-primary-foreground"
-                            : "border-border bg-transparent text-muted-foreground hover:border-foreground"
-                        }`}
-                      >
-                        {v}
-                      </button>
-                    );
-                  })}
-                </div>
-              </fieldset>
-            </Panel>
+            <WebGraphControls
+              hops={view.hops}
+              onHopsChange={(hops) => setView((v) => ({ ...v, hops }))}
+              valueFilter={valueFilter}
+              onToggleValue={toggleValue}
+            />
           </ReactFlow>
         </NodeInteractionContext.Provider>
       </EdgeInteractionContext.Provider>

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -28,16 +28,21 @@ import { Avatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api";
 import type { RelationSubgraph } from "@/lib/api-types";
-import { isRelationValue } from "@/lib/relation-value";
+import { isRelationValue, RELATION_VALUE_LABELS, RELATION_VALUES, type RelationValue } from "@/lib/relation-value";
 
 import {
   DEFAULT_SUBGRAPH_VIEW,
+  defaultValueFilter,
+  parseStoredValueFilter,
   parseStoredView,
   RELATION_SUBGRAPH_QUERY_KEY,
+  type RelationValueFilter,
   type SubgraphViewOptions,
+  VALUE_FILTER_STORAGE_KEY,
   VIEW_STORAGE_KEY,
 } from "./query-keys";
 import type { RelatingTarget } from "./relating-dialog";
+import { filterSubgraphByValue } from "./web-graph-filtering";
 import {
   computeNormalization,
   edgeAvoidance,
@@ -265,6 +270,10 @@ export function WebGraph({
   // the first paint (see the initialReady latch below).
   const [viewHydrated, setViewHydrated] = useState(false);
   const [initialReady, setInitialReady] = useState(false);
+  // Which relation depths (1..4) are drawn. A client-side cull over the fetched
+  // subgraph (see the `filtered` memo), so toggling re-filters instantly with no
+  // refetch. Lazy init so the default Set isn't a shared module singleton.
+  const [valueFilter, setValueFilter] = useState<RelationValueFilter>(defaultValueFilter);
 
   // Restore the user's last filter choice across reloads. Done in an
   // effect rather than the useState initializer so SSR-rendered markup
@@ -274,12 +283,18 @@ export function WebGraph({
   useEffect(() => {
     const stored = parseStoredView(window.localStorage.getItem(VIEW_STORAGE_KEY));
     if (stored && stored.hops !== DEFAULT_SUBGRAPH_VIEW.hops) setView(stored);
+    const storedFilter = parseStoredValueFilter(window.localStorage.getItem(VALUE_FILTER_STORAGE_KEY));
+    if (storedFilter) setValueFilter(storedFilter);
     setViewHydrated(true);
   }, []);
 
   useEffect(() => {
     window.localStorage.setItem(VIEW_STORAGE_KEY, JSON.stringify(view));
   }, [view]);
+
+  useEffect(() => {
+    window.localStorage.setItem(VALUE_FILTER_STORAGE_KEY, JSON.stringify([...valueFilter]));
+  }, [valueFilter]);
   // The view options become part of the query key so toggling refetches
   // automatically and the relating-dialog's mutation invalidator (which uses the
   // bare ["relations", "subgraph"] key) still hits every variant.
@@ -330,13 +345,34 @@ export function WebGraph({
   // later drag-induced re-warm doesn't yank the viewport around.
   const initialSettleDoneRef = useRef(false);
 
-  // Edges never change after the subgraph loads — derive instead of
-  // duplicating into React state.
+  // The relation-depth cull, applied before anything downstream reads the
+  // subgraph: the layout, the rendered edges, and the selection path tree all
+  // operate on this filtered view, so hiding a depth genuinely thins the web
+  // (nodes the cull orphans leave) rather than just hiding lines. Shaped like
+  // `data` so consumers swap straight over. See filterSubgraphByValue.
+  const filtered = useMemo(() => {
+    if (!data) return null;
+    const sub = filterSubgraphByValue(data.nodes, data.edges, data.centerId, valueFilter);
+    return { centerId: data.centerId, nodes: sub.nodes, edges: sub.edges };
+  }, [data, valueFilter]);
+
+  // Flip one depth in/out of the filter. Each toggle is independent (not a
+  // threshold) and a new Set keeps the state update immutable.
+  const toggleValue = useCallback((value: RelationValue) => {
+    setValueFilter((cur) => {
+      const next = new Set(cur);
+      if (next.has(value)) next.delete(value);
+      else next.add(value);
+      return next;
+    });
+  }, []);
+
+  // Derived edges for ReactFlow — rebuilt whenever the filtered subgraph changes.
   const edges = useMemo<Edge<EdgeData>[]>(() => {
-    if (!data) return [];
-    const centerId = data.centerId;
-    const nodeById = new Map(data.nodes.map((n) => [n.id, n]));
-    return data.edges.map((e) => {
+    if (!filtered) return [];
+    const centerId = filtered.centerId;
+    const nodeById = new Map(filtered.nodes.map((n) => [n.id, n]));
+    return filtered.edges.map((e) => {
       const isOutgoing = e.relatorId === centerId;
       const relatee = nodeById.get(e.relateeId);
       return {
@@ -363,20 +399,21 @@ export function WebGraph({
         },
       };
     });
-  }, [data]);
+  }, [filtered]);
 
   // Build (or rebuild) the d3-force simulation whenever the subgraph
   // changes. The viewing member is pinned at the origin so the layout
   // always orients around them.
   useEffect(() => {
-    if (!data) return;
-    const centerId = data.centerId;
+    if (!filtered) return;
+    const { centerId, nodes: subNodes, edges: subEdges } = filtered;
 
-    // Preserve positions across data changes (a new relation, a hops toggle)
-    // so the web doesn't reshuffle. Existing nodes keep their last position;
-    // new non-center nodes emerge from the center — where a just-related card
-    // flies to — and the sim eases them out. Only a true first layout (no
-    // prior nodes) scatters randomly.
+    // Preserve positions across data changes (a new relation, a hops toggle,
+    // a depth-filter toggle) so the web doesn't reshuffle. Existing nodes keep
+    // their last position; nodes the cull removed simply drop out of the sim;
+    // genuinely-new non-center nodes emerge from the center — where a
+    // just-related card flies to — and the sim eases them out. Only a true
+    // first layout (no prior nodes) gets the radial seed.
     const prevById = simNodesByIdRef.current;
     const isFirstLayout = prevById.size === 0;
     // The first layout gets a deterministic radial seed (you at the origin, the
@@ -385,12 +422,12 @@ export function WebGraph({
     // scatter — same web every load, far fewer crossings. See radialSeed.
     const seed = isFirstLayout
       ? radialSeed(
-          data.nodes.map((n) => n.id),
-          data.edges,
+          subNodes.map((n) => n.id),
+          subEdges,
           centerId,
         )
       : null;
-    const simNodes: SimNode[] = data.nodes.map((n) => {
+    const simNodes: SimNode[] = subNodes.map((n) => {
       if (n.id === centerId) return { id: n.id, x: 0, y: 0, fx: 0, fy: 0 };
       const prev = prevById.get(n.id);
       if (prev) return { id: n.id, x: prev.x, y: prev.y, vx: prev.vx, vy: prev.vy, fx: null, fy: null };
@@ -406,7 +443,7 @@ export function WebGraph({
     // the dragged node.
     const simNodeById = new Map(simNodes.map((n) => [n.id, n]));
     simNodesByIdRef.current = simNodeById;
-    const simEdges: SimEdge[] = data.edges.map((e) => ({
+    const simEdges: SimEdge[] = subEdges.map((e) => ({
       source: e.relatorId,
       target: e.relateeId,
       value: e.value,
@@ -419,7 +456,7 @@ export function WebGraph({
     const toRender = (x: number, y: number) =>
       norm ? { x: (x - norm.cx) * norm.scale, y: (y - norm.cy) * norm.scale } : { x, y };
     setNodes(
-      data.nodes.map((n) => {
+      subNodes.map((n) => {
         const sn = simNodeById.get(n.id);
         return {
           id: n.id,
@@ -570,7 +607,7 @@ export function WebGraph({
     return () => {
       sim.stop();
     };
-  }, [data]);
+  }, [filtered]);
 
   // Required for ReactFlow's drag to actually update positions in our
   // controlled `nodes` state; without it, drag fires events that go
@@ -744,8 +781,8 @@ export function WebGraph({
   // once per subgraph. Selecting a node walks these parent pointers back to the
   // center to find the chain that should stay lit while the rest dims.
   const parentByNode = useMemo(
-    () => (data ? shortestPathTree(data.edges, data.centerId) : new Map<string, string | null>()),
-    [data],
+    () => (filtered ? shortestPathTree(filtered.edges, filtered.centerId) : new Map<string, string | null>()),
+    [filtered],
   );
 
   // The node ids and edge ids on the selected node's path back to the center.
@@ -912,6 +949,10 @@ export function WebGraph({
                     <li>
                       <span className="font-medium text-foreground">2 hops</span> adds friends-of-friends.
                     </li>
+                    <li>
+                      Toggle <span className="font-medium text-foreground">1–4</span> to show only those relationship
+                      depths.
+                    </li>
                   </ul>
                   <button
                     type="button"
@@ -928,7 +969,7 @@ export function WebGraph({
             </Panel>
             <Panel
               position="top-right"
-              className="flex flex-col gap-1 rounded border border-border bg-background/90 p-2 text-sm"
+              className="flex flex-col gap-2 rounded border border-border bg-background/90 p-2 text-sm"
             >
               <label className="flex cursor-pointer items-center gap-2">
                 <input
@@ -938,6 +979,34 @@ export function WebGraph({
                 />
                 2 hops
               </label>
+              {/* Independent depth toggles (filled = shown). Reuses the 1–4
+               * vocabulary from the relating dialog; culling a depth thins the
+               * web to the ties that matter. */}
+              <fieldset className="m-0 flex flex-col gap-1 border-0 p-0">
+                <legend className="p-0 text-xs text-muted-foreground">Relationship depth</legend>
+                <div className="flex gap-1">
+                  {RELATION_VALUES.map((v) => {
+                    const on = valueFilter.has(v);
+                    return (
+                      <button
+                        key={v}
+                        type="button"
+                        aria-pressed={on}
+                        aria-label={`Depth ${v}: ${RELATION_VALUE_LABELS[v].headline}`}
+                        title={RELATION_VALUE_LABELS[v].headline}
+                        onClick={() => toggleValue(v)}
+                        className={`flex h-6 w-6 items-center justify-center rounded-full border text-xs font-semibold transition-colors ${
+                          on
+                            ? "border-primary bg-primary text-primary-foreground"
+                            : "border-border bg-transparent text-muted-foreground hover:border-foreground"
+                        }`}
+                      >
+                        {v}
+                      </button>
+                    );
+                  })}
+                </div>
+              </fieldset>
             </Panel>
           </ReactFlow>
         </NodeInteractionContext.Provider>

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -45,6 +45,7 @@ import {
   edgeStrokeWidth,
   linkDistance,
   NORMALIZATION_TARGET,
+  radialSeed,
 } from "./web-graph-layout";
 import { DIM_KEEP, decorateEdges, decorateNodes, pathToCenter, shortestPathTree } from "./web-graph-selection";
 
@@ -355,12 +356,26 @@ export function WebGraph({
     // prior nodes) scatters randomly.
     const prevById = simNodesByIdRef.current;
     const isFirstLayout = prevById.size === 0;
+    // The first layout gets a deterministic radial seed (you at the origin, the
+    // first ring evenly around you, friends-of-friends nestled by their friend),
+    // so d3-force polishes a near-correct layout instead of untangling random
+    // scatter — same web every load, far fewer crossings. See radialSeed.
+    const seed = isFirstLayout
+      ? radialSeed(
+          data.nodes.map((n) => n.id),
+          data.edges,
+          centerId,
+        )
+      : null;
     const simNodes: SimNode[] = data.nodes.map((n) => {
       if (n.id === centerId) return { id: n.id, x: 0, y: 0, fx: 0, fy: 0 };
       const prev = prevById.get(n.id);
       if (prev) return { id: n.id, x: prev.x, y: prev.y, vx: prev.vx, vy: prev.vy, fx: null, fy: null };
-      const spread = isFirstLayout ? 200 : 12;
-      return { id: n.id, x: (Math.random() - 0.5) * spread, y: (Math.random() - 0.5) * spread, fx: null, fy: null };
+      const seeded = seed?.get(n.id);
+      if (seeded) return { id: n.id, x: seeded.x, y: seeded.y, fx: null, fy: null };
+      // A genuinely-new node on an incremental update emerges from the center —
+      // where the just-related card flies to — and the sim eases it out.
+      return { id: n.id, x: (Math.random() - 0.5) * 12, y: (Math.random() - 0.5) * 12, fx: null, fy: null };
     });
     // Lookup map kept around for paintFromSim — avoids an O(n²) .find
     // scan on every tick. Also exposed via simNodesByIdRef so the

--- a/tests/functional/client/web-graph-controls.test.tsx
+++ b/tests/functional/client/web-graph-controls.test.tsx
@@ -24,13 +24,13 @@ const makeProps = (
 describe("WebGraphControls", () => {
   it("reflects the current hops in the checkbox", () => {
     render(<WebGraphControls {...makeProps({ hops: 1 })} />);
-    expect(screen.getByRole("checkbox", { name: "2 hops" })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Friends-of-friends" })).not.toBeChecked();
   });
 
   it("reports a hops change when the checkbox is toggled", () => {
     const onHopsChange = vi.fn();
     render(<WebGraphControls {...makeProps({ hops: 1, onHopsChange })} />);
-    fireEvent.click(screen.getByRole("checkbox", { name: "2 hops" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Friends-of-friends" }));
     expect(onHopsChange).toHaveBeenCalledWith(2);
   });
 

--- a/tests/functional/client/web-graph-controls.test.tsx
+++ b/tests/functional/client/web-graph-controls.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+// Panel reads ReactFlow context; stub it to a passthrough div (as the WebGraph
+// suite does) so the controls render in isolation.
+vi.mock("@xyflow/react", () => ({
+  Panel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+import { WebGraphControls } from "@/app/myweb/web-graph-controls";
+import type { RelationValue } from "@/lib/relation-value";
+
+const makeProps = (
+  over: Partial<ComponentProps<typeof WebGraphControls>> = {},
+): ComponentProps<typeof WebGraphControls> => ({
+  hops: 2,
+  onHopsChange: vi.fn(),
+  valueFilter: new Set<RelationValue>([1, 2, 3, 4]),
+  onToggleValue: vi.fn(),
+  ...over,
+});
+
+describe("WebGraphControls", () => {
+  it("reflects the current hops in the checkbox", () => {
+    render(<WebGraphControls {...makeProps({ hops: 1 })} />);
+    expect(screen.getByRole("checkbox", { name: "2 hops" })).not.toBeChecked();
+  });
+
+  it("reports a hops change when the checkbox is toggled", () => {
+    const onHopsChange = vi.fn();
+    render(<WebGraphControls {...makeProps({ hops: 1, onHopsChange })} />);
+    fireEvent.click(screen.getByRole("checkbox", { name: "2 hops" }));
+    expect(onHopsChange).toHaveBeenCalledWith(2);
+  });
+
+  it("presses each depth pill according to the filter", () => {
+    render(<WebGraphControls {...makeProps({ valueFilter: new Set<RelationValue>([3, 4]) })} />);
+    expect(screen.getByRole("button", { name: "Depth 1: Acquaintance" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "Depth 3: Close Friend" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Depth 4: Kin" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("reports a depth toggle when a pill is clicked", () => {
+    const onToggleValue = vi.fn();
+    render(<WebGraphControls {...makeProps({ onToggleValue })} />);
+    fireEvent.click(screen.getByRole("button", { name: "Depth 2: Friend" }));
+    expect(onToggleValue).toHaveBeenCalledWith(2);
+  });
+});

--- a/tests/functional/client/web-graph-filtering.test.ts
+++ b/tests/functional/client/web-graph-filtering.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { filterSubgraphByValue } from "@/app/myweb/web-graph-filtering";
+
+describe("filterSubgraphByValue", () => {
+  const node = (id: string) => ({ id });
+  const vedge = (relatorId: string, relateeId: string, value: number) => ({ relatorId, relateeId, value });
+  const ids = (ns: { id: string }[]) => ns.map((n) => n.id).sort();
+  const edgeIds = (es: { relatorId: string; relateeId: string }[]) => es.map((e) => `${e.relatorId}->${e.relateeId}`);
+
+  // C—A (depth 1), A—B (depth 3): B hangs off the center only through A.
+  const nodes = [node("C"), node("A"), node("B")];
+  const edges = [vedge("C", "A", 1), vedge("A", "B", 3)];
+
+  it("returns everything when all depths are included", () => {
+    const out = filterSubgraphByValue(nodes, edges, "C", new Set([1, 2, 3, 4]));
+    expect(ids(out.nodes)).toEqual(["A", "B", "C"]);
+    expect(edgeIds(out.edges)).toEqual(["C->A", "A->B"]);
+  });
+
+  it("drops edges of an excluded depth but keeps still-connected nodes", () => {
+    // Exclude 3 → A—B goes; A stays (linked via C—A), B drops with its edge.
+    const out = filterSubgraphByValue(nodes, edges, "C", new Set([1, 2, 4]));
+    expect(ids(out.nodes)).toEqual(["A", "C"]);
+    expect(edgeIds(out.edges)).toEqual(["C->A"]);
+  });
+
+  it("drops a node orphaned when the edge linking it to the center is excluded", () => {
+    // Exclude 1 → C—A goes; A is now unreachable, so A, B, and the kept A—B edge
+    // all drop. Just the center remains.
+    const out = filterSubgraphByValue(nodes, edges, "C", new Set([2, 3, 4]));
+    expect(ids(out.nodes)).toEqual(["C"]);
+    expect(out.edges).toEqual([]);
+  });
+
+  it("leaves a lone center when every depth is excluded", () => {
+    const out = filterSubgraphByValue(nodes, edges, "C", new Set());
+    expect(ids(out.nodes)).toEqual(["C"]);
+    expect(out.edges).toEqual([]);
+  });
+
+  it("keeps a node still reachable by an alternate kept path", () => {
+    // C—A (1), C—B (1), A—B (4): excluding 4 drops A—B, but A and B stay since
+    // both still reach C through depth-1 edges.
+    const triangle = [vedge("C", "A", 1), vedge("C", "B", 1), vedge("A", "B", 4)];
+    const out = filterSubgraphByValue(nodes, triangle, "C", new Set([1, 2, 3]));
+    expect(ids(out.nodes)).toEqual(["A", "B", "C"]);
+    expect(edgeIds(out.edges).sort()).toEqual(["C->A", "C->B"]);
+  });
+});

--- a/tests/functional/client/web-graph-layout.test.ts
+++ b/tests/functional/client/web-graph-layout.test.ts
@@ -7,6 +7,9 @@ import {
   edgeStrokeOpacity,
   edgeStrokeWidth,
   linkDistance,
+  radialSeed,
+  SEED_FIRST_HOP_RADIUS,
+  SEED_RING_GAP,
 } from "@/app/myweb/web-graph-layout";
 
 describe("edge visual encoding", () => {
@@ -123,5 +126,73 @@ describe("edgeAvoidance", () => {
     const hot = edgeAvoidance(0, 30, ax, ay, bx, by, 1);
     const cool = edgeAvoidance(0, 30, ax, ay, bx, by, 0.5);
     expect(cool?.dvy).toBeCloseTo((hot?.dvy ?? 0) / 2, 6);
+  });
+});
+
+describe("radialSeed", () => {
+  const edge = (relatorId: string, relateeId: string) => ({ relatorId, relateeId });
+  const radius = (p?: { x: number; y: number }) => (p ? Math.hypot(p.x, p.y) : Number.NaN);
+  const angleOf = (p?: { x: number; y: number }) => (p ? Math.atan2(p.y, p.x) : Number.NaN);
+
+  it("pins the center at the origin", () => {
+    expect(radialSeed(["C"], [], "C").get("C")).toEqual({ x: 0, y: 0 });
+  });
+
+  it("places a first-hop node on the first ring", () => {
+    const seed = radialSeed(["C", "A"], [edge("C", "A")], "C");
+    expect(radius(seed.get("A"))).toBeCloseTo(SEED_FIRST_HOP_RADIUS, 6);
+  });
+
+  it("spaces the first ring evenly around the center", () => {
+    // Four direct connections → quarters of the circle, id-ordered a,b,c,d.
+    const seed = radialSeed(
+      ["C", "a", "b", "c", "d"],
+      ["a", "b", "c", "d"].map((id) => edge("C", id)),
+      "C",
+    );
+    for (const id of ["a", "b", "c", "d"]) {
+      expect(radius(seed.get(id))).toBeCloseTo(SEED_FIRST_HOP_RADIUS, 6);
+    }
+    // a at 0, b at 90°, c at 180°, d at 270°.
+    expect(seed.get("a")?.x).toBeCloseTo(SEED_FIRST_HOP_RADIUS, 6);
+    expect(seed.get("b")?.y).toBeCloseTo(SEED_FIRST_HOP_RADIUS, 6);
+    expect(seed.get("c")?.x).toBeCloseTo(-SEED_FIRST_HOP_RADIUS, 6);
+    expect(seed.get("d")?.y).toBeCloseTo(-SEED_FIRST_HOP_RADIUS, 6);
+  });
+
+  it("is independent of edge order and edge direction", () => {
+    const ids = ["C", "A", "B", "Z"];
+    const a = radialSeed(ids, [edge("C", "A"), edge("C", "B"), edge("A", "Z")], "C");
+    // Same graph, edges shuffled and some stored relatee→relator.
+    const b = radialSeed(ids, [edge("Z", "A"), edge("B", "C"), edge("C", "A")], "C");
+    const dump = (m: Map<string, { x: number; y: number }>) => [...m.entries()].sort(([x], [y]) => x.localeCompare(y));
+    expect(dump(a)).toEqual(dump(b));
+  });
+
+  it("nestles deeper nodes in an arc around the friend they connect through", () => {
+    // C—A, C—B (first ring); A—W, A—Z (second ring, both hanging off A at angle 0).
+    const seed = radialSeed(
+      ["C", "A", "B", "W", "Z"],
+      [edge("C", "A"), edge("C", "B"), edge("A", "W"), edge("A", "Z")],
+      "C",
+    );
+    const aAngle = angleOf(seed.get("A"));
+    for (const id of ["W", "Z"]) {
+      // One hop deeper sits a full ring-gap further out…
+      expect(radius(seed.get(id))).toBeCloseTo(SEED_FIRST_HOP_RADIUS + SEED_RING_GAP, 6);
+      // …and stays within A's angular wedge (half the gap between A and B is π/2).
+      expect(Math.abs(angleOf(seed.get(id)) - aAngle)).toBeLessThan(Math.PI / 2);
+    }
+    // The two siblings fan to opposite sides of A, so they don't overlap.
+    expect(angleOf(seed.get("W"))).not.toBeCloseTo(angleOf(seed.get("Z")), 6);
+  });
+
+  it("gives an unreachable node a finite outer-ring spot", () => {
+    const seed = radialSeed(["C", "A", "X"], [edge("C", "A")], "C");
+    const x = seed.get("X");
+    expect(x).toBeDefined();
+    expect(Number.isFinite(radius(x))).toBe(true);
+    // Beyond the reachable graph's deepest ring.
+    expect(radius(x)).toBeGreaterThan(SEED_FIRST_HOP_RADIUS);
   });
 });

--- a/tests/functional/client/web-graph.test.tsx
+++ b/tests/functional/client/web-graph.test.tsx
@@ -119,7 +119,7 @@ describe("WebGraph — hops toggle", () => {
     $get.mockResolvedValue(okResponse(populatedWeb));
     renderGraph();
 
-    const toggle = await screen.findByRole("checkbox", { name: "2 hops" });
+    const toggle = await screen.findByRole("checkbox", { name: "Friends-of-friends" });
     expect(toggle).toBeChecked(); // default view is 2 hops
     await waitFor(() => expect($get).toHaveBeenCalledWith({ query: { hops: "2" } }));
 


### PR DESCRIPTION
Summary: A usability pass on the personal web graph — adds relationship-depth filtering, fixes two first-paint glitches, and splits the ~1010-line component into focused, testable modules.

Why: #374 landed the graph, but it loaded with visible glitches, gave no way to thin a dense 2-hop web, and had grown into a single file that was hard to work in.

Behavior:
- Deterministic radial seed — the same layout every load, with far fewer edge crossings — and the graph lands at the right view and zoom on first paint: no hop-count flash for a stored "1 hop" preference, no zoom-jump when the simulation settles.
- New relationship-depth filter (1–4 pills) culls the web to the ties that matter. The cull is orphan-safe (hiding the edge to a friend-of-friend drops them too), persisted across reloads, and re-relaxes the layout rather than just hiding lines.
- The "2 hops" toggle is renamed "Friends-of-friends".
- No API or schema changes — the depth filter is a client-side cull over the already-fetched subgraph.

Refactor (behavior-preserving): web-graph.tsx ~1010 → ~507 lines, split into WebGraphControls, web-graph-renderers, web-graph-filtering, and the useWebGraphSimulation hook — each with focused tests. Fit padding hoisted to one constant (0.10).

Test Plan:
- ran `npm test` locally — lint, typecheck, 435 functional, and 29 e2e all green (after rebasing onto #375).
- Browser-verified the layout determinism, the first-paint fixes (node-count and viewport-zoom traces), the depth filter (40 → 30 → lone-you, persisted across reload), and the refactors (renderers, drag, and fit all still work post-extraction).

Follow-up (not in this PR): keep the center node visually centered at 2 hops — the viewport normalizes on the cloud's bounding box, not the pinned center.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
