### PR TITLE
feat(members): hide mid-onboarding members from the directory

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-11 | James | Directory hides members who haven't set up their profile
+
+`listMembers` now requires a non-empty bio — the existing "has set up their profile" marker (the form requires it, CSV signups already have one) — so not-fully-onboarded signups stay out of the Member Directory until they finish the welcome/profile step.
+
 ## 2026-06-11 | James | API logs now flush before the Vercel function freezes
 
 next-axiom's buffered push was racing the serverless freeze and losing log events. The API middleware now ends every request with `waitUntil(log.flush())`.

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -397,11 +397,20 @@ export type MemberSummary = {
   avatarUrl: string | null;
 };
 
+// Invite signups get a profile row + displayName at first sign-in,
+// before the welcome profile step fills in any content — a row with no
+// bio is a member mid-onboarding, not a directory entry. A non-empty
+// bio is the "has set up their profile" marker: the profile form
+// requires it, and welcome/agreements keys on the same signal. Older
+// CSV-imported members carry bios without ever saving in-app, so this
+// gates on content, not on lastUpdatedProfile.
+const hasSetUpProfile = sql`btrim(coalesce(${profiles.bio}, '')) <> ''`;
+
 // includeHidden=true returns hidden profiles too — admins only.
 export const listMembers = async (options: { includeHidden?: boolean } = {}): Promise<MemberSummary[]> => {
   const where = options.includeHidden
     ? isNotNull(profiles.displayName)
-    : and(isNotNull(profiles.displayName), eq(profiles.hidden, false), isNull(profiles.deactivatedAt));
+    : and(isNotNull(profiles.displayName), hasSetUpProfile, eq(profiles.hidden, false), isNull(profiles.deactivatedAt));
   const rows = await db
     .select({
       id: profiles.id,

--- a/tests/functional/server/profiles.test.ts
+++ b/tests/functional/server/profiles.test.ts
@@ -287,7 +287,7 @@ describe("profiles.hidden", () => {
     for (const id of [visibleId, hiddenId]) {
       await db.execute(sql`INSERT INTO auth.users (id, is_sso_user, is_anonymous) VALUES (${id}::uuid, false, false)`);
     }
-    await db.insert(profiles).values({ id: visibleId, displayName: "Visible Vera" });
+    await db.insert(profiles).values({ id: visibleId, displayName: "Visible Vera", bio: "Here to be seen" });
     await db.insert(profiles).values({ id: hiddenId, displayName: "Hidden Henry", hidden: true });
   });
 
@@ -335,5 +335,42 @@ describe("profiles.hidden", () => {
     expect(await setProfileHidden({ profileId: visibleId, hidden: false })).toEqual({ ok: true });
     expect(await getProfileForMember(visibleId)).not.toBeNull();
     expect(await setProfileHidden({ profileId: randomUUID(), hidden: true })).toEqual({ error: "not_found" });
+  });
+});
+
+describe("directory onboarding gate", () => {
+  let pendingId: string;
+
+  beforeEach(async () => {
+    pendingId = randomUUID();
+    await db.execute(
+      sql`INSERT INTO auth.users (id, is_sso_user, is_anonymous) VALUES (${pendingId}::uuid, false, false)`,
+    );
+    // The state an invite signup is in before the welcome profile step:
+    // displayName from auth metadata, no bio yet.
+    await db.insert(profiles).values({ id: pendingId, displayName: "Pending Pete" });
+  });
+
+  afterEach(async () => {
+    await db.delete(profiles).where(eq(profiles.id, pendingId));
+    await db.execute(sql`DELETE FROM auth.users WHERE id = ${pendingId}::uuid`);
+  });
+
+  it("listMembers omits a member who has not set up their profile yet", async () => {
+    const visible = await listMembers();
+    expect(visible.find((m) => m.id === pendingId)).toBeUndefined();
+  });
+
+  it("admins still see mid-onboarding members via includeHidden", async () => {
+    const all = await listMembers({ includeHidden: true });
+    expect(all.find((m) => m.id === pendingId)).toBeDefined();
+  });
+
+  it("a saved bio makes the member visible (whitespace alone does not)", async () => {
+    await db.update(profiles).set({ bio: "   " }).where(eq(profiles.id, pendingId));
+    expect((await listMembers()).find((m) => m.id === pendingId)).toBeUndefined();
+
+    await db.update(profiles).set({ bio: "Hello, I exist now" }).where(eq(profiles.id, pendingId));
+    expect((await listMembers()).find((m) => m.id === pendingId)).toBeDefined();
   });
 });


### PR DESCRIPTION
Summary: The Member Directory omits members who haven't set up their profile yet (no bio).

Why: An invite signup gets a profile row and displayName at first sign-in, so they showed in the directory as an empty shell — name, no bio, no photo — until they finished the welcome profile step.

Behavior: `listMembers` member-facing path now also requires a non-empty bio, the codebase's existing "has set up their profile" marker (the profile form requires it; welcome/agreements keys on it). The gate is on content rather than `lastUpdatedProfile`, deliberately: older CSV-imported members have bios without ever saving in-app and stay visible. Surfaces built on the member list (relating picker, web graph) inherit the gate. Admin `includeHidden` is unchanged — `/admin/members` still shows everyone.

Test Plan:
- new functional tests: no-bio member omitted, whitespace-only bio omitted, visible once bio saved, admin view unaffected
- ran `npm test` locally — 486 functional + 31 e2e, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
