### PR TITLE
fix(logging): flush next-axiom before the Vercel function freezes

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-11 | James | API logs now flush before the Vercel function freezes
+
+next-axiom's buffered push was racing the serverless freeze and losing log events. The API middleware now ends every request with `waitUntil(log.flush())`.
+
 ## 2026-06-11 | James | CSV member importer retired
 
 The final 3 Google Form signups were imported to prod; the importer (`scripts/import-members-csv.ts` and `scripts/normalize-referrals.ts`) is gone. Implementations live in git history.

--- a/docs/doc-axiom.md
+++ b/docs/doc-axiom.md
@@ -9,7 +9,7 @@
 
 Axiom receives logs through two channels:
 
-- **Vercel Log Drain** — all serverless function stdout/stderr is streamed to Axiom automatically via the Vercel marketplace integration. No SDK or API key needed for this.
+- **Vercel Log Drain** — all serverless function stdout/stderr is streamed to Axiom automatically via the Vercel marketplace integration. No SDK or API key needed for this. Shipped platform-side, so it records that a request ran regardless of anything that happened inside the function — the authoritative invocation history.
 - **next-axiom** — the `next-axiom` package wraps `next.config.ts` and provides:
   - `log.info()` / `log.warn()` / `log.error()` / `log.debug()` for structured logging from client and server
   - Automatic Web Vitals reporting
@@ -23,7 +23,10 @@ Two rules keep logs queryable in Axiom:
 
 This is enforced by Biome's `suspicious/noConsole` rule, with per-path `off` overrides in `biome.json` for the legitimate helpers above. To add app telemetry, reach for `log.<level>` — if Biome flags a `console` call, that's the signal.
 
-One caveat: `next-axiom`'s `log` buffers and flushes on a throttle, and Route Handlers drain it as a side effect of the request. A **Server Component has no such wrapper**, so `await log.flush()` after logging there (as `src/app/page.tsx` does) to guarantee the event is sent before the function freezes.
+One caveat: `next-axiom`'s `log` buffers in-process and sends on a 1s throttle. A frozen serverless instance silently loses any unsent batch, and a failed send is dropped by the library, not retried — so events are only delivered reliably where something flushes before the function freezes:
+
+- **API requests** — the Hono logging middleware (`src/server/api.ts`) ends every request with `waitUntil(log.flush())`, which keeps the instance alive until the batch lands without delaying the response.
+- **Server Components** — no middleware runs, so `await log.flush()` after logging (as `src/app/page.tsx` does).
 
 ## Request Logging
 
@@ -66,5 +69,8 @@ The sync emits two message families: `"buttondown sync"` (structured events with
   Distribution of `attempts` across runs. `1` means no contention; `>1` means a retry succeeded. Pair with `skipped-lock-held` count (retries exhausted) to size the budget.
 - **One specific run (all events, by runId):**
   `["vercel"] | where message == "buttondown sync" and ['fields.runId'] == "<runId>"`
+- **Authoritative invocation history (did the cron fire at all):**
+  `["vercel"] | where ['request.path'] == "/api/cron/buttondown-sync" | project _time, ['request.statusCode'] | sort by _time desc`
+  Vercel log-drain records, independent of the in-process flush — present even for a run whose `next-axiom` events never arrived. When a cron run seems missing, this query distinguishes "didn't run" from "didn't log".
 
 Sentry surfaces the page-worthy events: `buttondown.sync_profile_error` (one per failing profile, tagged with `errorKind`), `buttondown.sync_lock_held` (cron overlap), and `buttondown.unsubscribed_member` (member-with-active-program who unsubscribed). Each Sentry issue's `runId` tag links back to the Axiom query above.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.107.0",
         "@tanstack/react-query": "^5.101.0",
+        "@vercel/functions": "^3.6.3",
         "@xyflow/react": "^12.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -5190,16 +5191,145 @@
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "license": "MIT"
     },
-    "node_modules/@vercel/functions": {
-      "version": "2.2.13",
-      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-2.2.13.tgz",
-      "integrity": "sha512-14ArBSIIcOBx9nrEgaJb4Bw+en1gl6eSoJWh8qjifLl5G3E4dRXCFOT8HP+w66vb9Wqyd1lAQBrmRhRwOj9X9A==",
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
+      "integrity": "sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/oidc": "2.0.2"
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-0.1.1.tgz",
+      "integrity": "sha512-LMRMEai3Z+BODyxGcU9+KiWrS/UElNiOLKiNRfGNt2Vu3NTEmXgFeXG9wBfocAnTe5yJCX/DY6k3k7S/LkPp/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@vercel/cli-exec/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.6.3.tgz",
+      "integrity": "sha512-Dg46bG7WapCcVNCT4hrcb+27Ao8iFg0WpFy2KkztyrB5JU5eWx6Rxo0BSnvg5+/VUepM3XItr9GjZw/cffv27A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.6.1"
+      },
+      "engines": {
+        "node": ">= 20"
       },
       "peerDependencies": {
         "@aws-sdk/credential-provider-web-identity": "*"
@@ -5211,16 +5341,26 @@
       }
     },
     "node_modules/@vercel/oidc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-2.0.2.tgz",
