### PR TITLE
feat(sentry): prod-only reporting, opt-in replay, tunnel rename

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-10 | James | Sentry now prod-only; replay only when ?debug-replay=1; tunnel renamed to /error-handling
+
+Sentry is `enabled` only when `VERCEL_ENV=production`. Session replay records only when a session carries `?debug-replay=1` (see docs/doc-sentry.md). Tunnel route moved from `/monitoring` to `/error-handling` to read more honestly in devtools.
+
 ## 2026-06-09 | James | /me replaces /profile; stable, member-owned slugs (#376, #188)
 
 `/profile` and `/profile/edit` merged into `/me` (Profile + Settings tabs); Settings holds the theme selector (docs/strategy-ui.md), profile URL, emergency contact, password, and deactivation. Slugs no longer track display-name changes: derived once, then edited only in Settings; display names may repeat, with name twins getting `-2`-style slug permutations.

--- a/docs/doc-sentry.md
+++ b/docs/doc-sentry.md
@@ -10,8 +10,8 @@
 
 | Variable | Where | Purpose |
 |----------|-------|---------|
-| `NEXT_PUBLIC_SENTRY_DSN` | `.env.local`, Vercel | Client-side error reporting |
-| `SENTRY_DSN` | `.env.local`, Vercel | Server-side error reporting |
+| `NEXT_PUBLIC_SENTRY_DSN` | Vercel (Production only) | Client-side error reporting |
+| `SENTRY_DSN` | Vercel (Production only) | Server-side error reporting |
 | `SENTRY_ORG` | `.env.local`, Vercel | Source map upload (org slug) |
 | `SENTRY_PROJECT` | `.env.local`, Vercel | Source map upload (project slug) |
 | `SENTRY_AUTH_TOKEN` | `.env.local`, Vercel | Source map upload (auth token) |
@@ -20,11 +20,12 @@ Auth tokens are generated at Settings → Auth Tokens in the Sentry dashboard.
 
 ## How It Works
 
-- **Client errors:** `instrumentation-client.ts` initializes Sentry in the browser with error tracking, performance traces, and session replay
+- **Client errors:** `instrumentation-client.ts` initializes Sentry in the browser with error tracking, performance traces, and opt-in session replay (see below)
 - **Server errors:** `sentry.server.config.ts` loaded via `instrumentation.ts` at server startup
 - **React crashes:** `src/app/global-error.tsx` catches uncaught errors and reports to Sentry
 - **Source maps:** uploaded automatically during `next build` when `SENTRY_AUTH_TOKEN` is set
-- **Tunnel route:** `/monitoring` proxies Sentry events through our domain to avoid ad blockers
+- **Tunnel route:** `/error-handling` proxies all browser-side Sentry traffic (errors, traces, replay) through our domain to avoid ad blockers
+- **Production deploys only:** both init configs set `enabled` on `VERCEL_ENV === "production"` (inlined into the client bundle via the `env` key in `next.config.ts`). Preview deploys and local dev send nothing — preview e2e runs were generating thousands of tunnel POSTs per run, tripping Vercel traffic-spike alerts
 
 ## PII Handling
 
@@ -35,16 +36,22 @@ Two `beforeSend` scrubbers in `src/lib/sentry-scrub.ts` provide defense-in-depth
 - **Client** (`scrubClientEvent`): on `/auth/`, `/signin`, and `/signup` URLs, the query string is dropped from `event.request.url` so OAuth tokens like `?code=...` don't ship. The event itself is still sent so genuine errors on these routes remain visible.
 - **Server** (`scrubServerEvent`): deletes `event.request.cookies` and removes the `authorization` and `cookie` headers from every event.
 
-Session replay is configured with `maskAllText: true` and `blockAllMedia: true`, so recordings show only structural placeholders for text and no images/video.
-
 Unit tests for both scrubbers live in `tests/functional/sentry-scrub.test.ts`.
