### PR TITLE
feat(admin): per-member sign-ins report with last-activity column

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -64,6 +64,12 @@ export default async function AdminPage() {
         >
           Manage members →
         </Link>
+        <Link
+          href="/admin/signins"
+          className="text-sm text-muted-foreground underline hover:text-foreground hover:no-underline"
+        >
+          View sign-ins →
+        </Link>
       </section>
 
       <section className="flex w-full max-w-xl flex-col gap-2">

--- a/src/app/admin/signins/page.tsx
+++ b/src/app/admin/signins/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { requireUser } from "@/lib/api-server";
+
+import { SigninsAdminPanel } from "./signins-admin-panel";
+
+export default async function AdminSigninsPage() {
+  const me = await requireUser();
+  // Generic 404 for non-admins, matching the /admin hub page.
+  if (!me.profile?.isAdmin) notFound();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+      <div className="flex w-full max-w-xl items-center justify-between">
+        <h1 className="text-2xl font-bold">Sign-ins</h1>
+        <Link href="/admin" className="text-base text-muted-foreground hover:text-foreground">
+          ← Admin
+        </Link>
+      </div>
+      <SigninsAdminPanel />
+    </main>
+  );
+}

--- a/src/app/admin/signins/signins-admin-panel.tsx
+++ b/src/app/admin/signins/signins-admin-panel.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/lib/api";
+import type { AdminSignin } from "@/lib/api-types";
+
+const QUERY_KEY = ["admin", "signins"] as const;
+const STALE_TIME = 5 * 60 * 1000;
+
+const fetchSignins = async (): Promise<AdminSignin[]> => {
+  const res = await apiClient.api.admin.signins.$get();
+  if (!res.ok) throw new Error(`admin/signins: ${res.status}`);
+  const body = await res.json();
+  return body.signins;
+};
+
+function formatSignin(iso: string) {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function SigninRow({ member, detail }: { member: AdminSignin; detail: string | null }) {
+  // lastActivityAt covers live sessions only, so it matches lastSignInAt
+  // for everyone else — show it only when it adds information.
+  const activity =
+    member.lastActivityAt && member.lastActivityAt !== member.lastSignInAt ? formatSignin(member.lastActivityAt) : null;
+
+  return (
+    <li className="flex items-center gap-3 rounded border border-border px-3 py-2">
+      <span className="min-w-0 flex-1 truncate font-medium">{member.displayName ?? "(unnamed)"}</span>
+      {member.hidden && <span className="shrink-0 text-xs text-muted-foreground">hidden</span>}
+      {member.deactivated && <span className="shrink-0 text-xs text-muted-foreground">deactivated</span>}
+      <span className="flex shrink-0 flex-col items-end">
+        {detail && <span className="text-sm text-muted-foreground">{detail}</span>}
+        {activity && <span className="text-xs text-muted-foreground">active {activity}</span>}
+      </span>
+    </li>
+  );
+}
+
+export function SigninsAdminPanel() {
+  const signinsQuery = useQuery({ queryKey: QUERY_KEY, queryFn: fetchSignins, staleTime: STALE_TIME });
+
+  if (signinsQuery.isPending) {
+    return <p className="text-sm text-muted-foreground">Loading…</p>;
+  }
+  if (signinsQuery.isError) {
+    return (
+      <p role="alert" className="text-sm text-destructive">
+        Couldn't load sign-ins.
+      </p>
+    );
+  }
+
+  // The API returns rows already ordered most-recent-first with
+  // never-signed-in members at the end, so a partition keeps that order.
+  const signedIn = signinsQuery.data.filter((m) => m.lastSignInAt !== null);
+  const neverSignedIn = signinsQuery.data.filter((m) => m.lastSignInAt === null);
+
+  return (
+    <div className="flex w-full max-w-xl flex-col gap-6">
+      <section className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">Most recent sign-in</h2>
+        <p className="text-sm text-muted-foreground">
+          Timestamps record the last full sign-in — a member with a live session who only refreshes their token keeps
+          their old timestamp. An "active" line shows the latest token refresh, available only while that session is
+          still alive.
+        </p>
+        {signedIn.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No one has signed in yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {signedIn.map((member) => (
+              <SigninRow key={member.id} member={member} detail={formatSignin(member.lastSignInAt as string)} />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">Never signed in</h2>
+        {neverSignedIn.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Everyone has signed in at least once.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {neverSignedIn.map((member) => (
+              <SigninRow key={member.id} member={member} detail={null} />
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -57,3 +57,7 @@ export type AdminMember = AdminMembersResponse["members"][number];
 export type AdminInvitesResponse = InferResponseType<(typeof apiClient.api.admin.invites)["$get"], 200>;
 
 export type AdminInvite = AdminInvitesResponse["invites"][number];
+
+export type AdminSigninsResponse = InferResponseType<(typeof apiClient.api.admin.signins)["$get"], 200>;
+
+export type AdminSignin = AdminSigninsResponse["signins"][number];

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -75,6 +75,7 @@ import {
 import { getProfileMiniMap } from "./relations-mini-map";
 import { getPersonalWeb } from "./relations-personal";
 import { profiles } from "./schema";
+import { listSigninsAdmin } from "./signins-admin";
 import { getSystemMetrics } from "./system-metrics";
 import { resetE2EUsers } from "./test-reset";
 
@@ -234,6 +235,10 @@ const adminRoutes = new Hono<{ Variables: ApiVariables }>()
   .get("/members", async (c) => {
     const members = await listMembersAdmin();
     return c.json({ members });
+  })
+  .get("/signins", async (c) => {
+    const signins = await listSigninsAdmin();
+    return c.json({ signins });
   })
   .patch(
     "/members/:id/admin",

--- a/src/server/signins-admin.ts
+++ b/src/server/signins-admin.ts
@@ -1,0 +1,63 @@
+import { sql } from "drizzle-orm";
+
+import { db } from "./db";
+
+// Per-member sign-in recency for the admin report. last_sign_in_at lives
+// on auth.users, which schema.ts maps only partially (id + email, for
+// FKs), so the whole query is raw SQL — same approach as
+// system-metrics.ts. It records the last *full* sign-in, not the last
+// visit: a member riding a live session only refreshes their token and
+// keeps their old timestamp.
+export type AdminSignin = {
+  id: string;
+  displayName: string | null;
+  // ISO string; null = has never signed in.
+  lastSignInAt: string | null;
+  // Latest of last_sign_in_at and any live session's token refresh.
+  // Session rows are deleted on sign-out, so this beats lastSignInAt
+  // only for members with a session alive right now.
+  lastActivityAt: string | null;
+  hidden: boolean;
+  deactivated: boolean;
+};
+
+export const listSigninsAdmin = async (): Promise<AdminSignin[]> => {
+  // NULLS LAST puts never-signed-in members after everyone else, so the
+  // API returns the report already in display order. sessions.refreshed_at
+  // is the one auth column stored *without* a time zone (UTC by
+  // convention), so it needs AT TIME ZONE 'UTC' before GREATEST can
+  // compare it against last_sign_in_at.
+  const rows = (await db.execute(sql`
+    SELECT
+      p.id,
+      p.display_name,
+      u.last_sign_in_at,
+      GREATEST(u.last_sign_in_at, s.last_refreshed_at) AS last_activity_at,
+      p.hidden,
+      (p.deactivated_at IS NOT NULL) AS deactivated
+    FROM auth.users u
+    JOIN public.profiles p ON p.id = u.id
+    LEFT JOIN (
+      SELECT user_id, max(refreshed_at AT TIME ZONE 'UTC') AS last_refreshed_at
+      FROM auth.sessions
+      GROUP BY user_id
+    ) s ON s.user_id = u.id
+    ORDER BY u.last_sign_in_at DESC NULLS LAST, lower(p.display_name) ASC NULLS LAST, p.id
+  `)) as unknown as {
+    id: string;
+    display_name: string | null;
+    last_sign_in_at: Date | null;
+    last_activity_at: Date | null;
+    hidden: boolean;
+    deactivated: boolean;
+  }[];
+
+  return rows.map((r) => ({
+    id: r.id,
+    displayName: r.display_name,
+    lastSignInAt: r.last_sign_in_at ? new Date(r.last_sign_in_at).toISOString() : null,
+    lastActivityAt: r.last_activity_at ? new Date(r.last_activity_at).toISOString() : null,
+    hidden: r.hidden,
+    deactivated: r.deactivated,
+  }));
+};

--- a/tests/functional/server/admin-signins.test.ts
+++ b/tests/functional/server/admin-signins.test.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from "node:crypto";
+import type { User } from "@supabase/supabase-js";
+import { eq, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+import { createServerClient } from "@supabase/ssr";
+
+import app from "@/server/api";
+import { db } from "@/server/db";
+import { profiles } from "@/server/schema";
+import type { AdminSignin } from "@/server/signins-admin";
+
+const mockCreateServerClient = vi.mocked(createServerClient);
+
+const fakeUser = (id: string): User =>
+  ({
+    id,
+    email: `${id}@testfake.local`,
+    user_metadata: {},
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+  }) as User;
+
+const authAs = (userId: string | null) => {
+  mockCreateServerClient.mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? fakeUser(userId) : null },
+        error: null,
+      }),
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test mock shape
+  } as any);
+};
+
+const insertUserAndProfile = async (id: string, opts: { isAdmin?: boolean } = {}) => {
+  await db.execute(
+    sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${id}::uuid, ${`${id}@testfake.local`}, false, false)`,
+  );
+  await db.insert(profiles).values({ id, isAdmin: opts.isAdmin ?? false });
+};
+
+const deleteUserAndProfile = async (id: string) => {
+  await db.delete(profiles).where(eq(profiles.id, id));
+  await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+};
+
+const setLastSignIn = async (id: string, iso: string) => {
+  await db.execute(sql`UPDATE auth.users SET last_sign_in_at = ${iso}::timestamptz WHERE id = ${id}::uuid`);
+};
+
+// auth.sessions.refreshed_at is a timestamp WITHOUT time zone holding UTC,
+// so strip the ISO suffix rather than let Postgres apply a zone shift.
+// The row cascade-deletes with its auth.users row.
+const insertSession = async (userId: string, refreshedAtIso: string) => {
+  const refreshedAt = refreshedAtIso.replace("T", " ").replace("Z", "");
+  await db.execute(
+    sql`INSERT INTO auth.sessions (id, user_id, refreshed_at) VALUES (${randomUUID()}::uuid, ${userId}::uuid, ${refreshedAt}::timestamp)`,
+  );
+};
+
+describe("GET /api/admin/signins", () => {
+  let admin: string;
+  let recent: string;
+  let older: string;
+  let never: string;
+
+  const RECENT_AT = "2026-06-10T08:30:00.000Z";
+  const RECENT_ACTIVE_AT = "2026-06-10T09:15:00.000Z";
+  const OLDER_AT = "2026-05-01T17:45:00.000Z";
+
+  beforeEach(async () => {
+    admin = randomUUID();
+    recent = randomUUID();
+    older = randomUUID();
+    never = randomUUID();
+    await insertUserAndProfile(admin, { isAdmin: true });
+    await insertUserAndProfile(recent);
+    await insertUserAndProfile(older);
+    await insertUserAndProfile(never);
+    // Names make the NULLS-LAST tail order deterministic (sorted by
+    // lowercased display name): Alex Admin before Nina Never.
+    await db.update(profiles).set({ displayName: "Alex Admin" }).where(eq(profiles.id, admin));
+    await db.update(profiles).set({ displayName: "Rita Recent" }).where(eq(profiles.id, recent));
+    await db.update(profiles).set({ displayName: "Olaf Older", hidden: true }).where(eq(profiles.id, older));
+    await db
+      .update(profiles)
+      .set({ displayName: "Nina Never", deactivatedAt: new Date() })
+      .where(eq(profiles.id, never));
+    await setLastSignIn(recent, RECENT_AT);
+    await setLastSignIn(older, OLDER_AT);
+    await insertSession(recent, RECENT_ACTIVE_AT);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(admin);
+    await deleteUserAndProfile(recent);
+    await deleteUserAndProfile(older);
+    await deleteUserAndProfile(never);
+  });
+
+  it("returns every member, most recent sign-in first, never-signed-in last", async () => {
+    authAs(admin);
+    const res = await app.request("/api/admin/signins");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { signins: AdminSignin[] };
+
+    // Other test files seed users concurrently, so assert on this
+    // test's fixtures only — filtering preserves relative order.
+    const mine = body.signins.filter((s) => [admin, recent, older, never].includes(s.id));
+    expect(mine.map((s) => s.id)).toEqual([recent, older, admin, never]);
+
+    expect(mine[0]).toEqual({
+      id: recent,
+      displayName: "Rita Recent",
+      lastSignInAt: RECENT_AT,
+      // Live-session token refresh wins over the sign-in timestamp.
+      lastActivityAt: RECENT_ACTIVE_AT,
+      hidden: false,
+      deactivated: false,
+    });
+    // No live session → activity falls back to the sign-in timestamp.
+    expect(mine[1]).toMatchObject({ lastSignInAt: OLDER_AT, lastActivityAt: OLDER_AT, hidden: true });
+    expect(mine[2]).toMatchObject({ lastSignInAt: null });
+    expect(mine[3]).toMatchObject({ lastSignInAt: null, lastActivityAt: null, deactivated: true });
+  });
+
+  it("returns 404 for an authenticated non-admin", async () => {
+    authAs(recent);
+    const res = await app.request("/api/admin/signins");
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not_found" });
+  });
+
+  it("returns 401 when no session is present", async () => {
+    authAs(null);
+    const res = await app.request("/api/admin/signins");
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
Summary: Add an admin-only /admin/signins page listing every member's
most recent sign-in, newest first, with never-signed-in members in a
trailing section.

Why: Admins had only aggregate sign-in counts (System Metrics) and no
per-member view of who is actually using the app.

Behavior: New GET /api/admin/signins (404 to non-admins) returns
members ordered by auth.users.last_sign_in_at, plus a lastActivityAt
column — GREATEST(last_sign_in_at, max(auth.sessions.refreshed_at)) —
which beats the sign-in timestamp only while a session is live. Rows
carry hidden/deactivated markers and an "active" line when the
activity timestamp is newer. The admin hub links to the page under
Members.

Test Plan:
- ran `npm test` locally (480 functional + 31 e2e, all green)
- tests/functional/server/admin-signins.test.ts covers ordering, ISO
  timestamps, live-session activity fallback, hidden/deactivated
  flags, 404 for non-admins, 401 unauthenticated

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
