### PR TITLE
feat(admin): copyable active-member email list on /admin/members

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-11 | James | Admin sign-in report; copyable member email list
+
+/admin/signins shows each member's last sign-in and live-session activity; /admin/members now ends with a list of active member emails for pasting into Google Calendar.
+
 ## 2026-06-10 | James | Sentry now prod-only; replay only when ?debug-replay=1; tunnel renamed to /error-handling
 
 Sentry is `enabled` only when `VERCEL_ENV=production`. Session replay records only when a session carries `?debug-replay=1` (see docs/doc-sentry.md). Tunnel route moved from `/monitoring` to `/error-handling` to read more honestly in devtools.

--- a/src/app/admin/members/member-emails-panel.tsx
+++ b/src/app/admin/members/member-emails-panel.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api";
+
+const QUERY_KEY = ["admin", "member-emails"] as const;
+const STALE_TIME = 5 * 60 * 1000;
+
+const fetchEmails = async (): Promise<string[]> => {
+  const res = await apiClient.api.admin["member-emails"].$get();
+  if (!res.ok) throw new Error(`admin/member-emails: ${res.status}`);
+  const body = await res.json();
+  return body.emails;
+};
+
+export function MemberEmailsPanel() {
+  const emailsQuery = useQuery({ queryKey: QUERY_KEY, queryFn: fetchEmails, staleTime: STALE_TIME });
+  const [copied, setCopied] = useState(false);
+
+  if (emailsQuery.isPending) {
+    return <p className="text-sm text-muted-foreground">Loading…</p>;
+  }
+  if (emailsQuery.isError) {
+    return (
+      <p role="alert" className="text-sm text-destructive">
+        Couldn't load email addresses.
+      </p>
+    );
+  }
+
+  // Comma+space separation so the whole box pastes cleanly into Google
+  // Calendar's guest field.
+  const list = emailsQuery.data.join(", ");
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(list);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API is available in all supported browsers. If a user
+      // manages to hit this, the addresses are still in the box — they
+      // can select and copy by hand.
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <p className="text-sm text-muted-foreground">
+        All {emailsQuery.data.length} active members — hidden, deactivated, and e2e test accounts are excluded.
+      </p>
+      <textarea
+        readOnly
+        value={list}
+        rows={5}
+        aria-label="Active member email addresses"
+        onFocus={(e) => e.currentTarget.select()}
+        className="w-full rounded border border-border bg-muted/50 p-3 text-xs"
+      />
+      <Button size="sm" className="self-start" onClick={copy}>
+        {copied ? "Copied" : "Copy all"}
+      </Button>
+    </div>
+  );
+}

--- a/src/app/admin/members/page.tsx
+++ b/src/app/admin/members/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { requireUser } from "@/lib/api-server";
 
+import { MemberEmailsPanel } from "./member-emails-panel";
 import { MembersAdminPanel } from "./members-admin-panel";
 
 export default async function AdminMembersPage() {
@@ -19,6 +20,11 @@ export default async function AdminMembersPage() {
         </Link>
       </div>
       <MembersAdminPanel currentUserId={me.profile.id} />
+
+      <section className="flex w-full max-w-xl flex-col gap-2">
+        <h2 className="text-lg font-semibold">Email addresses</h2>
+        <MemberEmailsPanel />
+      </section>
     </main>
   );
 }

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -25,7 +25,7 @@ import {
   revokeInvite,
   validateNote,
 } from "./invites";