-      "integrity": "sha512-59PBFx3T+k5hLTEWa3ggiMpGRz1OVvl9eN8SUai+A43IsqiOuAe7qPBf+cray/Fj6mkgnxm/D7IAtjc8zSHi7g==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.6.1.tgz",
+      "integrity": "sha512-8ipTFoiX3WBRrvXLjSrmgAiwtMDQk3EgSxe8N7v2rXBz39NBIIyoGXeVbJRoBcP8WEuVnvjvIQsggbGU7ZKrMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/ms": "2.1.0",
-        "ms": "2.1.3"
+        "@vercel/cli-config": "0.2.0",
+        "@vercel/cli-exec": "0.1.1",
+        "jose": "^5.9.6"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/oidc/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -9575,6 +9715,39 @@
         "react": ">=18.0.0"
       }
     },
+    "node_modules/next-axiom/node_modules/@vercel/functions": {
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-2.2.13.tgz",
+      "integrity": "sha512-14ArBSIIcOBx9nrEgaJb4Bw+en1gl6eSoJWh8qjifLl5G3E4dRXCFOT8HP+w66vb9Wqyd1lAQBrmRhRwOj9X9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-axiom/node_modules/@vercel/oidc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-2.0.2.tgz",
+      "integrity": "sha512-59PBFx3T+k5hLTEWa3ggiMpGRz1OVvl9eN8SUai+A43IsqiOuAe7qPBf+cray/Fj6mkgnxm/D7IAtjc8zSHi7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/ms": "2.1.0",
+        "ms": "2.1.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -9813,6 +9986,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/outvariant": {
@@ -12788,6 +12970,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.107.0",
     "@tanstack/react-query": "^5.101.0",
+    "@vercel/functions": "^3.6.3",
     "@xyflow/react": "^12.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,4 +1,5 @@
 import type { User } from "@supabase/supabase-js";
+import { waitUntil } from "@vercel/functions";
 import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
@@ -300,6 +301,13 @@ const api = new Hono<{ Variables: ApiVariables }>()
       // requests it never authenticates. See docs/doc-axiom.md.
       userId: (c.get("user") as User | undefined)?.id ?? null,
     });
+    // next-axiom buffers events in-process and sends on a 1s throttle;
+    // a frozen serverless instance silently loses any unsent batch
+    // (whole cron runs went missing from Axiom this way — see
+    // docs/doc-axiom.md). waitUntil keeps the instance alive until the
+    // batch is delivered without delaying the response. Outside Vercel
+    // it no-ops and the long-lived process delivers on the throttle.
+    waitUntil(log.flush());
   })
   .use("*", requireAuth)
   .get("/hello", (c) => {

--- a/src/server/buttondown-sync.ts
+++ b/src/server/buttondown-sync.ts
@@ -149,7 +149,7 @@ export const classifyError = (err: unknown): SyncErrorKind => {
 
 /** Structured event the sync emits to the caller's logger. */
 export type SyncLogEvent =
-  | ({ action: "summary"; runId: string } & Omit<SyncRunSummary, "runId" | "write">)
+  | ({ action: "summary"; runId: string } & Omit<SyncRunSummary, "runId">)
   | { action: "subscriber-created"; runId: string; profileId: string; subscriberId: string | null; dryRun: boolean }
   | {
       action: "tags-updated";
@@ -463,7 +463,7 @@ export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary>
       message: err instanceof Error ? err.message : String(err),
       errorKind: classifyError(err),
     });
-    log({ action: "summary", runId, ...summaryWithoutMeta(summary) });
+    log({ action: "summary", runId, ...summaryWithoutRunId(summary) });
     return summary;
   }
 
@@ -494,12 +494,15 @@ export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary>
   }
 
   summary.durationMs = Date.now() - startedAt;
-  log({ action: "summary", runId, ...summaryWithoutMeta(summary) });
+  log({ action: "summary", runId, ...summaryWithoutRunId(summary) });
   return summary;
 };
 
-const summaryWithoutMeta = (s: SyncRunSummary) => {
-  const { runId: _r, write: _w, ...rest } = s;
+// runId is passed explicitly by the emitter; everything else —
+// including `write`, which doc-axiom's dry-run/write split queries —
+// rides along on the summary event.
+const summaryWithoutRunId = (s: SyncRunSummary) => {
+  const { runId: _r, ...rest } = s;
   return rest;
 };
 


### PR DESCRIPTION
Summary: API requests now flush next-axiom's buffer via waitUntil() before the function freezes, and the Buttondown sync summary event carries `write`.

Why: next-axiom buffers in-process and sends on a 1s throttle; a frozen serverless instance silently loses any unsent batch, and the library drops failed sends rather than retrying. Roughly half the daily Buttondown cron runs left no Axiom events despite demonstrably running — Vercel log-drain records show invocation every day at 08:00 UTC. Separately, the summary event stripped `write`, so doc-axiom's documented dry-run/write query could never return data.

Behavior: The Hono logging middleware ends every request with `waitUntil(log.flush())` (new dependency: `@vercel/functions`) — the platform keeps the instance alive until the batch is delivered, with zero added response latency; outside Vercel it no-ops and the long-lived process delivers as before. Sync summaries now include `fields.write`. `docs/doc-axiom.md` states the delivery rules and adds a drain-side invocation-history query that distinguishes "didn't run" from "didn't log".

Test Plan:
- ran `npm test` locally — 483 functional + 31 e2e, all passing
- reviewer note: post-deploy confirmation is the next daily 08:00 UTC cron summary arriving in Axiom with `fields.write` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