+
+## Session Replay — opt-in only
+
+Replay records nothing by default. To see what a user is experiencing in a "works on my machine" scenario, have them load any page with `?debug-replay=1` — that browser session then records at 100% (including buffered capture of any errors) and appears under Replays in the Sentry dashboard. The flag persists in `sessionStorage`, so it survives navigation within the app and clears when the tab closes.
+
+Recordings are masked: `maskAllText: true` and `blockAllMedia: true` mean only structural placeholders for text and no images/video.
 
 ## Sample Rates
 
-| Setting | Development | Production |
-|---------|------------|------------|
-| Traces | 100% | 10% |
-| Session replay | 10% | 10% |
-| Replay on error | 100% | 100% |
+Sentry reports from production deploys only (the `enabled` gate), so a single set of rates applies:
+
+| Setting | Rate |
+|---------|------|
+| Traces | 10% |
+| Session replay | 0% (100% with `?debug-replay=1`) |
+| Replay on error | 0% (100% with `?debug-replay=1`) |
 
 Adjust in `instrumentation-client.ts` and `sentry.server.config.ts`.

--- a/docs/doc-vercel.md
+++ b/docs/doc-vercel.md
@@ -14,6 +14,7 @@ Current configuration for the Vercel project as deployed. This documents setting
 - **Deployment Protection:** Vercel Authentication disabled on preview deployments, so GitHub Actions can run Playwright e2e tests against preview URLs without hitting a sign-in wall
 - **Integrations:** Axiom (Log Drain — streams all serverless function output to Axiom automatically)
 - **Environment variables:** `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY`, `DATABASE_URL`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` — set in Vercel dashboard (Settings → Environment Variables), not committed to the repo
+  - The two DSN vars are scoped to **Production** only, matching the `enabled` gate in the Sentry init configs: preview and dev deploys carry no DSN at all, so Sentry traffic comes solely from production
 
 ---
 

--- a/docs/strategy-security.md
+++ b/docs/strategy-security.md
@@ -77,7 +77,7 @@ Outbound XHR/fetch/WebSocket destinations.
 
 The two entries:
 
-- **`'self'`** covers our Hono API routes (all database access), the Sentry tunnel at `/monitoring` (configured via `tunnelRoute` in `next.config.ts`), and the next-axiom client proxy at `/_axiom/*`. Both observability tools route browser telemetry through our own origin, which is why this list is short.
+- **`'self'`** covers our Hono API routes (all database access), the Sentry tunnel at `/error-handling` (configured via `tunnelRoute` in `next.config.ts`), and the next-axiom client proxy at `/_axiom/*`. Both observability tools route browser telemetry through our own origin, which is why this list is short.
 - **`https://*.supabase.co`** is required because Supabase Auth (GoTrue) is the only Supabase service we call directly from the browser. The signin/signup forms call `supabase.auth.signInWith*` and `updateUser`; the `AuthProvider` subscribes to `onAuthStateChange`, which performs background token refreshes against `https://<project>.supabase.co/auth/v1/token`. Database queries do **not** go to Supabase from the browser — they go through Hono.
 
 The dev-only `http://127.0.0.1:54321` entry exists because `npm run dev` points the browser auth client at the local Supabase stack (`NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321`). Without it in dev, every signin/signup/token-refresh call would be CSP-blocked. The branch is keyed on `process.env.NODE_ENV` so the URL never appears in production response headers.

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,17 +2,40 @@ import * as Sentry from "@sentry/nextjs";
 
 import { scrubClientEvent } from "@/lib/sentry-scrub";
 
+// Session replay is opt-in for support sessions: load any page with
+// ?debug-replay=1 and the rest of the browser session records (masked text,
+// no media). The flag sticks in sessionStorage so it survives in-app
+// navigation but ends when the tab closes.
+const debugReplay = (() => {
+  try {
+    if (new URLSearchParams(window.location.search).has("debug-replay")) {
+      window.sessionStorage.setItem("debug-replay", "1");
+    }
+    return window.sessionStorage.getItem("debug-replay") === "1";
+  } catch {
+    // sessionStorage can throw when the user blocks site data
+    return false;
+  }
+})();
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
-  integrations: [
-    Sentry.replayIntegration({
-      maskAllText: true,
-      blockAllMedia: true,
-    }),
-  ],
+  // Report from production deploys only: preview e2e runs were sending
+  // thousands of tunnel POSTs per run (Vercel traffic-spike alerts), and
+  // local dev errors are already on the developer's screen.
+  // NEXT_PUBLIC_VERCEL_ENV is inlined via the env key in next.config.ts.
+  enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === "production",
+  tracesSampleRate: 0.1,
+  replaysSessionSampleRate: debugReplay ? 1.0 : 0,
+  replaysOnErrorSampleRate: debugReplay ? 1.0 : 0,
+  integrations: debugReplay
+    ? [
+        Sentry.replayIntegration({
+          maskAllText: true,
+          blockAllMedia: true,
+        }),
+      ]
+    : [],
   beforeSend: scrubClientEvent,
 });
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -38,7 +38,7 @@ const securityHeaders = [
       // Supabase auth: signin/signup forms and the AuthProvider's token refresh
       // call GoTrue directly from the browser. Database queries go through Hono
       // ('self'), so PostgREST is not listed. Realtime is not used.
-      // Sentry ingest goes through the /monitoring tunnel and next-axiom proxies
+      // Sentry ingest goes through the /error-handling tunnel and next-axiom proxies
       // client telemetry through /_axiom — both covered by 'self'.
       connectSrc,
       "img-src 'self' data: blob: https:",
@@ -71,6 +71,10 @@ if (!isProd) {
 }
 
 const nextConfig: NextConfig = {
+  // Inlines the deploy environment into the client bundle so
+  // instrumentation-client.ts can gate Sentry to production deploys,
+  // independent of Vercel's "expose system env vars" dashboard toggle.
+  env: { NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV ?? "" },
   typedRoutes: true,
   images: {
     remotePatterns,
@@ -97,7 +101,9 @@ export default withSentryConfig(withAxiom(nextConfig), {
   project: process.env.SENTRY_PROJECT,
   authToken: process.env.SENTRY_AUTH_TOKEN,
   widenClientFileUpload: true,
-  tunnelRoute: "/monitoring",
+  // Same-origin proxy for all browser-side Sentry traffic. Named to read
+  // honestly in devtools and to dodge blocklist rules that match /monitoring.
+  tunnelRoute: "/error-handling",
   silent: !process.env.CI,
   sourcemaps: { disable: process.env.VERCEL_ENV !== "production" },
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,7 +4,10 @@ import { scrubServerEvent } from "@/lib/sentry-scrub";
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
+  // Report from production deploys only — mirrors the client gate in
+  // instrumentation-client.ts.
+  enabled: process.env.VERCEL_ENV === "production",
+  tracesSampleRate: 0.1,
   includeLocalVariables: true,
   beforeSend: scrubServerEvent,
 });


### PR DESCRIPTION
Summary: Gate Sentry to production deploys, make session replay opt-in
via ?debug-replay=1, and rename the tunnel route from /monitoring to
/error-handling.

Why: Preview e2e runs sent thousands of tunnel POSTs per run, tripping
Vercel traffic-spike alerts; always-on replay read as user surveillance
while nobody consumed the recordings; /monitoring is matched by
ad-blocker blocklists.

Behavior:
- Both Sentry init configs set enabled only when VERCEL_ENV=production
  (the client reads NEXT_PUBLIC_VERCEL_ENV, inlined via the env key in
  next.config.ts); preview deploys and local dev send nothing.
- Replay records only when a session carries ?debug-replay=1, persisted
  in sessionStorage for the tab's lifetime; without the flag the replay
  integration never loads.
- tracesSampleRate is a flat 0.1 - the dev-only 1.0 branch became dead
  code behind the enabled gate.
- Browser-side Sentry traffic now POSTs to /error-handling.
- The two Vercel DSN env vars are rescoped to Production only
  (recorded in docs/doc-vercel.md).

Test Plan:
- ran `npm test` locally (functional suites + 31 e2e specs, green)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