-import { listMembersAdmin, setAdminStatus } from "./members-admin";
+import { listActiveMemberEmails, listMembersAdmin, setAdminStatus } from "./members-admin";
 import {
   deactivateProfile,
   getProfileForMember,
@@ -239,6 +239,10 @@ const adminRoutes = new Hono<{ Variables: ApiVariables }>()
   .get("/signins", async (c) => {
     const signins = await listSigninsAdmin();
     return c.json({ signins });
+  })
+  .get("/member-emails", async (c) => {
+    const emails = await listActiveMemberEmails();
+    return c.json({ emails });
   })
   .patch(
     "/members/:id/admin",

--- a/src/server/members-admin.ts
+++ b/src/server/members-admin.ts
@@ -1,8 +1,9 @@
-import { asc, count, eq } from "drizzle-orm";
+import { asc, count, eq, sql } from "drizzle-orm";
 
 import { attachAvatarUrls } from "./avatars";
 import { db } from "./db";
 import { profiles } from "./schema";
+import { E2E_EMAILS } from "./test-reset";
 
 export type AdminMember = {
   id: string;
@@ -30,6 +31,28 @@ export const listMembersAdmin = async (): Promise<AdminMember[]> => {
 
   const withUrls = await attachAvatarUrls(rows);
   return withUrls.map((r) => ({ ...r, createdAt: r.createdAt.toISOString() }));
+};
+
+// Recipient list for the admin members page: every member who should
+// receive mail — hidden profiles, deactivated profiles, and the seeded
+// e2e accounts are excluded. Email lives on auth.users, which schema.ts
+// maps only partially (id + email, for FKs), so the query is raw SQL —
+// same approach as signins-admin.ts.
+export const listActiveMemberEmails = async (): Promise<string[]> => {
+  const e2eList = sql.join(
+    E2E_EMAILS.map((e) => sql`${e}`),
+    sql`, `,
+  );
+  const rows = (await db.execute(sql`
+    SELECT u.email
+    FROM auth.users u
+    JOIN public.profiles p ON p.id = u.id
+    WHERE p.hidden = false
+      AND p.deactivated_at IS NULL
+      AND u.email NOT IN (${e2eList})
+    ORDER BY lower(u.email), u.email
+  `)) as unknown as { email: string }[];
+  return rows.map((r) => r.email);
 };
 
 export const setAdminStatus = async (

--- a/tests/functional/server/admin-member-emails.test.ts
+++ b/tests/functional/server/admin-member-emails.test.ts
@@ -1,0 +1,140 @@
+import { randomUUID } from "node:crypto";
+import type { User } from "@supabase/supabase-js";
+import { eq, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+import { createServerClient } from "@supabase/ssr";
+
+import app from "@/server/api";
+import { db } from "@/server/db";
+import { profiles } from "@/server/schema";
+import { E2E_EMAILS } from "@/server/test-reset";
+
+const mockCreateServerClient = vi.mocked(createServerClient);
+
+const fakeUser = (id: string): User =>
+  ({
+    id,
+    email: `${id}@testfake.local`,
+    user_metadata: {},
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+  }) as User;
+
+const authAs = (userId: string | null) => {
+  mockCreateServerClient.mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? fakeUser(userId) : null },
+        error: null,
+      }),
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test mock shape
+  } as any);
+};
+
+const insertUserAndProfile = async (id: string, opts: { isAdmin?: boolean; email?: string } = {}) => {
+  await db.execute(
+    sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${id}::uuid, ${opts.email ?? `${id}@testfake.local`}, false, false)`,
+  );
+  await db.insert(profiles).values({ id, isAdmin: opts.isAdmin ?? false });
+};
+
+const deleteUserAndProfile = async (id: string) => {
+  await db.delete(profiles).where(eq(profiles.id, id));
+  await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+};
+
+describe("GET /api/admin/member-emails", () => {
+  let admin: string;
+  let active: string;
+  let hiddenMember: string;
+  let deactivated: string;
+  // The seeded e2e account may already exist (dev DBs run the e2e
+  // seed script; fresh CI DBs don't), so create it only when absent
+  // and clean up only what this run created.
+  const E2E_EMAIL = E2E_EMAILS[0];
+  let e2eId: string;
+  let e2eUserCreated = false;
+  let e2eProfileCreated = false;
+
+  beforeEach(async () => {
+    admin = randomUUID();
+    active = randomUUID();
+    hiddenMember = randomUUID();
+    deactivated = randomUUID();
+    await insertUserAndProfile(admin, { isAdmin: true });
+    await insertUserAndProfile(active);
+    await insertUserAndProfile(hiddenMember);
+    await insertUserAndProfile(deactivated);
+    await db.update(profiles).set({ hidden: true }).where(eq(profiles.id, hiddenMember));
+    await db.update(profiles).set({ deactivatedAt: new Date() }).where(eq(profiles.id, deactivated));
+
+    const existing = (await db.execute(sql`SELECT id FROM auth.users WHERE email = ${E2E_EMAIL}`)) as unknown as {
+      id: string;
+    }[];
+    if (existing.length > 0) {
+      e2eId = existing[0].id;
+    } else {
+      e2eId = randomUUID();
+      await db.execute(
+        sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${e2eId}::uuid, ${E2E_EMAIL}, false, false)`,
+      );
+      e2eUserCreated = true;
+    }
+    const existingProfile = await db.select({ id: profiles.id }).from(profiles).where(eq(profiles.id, e2eId));
+    if (existingProfile.length === 0) {
+      await db.insert(profiles).values({ id: e2eId });
+      e2eProfileCreated = true;
+    }
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    await deleteUserAndProfile(admin);
+    await deleteUserAndProfile(active);
+    await deleteUserAndProfile(hiddenMember);
+    await deleteUserAndProfile(deactivated);
+    if (e2eProfileCreated) await db.delete(profiles).where(eq(profiles.id, e2eId));
+    if (e2eUserCreated) await db.execute(sql`DELETE FROM auth.users WHERE id = ${e2eId}::uuid`);
+    e2eUserCreated = false;
+    e2eProfileCreated = false;
+  });
+
+  it("returns active member emails sorted, excluding hidden, deactivated, and e2e accounts", async () => {
+    authAs(admin);
+    const res = await app.request("/api/admin/member-emails");
+    expect(res.status).toBe(200);
+    const { emails } = (await res.json()) as { emails: string[] };
+
+    // Other test files seed users concurrently, so assert on this
+    // test's fixtures only — filtering preserves relative order.
+    const fixtureEmails = [admin, active, hiddenMember, deactivated].map((id) => `${id}@testfake.local`);
+    const mine = emails.filter((e) => fixtureEmails.includes(e));
+    expect(mine).toEqual([`${admin}@testfake.local`, `${active}@testfake.local`].sort());
+
+    expect(emails).not.toContain(`${hiddenMember}@testfake.local`);
+    expect(emails).not.toContain(`${deactivated}@testfake.local`);
+    for (const e2eEmail of E2E_EMAILS) {
+      expect(emails).not.toContain(e2eEmail);
+    }
+  });
+
+  it("returns 404 for an authenticated non-admin", async () => {
+    authAs(active);
+    const res = await app.request("/api/admin/member-emails");
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not_found" });
+  });
+
+  it("returns 401 when no session is present", async () => {
+    authAs(null);
+    const res = await app.request("/api/admin/member-emails");
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
Summary: /admin/members now ends with a read-only, comma+space-separated list of active member email addresses with a Copy button.

Why: Organizers paste the membership into Google Calendar invites and need the address list without collecting it by hand.

Behavior: New GET /api/admin/member-emails (admin-only, 404 for non-admins) returns the emails of members who are neither hidden nor deactivated, excluding the seeded e2e accounts, sorted by email. /admin/members gains an "Email addresses" section: read-only textarea with select-all on focus, a Copy button, and a count line.

Test Plan:
- ran `npm test` locally (483 functional + 31 e2e, all passed)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
