### PR TITLE
feat(ui): onboarding gets an explicit ending; unified top bar (#399)

### DIFF
--- a/docs/design-welcome.md
+++ b/docs/design-welcome.md
@@ -20,8 +20,16 @@ Onboarding is four ordered steps:
 4. **Personal web** — build the relational web on `/myweb`.
 
 Steps 1–3 live under `/welcome`. Step 4 is the existing `/myweb` page; the
-welcome flow simply hands off to it at the end. The `/myweb` joyride tour is
-unchanged and remains gated by its own marker (see below).
+welcome flow hands off to it at the end. The `/myweb` joyride tour remains
+gated by its own marker (see below).
+
+- The first "Done" click on `/myweb` runs a farewell capstone — a one-step
+  tour spotlighting the top bar, lighting the home icon and the menu
+  together (joyride takes one target per step, so `SiteHeader` carries an
+  invisible full-width strip as the spotlight target) — giving onboarding
+  an explicit end. During the `/welcome` steps `SiteHeader` renders
+  nothing at all — no home link, no menu — so the guided sequence stays
+  exit-free.
 
 ## Route structure
 

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-12 | James | Home link + Onboarding gets an explicit ending
+
+A home icon sits top-left on every page, the whole header (home + menu) hides during `/welcome`, profile-save now opens the Settings tab itself, and the first Done on /myweb runs a farewell capstone lighting up the home icon and menu icon together.
+
 ## 2026-06-11 | James | Buttondown cutover complete
 
 `BUTTONDOWN_SYNC_WRITE=1` is live in prod, the Apps Script trigger is disabled, and the Google Form is retired — the app is the sole writer of program tags. (#261, docs/design-buttondown.md)

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-12 | James | Unified top bar
+
+Page titles and breadcrumbs now share one band with the fixed home/menu icons, via a shared `PageHeader` (full-width row, `pt-3` mains).
+
 ## 2026-06-12 | James | Home link + Onboarding gets an explicit ending
 
 A home icon sits top-left on every page, the whole header (home + menu) hides during `/welcome`, profile-save now opens the Settings tab itself, and the first Done on /myweb runs a farewell capstone lighting up the home icon and menu icon together.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 
-import { BreadcrumbLink } from "@/components/breadcrumb-link";
+import { PageHeader } from "@/components/page-header";
 import { requireUser } from "@/lib/api-server";
 import { appVersion, changelog, formatChangelogDate } from "@/lib/changelog";
 
@@ -13,11 +13,8 @@ export default async function AboutPage() {
   await requireUser();
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-8 p-8">
-      <div className="flex w-full max-w-2xl items-center justify-between">
-        <h1 className="text-2xl font-bold">About</h1>
-        <BreadcrumbLink fallback="/" />
-      </div>
+    <main className="flex min-h-screen flex-col items-center gap-8 px-8 pb-8 pt-3">
+      <PageHeader title="About" />
 
       <CollapsibleSection title="System Metrics">
         <SystemMetrics />

--- a/src/app/admin/invites/page.tsx
+++ b/src/app/admin/invites/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { PageHeader } from "@/components/page-header";
 import { requireUser } from "@/lib/api-server";
 
 import { InvitesAdmin } from "./invites-admin";
@@ -11,13 +12,18 @@ export default async function AdminInvitesPage() {
   if (!me.profile?.isAdmin) notFound();
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-xl items-center justify-between">
-        <h1 className="text-2xl font-bold">Invites</h1>
-        <Link href="/admin" className="text-base text-muted-foreground hover:text-foreground">
-          ← Admin
-        </Link>
-      </div>
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+      <PageHeader
+        title="Invites"
+        right={
+          <Link
+            href="/admin"
+            className="shrink-0 whitespace-nowrap text-base text-muted-foreground hover:text-foreground"
+          >
+            ← Admin
+          </Link>
+        }
+      />
       <InvitesAdmin />
     </main>
   );

--- a/src/app/admin/invites/page.tsx
+++ b/src/app/admin/invites/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { PageHeader } from "@/components/page-header";
@@ -13,17 +12,7 @@ export default async function AdminInvitesPage() {
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
-      <PageHeader
-        title="Invites"
-        right={
-          <Link
-            href="/admin"
-            className="shrink-0 whitespace-nowrap text-base text-muted-foreground hover:text-foreground"
-          >
-            ← Admin
-          </Link>
-        }
-      />
+      <PageHeader title="Invites" fallback="/admin" />
       <InvitesAdmin />
     </main>
   );

--- a/src/app/admin/members/page.tsx
+++ b/src/app/admin/members/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { PageHeader } from "@/components/page-header";
@@ -14,17 +13,7 @@ export default async function AdminMembersPage() {
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
-      <PageHeader
-        title="Members"
-        right={
-          <Link
-            href="/admin"
-            className="shrink-0 whitespace-nowrap text-base text-muted-foreground hover:text-foreground"
-          >
-            ← Admin
-          </Link>
-        }
-      />
+      <PageHeader title="Members" fallback="/admin" />
       <MembersAdminPanel currentUserId={me.profile.id} />
 
       <section className="flex w-full max-w-xl flex-col gap-2">

--- a/src/app/admin/members/page.tsx
+++ b/src/app/admin/members/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { PageHeader } from "@/components/page-header";
 import { requireUser } from "@/lib/api-server";
 
 import { MemberEmailsPanel } from "./member-emails-panel";
@@ -12,13 +13,18 @@ export default async function AdminMembersPage() {
   if (!me.profile?.isAdmin) notFound();
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-xl items-center justify-between">
-        <h1 className="text-2xl font-bold">Members</h1>
-        <Link href="/admin" className="text-base text-muted-foreground hover:text-foreground">
-          ← Admin
-        </Link>
-      </div>
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+      <PageHeader
+        title="Members"
+        right={
+          <Link
+            href="/admin"
+            className="shrink-0 whitespace-nowrap text-base text-muted-foreground hover:text-foreground"
+          >
+            ← Admin
+          </Link>
+        }
+      />
       <MembersAdminPanel currentUserId={me.profile.id} />
 
       <section className="flex w-full max-w-xl flex-col gap-2">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { BreadcrumbLink } from "@/components/breadcrumb-link";
+import { PageHeader } from "@/components/page-header";
 import { requireUser, serverApiClient } from "@/lib/api-server";
 
 import { AdminHidden } from "./admin-hidden";
@@ -19,11 +19,8 @@ export default async function AdminPage() {
   const { appSettings } = await res.json();
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-xl items-center justify-between">
-        <h1 className="text-2xl font-bold">Admin</h1>
-        <BreadcrumbLink fallback="/" />
-      </div>
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+      <PageHeader title="Admin" />
 
       <section className="flex w-full max-w-xl flex-col gap-2">
         <h2 className="text-lg font-semibold">App settings</h2>

--- a/src/app/admin/programs/[id]/page.tsx
+++ b/src/app/admin/programs/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { PageHeader } from "@/components/page-header";
 import { requireUser } from "@/lib/api-server";
 
 import { ProgramDetail } from "./program-detail";
@@ -12,13 +13,18 @@ export default async function AdminProgramDetailPage({ params }: { params: Promi
   const { id } = await params;
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-xl items-center justify-between">
-        <h1 className="text-2xl font-bold">Program</h1>
-        <Link href="/admin/programs" className="text-base text-muted-foreground hover:text-foreground">
-          ← Programs
-        </Link>
-      </div>
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+      <PageHeader
+        title="Program"
+        right={
+          <Link
+            href="/admin/programs"
+            className="shrink-0 whitespace-nowrap text-base text-muted-foreground hover:text-foreground"
+          >
+            ← Programs
+          </Link>
+        }
+      />
       <ProgramDetail programId={id} />
     </main>
   );

--- a/src/app/admin/programs/[id]/page.tsx
+++ b/src/app/admin/programs/[id]/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { PageHeader } from "@/components/page-header";
@@ -14,17 +13,7 @@ export default async function AdminProgramDetailPage({ params }: { params: Promi
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
-      <PageHeader
-        title="Program"
-        right={
-          <Link
-            href="/admin/programs"
-            className="shrink-0 whitespace-nowrap text-base text-muted-foreground hover:text-foreground"
-          >
-            ← Programs
-          </Link>
-        }
-      />
+      <PageHeader title="Program" fallback="/admin/programs" />
       <ProgramDetail programId={id} />
     </main>
   );

--- a/src/app/admin/programs/page.tsx
+++ b/src/app/admin/programs/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { PageHeader } from "@/components/page-header";
 import { requireUser } from "@/lib/api-server";
 
 import { ProgramsAdmin } from "./programs-admin";
@@ -11,13 +12,18 @@ export default async function AdminProgramsPage() {
   if (!me.profile?.isAdmin) notFound();
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-xl items-center justify-between">
-        <h1 className="text-2xl font-bold">Programs</h1>
-        <Link href="/admin" className="text-base text-muted-foreground hover:text-foreground">
-          ← Admin
-        </Link>
-      </div>
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+      <PageHeader
+        title="Programs"
+        right={
+          <Link
+            href="/admin"
+            className="shrink-0 whitespace-nowrap text-base text-muted-foreground hover:text-foreground"
+          >
+            ← Admin
+          </Link>
+        }
+      />
       <ProgramsAdmin />
     </main>
   );

--- a/src/app/admin/programs/page.tsx
+++ b/src/app/admin/programs/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { PageHeader } from "@/components/page-header";
@@ -13,17 +12,7 @@ export default async function AdminProgramsPage() {
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
-      <PageHeader
-        title="Programs"
-        right={
-          <Link
-            href="/admin"
-            className="shrink-0 whitespace-nowrap text-base text-muted-foreground hover:text-foreground"
-          >
-            ← Admin
-          </Link>
-        }
-      />
+      <PageHeader title="Programs" fallback="/admin" />
       <ProgramsAdmin />
     </main>
   );

--- a/src/app/admin/signins/page.tsx
+++ b/src/app/admin/signins/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { PageHeader } from "@/components/page-header";
@@ -13,17 +12,7 @@ export default async function AdminSigninsPage() {
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
-      <PageHeader
-        title="Sign-ins"
-        right={
-          <Link
-            href="/admin"
-            className="shrink-0 whitespace-nowrap text-base text-muted-foreground hover:text-foreground"
-          >
-            ← Admin
-          </Link>
-        }
-      />
+      <PageHeader title="Sign-ins" fallback="/admin" />
       <SigninsAdminPanel />
     </main>
   );

--- a/src/app/admin/signins/page.tsx
+++ b/src/app/admin/signins/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { PageHeader } from "@/components/page-header";
 import { requireUser } from "@/lib/api-server";
 
 import { SigninsAdminPanel } from "./signins-admin-panel";
@@ -11,13 +12,18 @@ export default async function AdminSigninsPage() {
   if (!me.profile?.isAdmin) notFound();
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-xl items-center justify-between">
-        <h1 className="text-2xl font-bold">Sign-ins</h1>
-        <Link href="/admin" className="text-base text-muted-foreground hover:text-foreground">
-          ← Admin
-        </Link>
-      </div>
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+      <PageHeader
+        title="Sign-ins"
+        right={
+          <Link
+            href="/admin"
+            className="shrink-0 whitespace-nowrap text-base text-muted-foreground hover:text-foreground"
+          >
+            ← Admin
+          </Link>
+        }
+      />
       <SigninsAdminPanel />
     </main>
   );

--- a/src/app/intentions/page.tsx
+++ b/src/app/intentions/page.tsx
@@ -1,5 +1,5 @@
-import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { HelpHint } from "@/components/help-hint";
+import { PageHeader } from "@/components/page-header";
 import { requireUser, serverApiClient } from "@/lib/api-server";
 import type { Intention } from "@/lib/api-types";
 
@@ -13,22 +13,24 @@ export default async function IntentionsPage() {
   const { intentions }: { intentions: Intention[] } = await res.json();
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-2xl items-center justify-between">
-        <div>
-          <div className="flex items-center gap-2">
-            <h1 className="text-2xl font-bold">Current intentions</h1>
-            <HelpHint label="About current intentions">
-              Freshest intentions sit in the centre. Hover or tap to read one in full; click to open a member.
-            </HelpHint>
-          </div>
-          <p className="text-sm text-muted-foreground">What the network is working toward right now.</p>
-          <p className="mt-1 max-w-md text-xs text-muted-foreground">
-            NOTE: This page is a first draft, and we&apos;re still figuring out how to visualize and browse for
-            serendipity — feedback welcome!
-          </p>
-        </div>
-        <BreadcrumbLink fallback="/" />
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+      <PageHeader
+        title="Current intentions"
+        hint={
+          <HelpHint label="About current intentions">
+            Freshest intentions sit in the centre. Hover or tap to read one in full; click to open a member.
+          </HelpHint>
+        }
+      />
+
+      {/* Intro sits in the visualization's column (max-w-2xl, like the
+       * cloud below), so the header row stays a slim title bar. */}
+      <div className="w-full max-w-2xl">
+        <p className="text-sm text-muted-foreground">What the network is working toward right now.</p>
+        <p className="mt-1 max-w-md text-xs text-muted-foreground">
+          NOTE: This page is a first draft, and we&apos;re still figuring out how to visualize and browse for
+          serendipity — feedback welcome!
+        </p>
       </div>
 
       <IntentionsCloud intentions={intentions} />

--- a/src/app/invites/page.tsx
+++ b/src/app/invites/page.tsx
@@ -1,4 +1,4 @@
-import { BreadcrumbLink } from "@/components/breadcrumb-link";
+import { PageHeader } from "@/components/page-header";
 import { requireUser } from "@/lib/api-server";
 
 import { InvitesPanel } from "./invites-panel";
@@ -7,11 +7,8 @@ export default async function InvitesPage() {
   const me = await requireUser();
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-xl items-center justify-between">
-        <h1 className="text-2xl font-bold">Invites</h1>
-        <BreadcrumbLink fallback="/" />
-      </div>
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+      <PageHeader title="Invites" />
       <InvitesPanel me={me} />
     </main>
   );

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,4 +1,4 @@
-import { BreadcrumbLink } from "@/components/breadcrumb-link";
+import { PageHeader } from "@/components/page-header";
 import { requireUser } from "@/lib/api-server";
 import type { Me } from "@/lib/api-types";
 
@@ -16,11 +16,8 @@ export default async function MePage() {
   if (!me.profile) throw new Error("authenticated user has no profile");
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-md items-center justify-between">
-        <h1 className="text-2xl font-bold">My page</h1>
-        <BreadcrumbLink fallback="/" />
-      </div>
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+      <PageHeader title="My page" />
 
       {me.profile.hidden && (
         <p role="alert" className="w-full max-w-md rounded-md border border-border bg-muted px-4 py-3 text-sm">

--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { Avatar } from "@/components/avatar";
-import { BreadcrumbLink } from "@/components/breadcrumb-link";
+import { PageHeader } from "@/components/page-header";
 import { QueryProvider } from "@/components/query-provider";
 import { requireUser, serverApiClient } from "@/lib/api-server";
 import type { MemberProfile } from "@/lib/api-types";
@@ -27,11 +27,8 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
 
   if (res.status === 404) {
     return (
-      <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-        <div className="flex w-full max-w-md items-center justify-between">
-          <h1 className="text-2xl font-bold">Member not found</h1>
-          <BreadcrumbLink fallback="/members" />
-        </div>
+      <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+        <PageHeader title="Member not found" fallback="/members" />
         <p className="text-muted-foreground">We couldn&apos;t find a member with that name or ID.</p>
       </main>
     );
@@ -43,14 +40,12 @@ export default async function MemberProfilePage({ params }: { params: Promise<{ 
 
   return (
     <QueryProvider>
-      <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-        <div className="flex w-full max-w-md items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold">{profile.displayName ?? "Member"}</h1>
-            <p className="text-sm text-muted-foreground">Member since {memberSince}</p>
-          </div>
-          <BreadcrumbLink fallback="/members" />
-        </div>
+      <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+        <PageHeader
+          title={profile.displayName ?? "Member"}
+          subtitle={<p className="text-sm text-muted-foreground">Member since {memberSince}</p>}
+          fallback="/members"
+        />
 
         {isOwnProfile ? (
           // Square, the same footprint as the mini-map on others' profiles.

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,4 +1,4 @@
-import { BreadcrumbLink } from "@/components/breadcrumb-link";
+import { PageHeader } from "@/components/page-header";
 import { requireUser, serverApiClient } from "@/lib/api-server";
 import type { MemberSummary } from "@/lib/api-types";
 
@@ -12,11 +12,8 @@ export default async function MembersPage() {
   const { members }: { members: MemberSummary[] } = await res.json();
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-5xl items-center justify-between">
-        <h1 className="text-2xl font-bold">Member directory</h1>
-        <BreadcrumbLink fallback="/" />
-      </div>
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+      <PageHeader title="Member directory" />
 
       <MembersList members={members} />
     </main>

--- a/src/app/myweb/farewell-tour.tsx
+++ b/src/app/myweb/farewell-tour.tsx
@@ -8,29 +8,34 @@ import type { Controls, EventData, Step } from "react-joyride";
 // it client-only. Joyride is a named export, so wrap it into a default.
 const Joyride = dynamic(() => import("react-joyride").then((m) => ({ default: m.Joyride })), { ssr: false });
 
-// The title doubles as the save confirmation: the tour only fires on a
-// successful save, and its overlay+scroll hides the form's own status
-// line, so this is the feedback the member actually reads. The save
-// also opens the Settings tab, so the step spotlights the panel itself
-// rather than asking the member to find the tab (#399).
+// The capstone after a first-time member clicks Done — the explicit
+// "onboarding is over" moment (#399). It spotlights the whole top bar
+// so the home icon and the menu light up together; the way onward
+// doubles as the lesson.
 const STEPS: Step[] = [
   {
-    target: "[data-tour='settings-panel']",
-    title: "Profile saved!",
-    placement: "top",
-    content:
-      "One more thing — we've opened the Settings tab for you. Your (optional) password, emergency contact info, and other settings live here. Take a look before you continue.",
+    target: "[data-tour='top-bar']",
+    title: "You're all set!",
+    placement: "bottom",
+    content: (
+      <>
+        That&apos;s the whole tour — your web is saved, and you can hit &quot;Edit&quot; to add more relationships.
+        <br />
+        <br />
+        Up top: the house (left) takes you home, and the menu (right) opens everything else. Welcome to the IS Web App!
+      </>
+    ),
   },
 ];
 
-// One step, so the only endings are user-driven: "Got it" (last) or
+// One step, so the only endings are user-driven: "Thanks!" (last) or
 // close. The primary-button completion arrives with action "update"
 // (joyride's internal finish transition), so it's detected via
 // status === "finished" — which only completion produces; run=false
 // teardowns pause without a tour:end. Skip/close keep the action-verb
 // filter from WelcomeTour, since status "skipped" also fires on passive
 // teardowns (HMR, navigation) and must not count as a dismissal.
-export function WelcomeSettingsTour({ run, onClose }: { run: boolean; onClose: () => void }) {
+export function FarewellTour({ run, onClose }: { run: boolean; onClose: () => void }) {
   const handleEvent = (data: EventData, _controls: Controls) => {
     if (data.type === "tour:end" && (data.status === "finished" || data.action === "skip" || data.action === "close")) {
       onClose();
@@ -43,12 +48,12 @@ export function WelcomeSettingsTour({ run, onClose }: { run: boolean; onClose: (
       run={run}
       onEvent={handleEvent}
       continuous
-      locale={{ last: "Got it" }}
+      locale={{ last: "Thanks!" }}
       options={{
         // The tooltip should appear immediately, not as a pulse beacon.
         skipBeacon: true,
         buttons: ["primary"],
-        // Dismissal is an intentional act (the Got it button), not an
+        // Dismissal is an intentional act (the Thanks! button), not an
         // errant background click.
         overlayClickAction: false,
         // Project teal, matches the rest of the palette closely enough.

--- a/src/app/myweb/my-web.tsx
+++ b/src/app/myweb/my-web.tsx
@@ -3,11 +3,10 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
 
-import { BreadcrumbLink } from "@/components/breadcrumb-link";
+import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api";
 import type { RelationCandidatesFeed } from "@/lib/api-types";
-import { cn } from "@/lib/utils";
 
 import { FarewellTour } from "./farewell-tour";
 import { FlyCard } from "./fly-card";
@@ -167,15 +166,12 @@ export function MyWeb({ initialLastUpdatedWeb }: { initialLastUpdatedWeb: Date |
 
   return (
     <div className="flex w-full flex-col items-center gap-6">
-      {/* The title row lives here rather than page.tsx so the farewell
+      {/* The header lives here rather than page.tsx so the farewell
        * capstone can hide it: "My web" and the breadcrumb sit inside the
        * spotlit top strip and would compete with the icons being
        * introduced. visibility (not display) keeps the layout stable
        * under the tooltip. */}
-      <div className={cn("flex w-full max-w-5xl items-center justify-between", farewellRun && "invisible")}>
-        <h1 className="text-2xl font-bold">My web</h1>
-        <BreadcrumbLink fallback="/" />
-      </div>
+      <PageHeader title="My web" className={farewellRun ? "invisible" : undefined} />
       {/* Below 600px the graph breaks out of the page's horizontal padding to
        * go edge-to-edge; the title/breadcrumb (above) and the Edit/Done row +
        * feed (below) keep their padding. The negative margin equals -(50vw -

--- a/src/app/myweb/my-web.tsx
+++ b/src/app/myweb/my-web.tsx
@@ -3,10 +3,13 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
 
+import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api";
 import type { RelationCandidatesFeed } from "@/lib/api-types";
+import { cn } from "@/lib/utils";
 
+import { FarewellTour } from "./farewell-tour";
 import { FlyCard } from "./fly-card";
 import { RELATION_CANDIDATES_QUERY_KEY, RELATION_SUBGRAPH_QUERY_KEY } from "./query-keys";
 import { RelatingDialog, type RelatingTarget } from "./relating-dialog";
@@ -67,12 +70,25 @@ export function MyWeb({ initialLastUpdatedWeb }: { initialLastUpdatedWeb: Date |
   // Bumped after a successful relation so the tour advances past the
   // "click anyone here" step automatically.
   const [tourAdvanceToken, setTourAdvanceToken] = useState(0);
+  // The first Done click of a first-time visit earns a farewell capstone
+  // — the explicit "onboarding is over" moment (#399). Eligibility is
+  // decided at mount alongside the tour, so dismissing the tour mid-way
+  // (which writes the session flag) doesn't cancel the goodbye.
+  const [farewellEligible, setFarewellEligible] = useState(false);
+  const [farewellRun, setFarewellRun] = useState(false);
   useEffect(() => {
     if (initialLastUpdatedWeb !== null) return;
     if (window.sessionStorage.getItem(TOUR_DISMISSED_KEY) === "1") return;
     setTourRun(true);
+    setFarewellEligible(true);
   }, [initialLastUpdatedWeb]);
-  const markDone = useMarkDone(() => setMode("view"));
+  const markDone = useMarkDone(() => {
+    setMode("view");
+    if (farewellEligible) {
+      setFarewellEligible(false);
+      setFarewellRun(true);
+    }
+  });
 
   const queryClient = useQueryClient();
   // The suggestion card currently flying into the graph (null when idle).
@@ -151,8 +167,17 @@ export function MyWeb({ initialLastUpdatedWeb }: { initialLastUpdatedWeb: Date |
 
   return (
     <div className="flex w-full flex-col items-center gap-6">
+      {/* The title row lives here rather than page.tsx so the farewell
+       * capstone can hide it: "My web" and the breadcrumb sit inside the
+       * spotlit top strip and would compete with the icons being
+       * introduced. visibility (not display) keeps the layout stable
+       * under the tooltip. */}
+      <div className={cn("flex w-full max-w-5xl items-center justify-between", farewellRun && "invisible")}>
+        <h1 className="text-2xl font-bold">My web</h1>
+        <BreadcrumbLink fallback="/" />
+      </div>
       {/* Below 600px the graph breaks out of the page's horizontal padding to
-       * go edge-to-edge; the title/breadcrumb (page) and the Edit/Done row +
+       * go edge-to-edge; the title/breadcrumb (above) and the Edit/Done row +
        * feed (below) keep their padding. The negative margin equals -(50vw -
        * half the container), the canonical full-bleed within a padded parent. */}
       <div className="w-full max-[600px]:mx-[calc(50%_-_50vw)] max-[600px]:w-screen">
@@ -203,6 +228,7 @@ export function MyWeb({ initialLastUpdatedWeb }: { initialLastUpdatedWeb: Date |
         />
       )}
       <WelcomeTour key={tourKey} run={tourRun} advanceToken={tourAdvanceToken} onClose={dismissTour} />
+      <FarewellTour run={farewellRun} onClose={() => setFarewellRun(false)} />
     </div>
   );
 }

--- a/src/app/myweb/page.tsx
+++ b/src/app/myweb/page.tsx
@@ -32,7 +32,7 @@ export default async function MyWebPage() {
   });
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
       <HydrationBoundary state={dehydrate(queryClient)}>
         <MyWeb initialLastUpdatedWeb={initialLastUpdatedWeb} />
       </HydrationBoundary>

--- a/src/app/myweb/page.tsx
+++ b/src/app/myweb/page.tsx
@@ -1,6 +1,5 @@
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 
-import { BreadcrumbLink } from "@/components/breadcrumb-link";
 import { requireUser, serverApiClient } from "@/lib/api-server";
 
 import { MyWeb } from "./my-web";
@@ -34,10 +33,6 @@ export default async function MyWebPage() {
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-5xl items-center justify-between">
-        <h1 className="text-2xl font-bold">My web</h1>
-        <BreadcrumbLink fallback="/" />
-      </div>
       <HydrationBoundary state={dehydrate(queryClient)}>
         <MyWeb initialLastUpdatedWeb={initialLastUpdatedWeb} />
       </HydrationBoundary>

--- a/src/app/programs/[slug]/page.tsx
+++ b/src/app/programs/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { BreadcrumbLink } from "@/components/breadcrumb-link";
+import { PageHeader } from "@/components/page-header";
 import { requireUser } from "@/lib/api-server";
 
 import { ProgramSlugDetail } from "./program-slug-detail";
@@ -8,11 +8,8 @@ export default async function ProgramDetailPage({ params }: { params: Promise<{ 
   const { slug } = await params;
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-3xl items-center justify-between">
-        <h1 className="text-2xl font-bold">Program</h1>
-        <BreadcrumbLink fallback="/programs" />
-      </div>
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+      <PageHeader title="Program" fallback="/programs" />
       <ProgramSlugDetail slug={slug} />
     </main>
   );

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -1,4 +1,4 @@
-import { BreadcrumbLink } from "@/components/breadcrumb-link";
+import { PageHeader } from "@/components/page-header";
 import { requireUser } from "@/lib/api-server";
 
 import { ProgramsList } from "./programs-list";
@@ -7,11 +7,8 @@ export default async function ProgramsPage() {
   await requireUser();
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 p-8">
-      <div className="flex w-full max-w-5xl items-center justify-between">
-        <h1 className="text-2xl font-bold">Programs</h1>
-        <BreadcrumbLink fallback="/" />
-      </div>
+    <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
+      <PageHeader title="Programs" />
       <p className="w-full max-w-5xl text-base text-muted-foreground">
         Browse programs and join the ones that interest you.
       </p>

--- a/src/app/welcome/profile/welcome-tabs.tsx
+++ b/src/app/welcome/profile/welcome-tabs.tsx
@@ -16,30 +16,31 @@ import { WelcomeSettingsTour } from "./welcome-settings-tour";
 type TabId = "profile" | "settings";
 
 // The welcome profile step wears the same tabs as /me, so members meet
-// the page shape they'll use from then on. Saving the profile reveals
-// a one-step tour pointing at Settings plus the Continue button that
-// advances the flow — tabs only swap panels here (no URL change), so
-// they're buttons, not anchors.
+// the page shape they'll use from then on. Saving the profile opens the
+// Settings tab itself — members told "your settings live here" weren't
+// finding the tab (#399) — and fires a one-step tour over the revealed
+// panel, plus the Continue button that advances the flow. Tabs only
+// swap panels here (no URL change), so they're buttons, not anchors.
 export function WelcomeTabs({ profile }: { profile: Me["profile"] }) {
   const router = useRouter();
   const [tab, setTab] = useState<TabId>("profile");
   const [saved, setSaved] = useState(false);
   const [tourDismissed, setTourDismissed] = useState(false);
 
-  const openSettings = () => {
-    setTab("settings");
-    // Clicking the spotlighted tab is the tour's point made — don't
-    // leave the tooltip hanging over the settings panel.
+  // A manual tab switch while the tour is up means the member is already
+  // navigating — don't leave the tooltip hanging over the wrong panel.
+  const switchTab = (id: TabId) => {
+    setTab(id);
     setTourDismissed(true);
   };
 
   return (
     <>
       <TabBar ariaLabel="Profile and settings">
-        <Tab active={tab === "profile"} onClick={() => setTab("profile")}>
+        <Tab active={tab === "profile"} onClick={() => switchTab("profile")}>
           Profile
         </Tab>
-        <Tab active={tab === "settings"} onClick={openSettings} data-tour="settings-tab">
+        <Tab active={tab === "settings"} onClick={() => switchTab("settings")}>
           Settings
         </Tab>
       </TabBar>
@@ -58,12 +59,16 @@ export function WelcomeTabs({ profile }: { profile: Me["profile"] }) {
             supplementaryInfo: profile?.supplementaryInfo ?? "",
             currentIntention: profile?.currentIntention ?? "",
           }}
-          onSaved={() => setSaved(true)}
+          onSaved={() => {
+            setSaved(true);
+            setTab("settings");
+          }}
         />
       </section>
 
       <section
         aria-label="Settings"
+        data-tour="settings-panel"
         className={cn("w-full max-w-md flex-col gap-6", tab === "settings" ? "flex" : "hidden")}
       >
         <SettingsSections

--- a/src/components/breadcrumb-link.tsx
+++ b/src/components/breadcrumb-link.tsx
@@ -12,7 +12,9 @@ type Props = {
   className?: string;
 };
 
-const DEFAULT_CLASSES = "text-base text-muted-foreground hover:text-foreground";
+// shrink-0 + nowrap: the link sits in tight justify-between title rows
+// and must not wrap "← Label" onto two lines when the title is long.
+const DEFAULT_CLASSES = "shrink-0 whitespace-nowrap text-base text-muted-foreground hover:text-foreground";
 
 // History-aware breadcrumb link. On first render (and on the server)
 // it shows the per-page fallback so SSR and hydration agree; a client

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+
+import { BreadcrumbLink } from "@/components/breadcrumb-link";
+import { cn } from "@/lib/utils";
+
+// The unified top row: the page title shares one horizontal band with
+// the fixed home icon (left) and menu (right), with the breadcrumb at
+// the right edge beside the menu. Pages render this as the first child
+// of a `main` with `pt-3`, which lands the title's text line level
+// with the icon glyphs (icon boxes are p-3 + size-8 → y 12-44). The
+// row's px-6, on top of the main's px-8, keeps both ends clear of the
+// fixed corner icons (their boxes end 44px from the viewport edge).
+export function PageHeader({
+  title,
+  hint,
+  subtitle,
+  right,
+  fallback = "/",
+  className,
+}: {
+  title: string;
+  /** Rendered beside the h1 (e.g. a HelpHint). */
+  hint?: ReactNode;
+  /** Hangs under the h1 inside the band (e.g. "Member since 2026"). */
+  subtitle?: ReactNode;
+  /** Replaces the default breadcrumb (e.g. the admin "← Admin" link). */
+  right?: ReactNode;
+  /** Breadcrumb fallback route when no nav history exists. */
+  fallback?: string;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex w-full items-baseline justify-between px-6", className)}>
+      <div>
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-bold">{title}</h1>
+          {hint}
+        </div>
+        {subtitle}
+      </div>
+      {right ?? <BreadcrumbLink fallback={fallback} />}
+    </div>
+  );
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Menu, ShieldCheck } from "lucide-react";
+import { House, Menu, ShieldCheck } from "lucide-react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 import { useAuth } from "@/components/auth-provider";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { clearNavHistory } from "@/lib/route-labels";
 import { cn } from "@/lib/utils";
@@ -33,13 +34,29 @@ function MenuLink({
   );
 }
 
-export function SiteHeader({ displayName, isAdmin }: { displayName: string | null; isAdmin: boolean }) {
-  const { user } = useAuth();
-
-  if (!user) return null;
-
+// The top-left corner: a home link styled as an icon button. Plain
+// anchor + buttonVariants rather than <Button render>: Base UI stamps
+// role="button" on rendered anchors, and this one should announce as
+// the link it is.
+function HomeLink() {
   return (
-    <header className="fixed top-0 right-0 z-40 p-3">
+    <div className="fixed top-0 left-0 z-40 p-3" data-tour="home-icon">
+      <Link
+        href="/"
+        aria-label="Home"
+        onClick={clearNavHistory}
+        className={buttonVariants({ variant: "ghost", size: "icon" })}
+      >
+        <House />
+      </Link>
+    </div>
+  );
+}
+
+// The top-right corner: the hamburger trigger and the nav sheet it opens.
+function MenuSheet({ displayName, isAdmin }: { displayName: string | null; isAdmin: boolean }) {
+  return (
+    <div className="fixed top-0 right-0 z-40 p-3">
       <Sheet>
         <SheetTrigger render={<Button variant="ghost" size="icon" aria-label="Open menu" />}>
           <Menu />
@@ -84,6 +101,27 @@ export function SiteHeader({ displayName, isAdmin }: { displayName: string | nul
           </nav>
         </SheetContent>
       </Sheet>
+    </div>
+  );
+}
+
+export function SiteHeader({ displayName, isAdmin }: { displayName: string | null; isAdmin: boolean }) {
+  const { user } = useAuth();
+  const pathname = usePathname();
+
+  if (!user) return null;
+  // The /welcome steps stay free of exits — no home link, no menu — so
+  // members finish the sequence (#399).
+  if (pathname.startsWith("/welcome")) return null;
+
+  return (
+    <header>
+      {/* Invisible spotlight target for the /myweb farewell tour: one
+       * strip covering the home icon and the menu (joyride steps take a
+       * single target), sized to the icons' box (size-8 + p-3). */}
+      <div aria-hidden className="pointer-events-none fixed inset-x-0 top-0 h-14" data-tour="top-bar" />
+      <HomeLink />
+      <MenuSheet displayName={displayName} isAdmin={isAdmin} />
     </header>
   );
 }

--- a/src/lib/changelog.tsx
+++ b/src/lib/changelog.tsx
@@ -37,6 +37,11 @@ export type ChangelogEntry = {
 // ordering; a functional test asserts it stays sorted.
 export const changelog: ChangelogEntry[] = [
   {
+    date: "2026-06-12",
+    title: "Home button",
+    description: "There's no place like home... (house icon at the top-left)",
+  },
+  {
     date: "2026-06-09",
     title: "Dark mode",
     description: "Pick light, dark, or match-your-system — the setting sticks on each device.",

--- a/src/lib/route-labels.ts
+++ b/src/lib/route-labels.ts
@@ -34,6 +34,9 @@ const EXACT_LABELS: Record<string, string> = {
   "/about": "About",
   "/admin": "Admin",
   "/admin/programs": "Admin programs",
+  "/admin/invites": "Admin invites",
+  "/admin/signins": "Admin sign-ins",
+  "/admin/members": "Admin members",
 };
 const PREFIX_LABELS: Record<string, string> = {
   "/admin/programs/": "Admin programs",

--- a/tests/e2e/myweb.spec.ts
+++ b/tests/e2e/myweb.spec.ts
@@ -65,4 +65,28 @@ test.describe("/myweb — first-time welcome tour", () => {
     await page.getByRole("button", { name: /^Dismiss tour$/ }).click();
     await expect(page.getByText("Mapping your relational web")).toBeHidden();
   });
+
+  test("first Done shows the farewell capstone over the home icon, then stays on /myweb", async ({ page }) => {
+    await signInAs(page, "regular");
+    // Distinct bio per completeWelcome caller — see the #149 probe.
+    await completeWelcome(page, { bio: "e2e bio · myweb.spec · farewell" });
+    await page.getByRole("link", { name: "My web" }).click();
+    await page.waitForURL((u) => u.pathname === "/myweb", { timeout: TIMEOUT_MS });
+
+    // Farewell eligibility is decided at mount, so dismissing the
+    // welcome tour mid-way still earns the goodbye.
+    await expect(page.getByText("Mapping your relational web")).toBeVisible({ timeout: 5_000 });
+    await page.getByRole("button", { name: /^Dismiss tour$/ }).click();
+    await page.getByRole("button", { name: "Done", exact: true }).click();
+
+    await expect(page.getByText("You're all set!")).toBeVisible();
+    // The title row hides while the capstone spotlights the top strip —
+    // "My web" and the breadcrumb sit inside it and would compete with
+    // the icons — and returns on dismissal.
+    await expect(page.getByRole("heading", { name: "My web" })).toBeHidden();
+    await page.getByRole("button", { name: "Thanks!" }).click();
+    await expect(page.getByText("You're all set!")).toBeHidden();
+    await expect(page.getByRole("heading", { name: "My web" })).toBeVisible();
+    expect(new URL(page.url()).pathname).toBe("/myweb");
+  });
 });

--- a/tests/e2e/signout.spec.ts
+++ b/tests/e2e/signout.spec.ts
@@ -1,9 +1,15 @@
 import { expect, test } from "@playwright/test";
 
-import { signInAs, TIMEOUT_MS } from "./helpers/session";
+import { completeWelcome, signInAs, TIMEOUT_MS } from "./helpers/session";
 
 test("sign-out button signs the user out and lands on /signin", async ({ page }) => {
   await signInAs(page, "regular");
+  // A mid-onboarding member is redirected to /welcome, which renders no
+  // menu; finish onboarding (if fresh) so the menu is reachable from /.
+  // Distinct bio per completeWelcome caller — see the #149 probe.
+  if (new URL(page.url()).pathname.startsWith("/welcome")) {
+    await completeWelcome(page, { bio: "e2e bio · signout.spec" });
+  }
 
   await page.goto("/");
   await page.getByRole("button", { name: "Open menu" }).click();

--- a/tests/e2e/welcome.spec.ts
+++ b/tests/e2e/welcome.spec.ts
@@ -56,29 +56,34 @@ test("fresh user completes the welcome flow end to end", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Welcome" })).toBeVisible();
   await page.getByRole("button", { name: "I agree" }).click();
 
-  // Step 2 — profile.
+  // Step 2 — profile. The /welcome steps render no header chrome (home
+  // icon, menu) — the guided sequence keeps members moving forward (#399).
   await page.waitForURL((u) => u.pathname === "/welcome/profile", { timeout: TIMEOUT_MS });
+  await expect(page.locator("[data-tour='home-icon']")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Open menu" })).toHaveCount(0);
   await page.getByLabel("Display name").fill("Welcome Tester");
   await page.getByLabel("Bio").fill("Loves writing, hikes, long coffees.");
   await page.getByLabel("Keywords (comma-separated)").fill("writing, coffee, hiking");
   await page.getByLabel("Location").fill("Lisbon");
   await page.getByRole("button", { name: "Save" }).click();
 
-  // Saving reveals the one-step settings tour (its title doubles as the
-  // save confirmation); the spotlighted Settings tab holds the welcome
-  // variant of the /me settings (no deactivate).
+  // Saving auto-opens the Settings tab (#399) and fires the one-step
+  // settings tour over the panel (its title doubles as the save
+  // confirmation); the panel holds the welcome variant of the /me
+  // settings (no deactivate).
   await expect(page.getByText("Profile saved!")).toBeVisible();
-  await page.getByRole("button", { name: "Got it" }).click();
-  await page.getByRole("tab", { name: "Settings" }).click();
   await expect(page.getByRole("heading", { name: "Theme" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Deactivate account" })).toBeHidden();
+  await page.getByRole("button", { name: "Got it" }).click();
   await page.getByRole("button", { name: "Continue" }).click();
 
   // Step 3 — programs.
   await page.waitForURL((u) => u.pathname === "/welcome/programs", { timeout: TIMEOUT_MS });
   await page.getByRole("button", { name: "Done", exact: true }).click();
 
-  // Onboarding complete — the flow hands off to /myweb.
+  // Onboarding complete — the flow hands off to /myweb, where the home
+  // icon is back.
   await page.waitForURL((u) => u.pathname === "/myweb", { timeout: TIMEOUT_MS });
   await expect(page.getByRole("heading", { name: "My web" })).toBeVisible();
+  await expect(page.locator("[data-tour='home-icon']")).toBeVisible();
 });

--- a/tests/functional/client/site-header.test.tsx
+++ b/tests/functional/client/site-header.test.tsx
@@ -1,8 +1,16 @@
 import type { User } from "@supabase/supabase-js";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SiteHeader } from "@/components/site-header";
+
+// jsdom renders outside a Next router, where usePathname() is null;
+// SiteHeader branches on it (all header chrome hidden during /welcome).
+let mockPathname = "/";
+vi.mock("next/navigation", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("next/navigation")>()),
+  usePathname: () => mockPathname,
+}));
 
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
@@ -19,6 +27,33 @@ import { AuthProvider } from "@/components/auth-provider";
 const user = { id: "u1", email: "a@b.c" } as unknown as User;
 
 describe("SiteHeader", () => {
+  beforeEach(() => {
+    mockPathname = "/";
+  });
+
+  it("shows the home icon and menu outside /welcome", () => {
+    mockPathname = "/members";
+    render(
+      <AuthProvider initialUser={user}>
+        <SiteHeader displayName={null} isAdmin={false} />
+      </AuthProvider>,
+    );
+    const home = screen.getByRole("link", { name: "Home" });
+    expect(home).toBeVisible();
+    expect(home).toHaveAttribute("href", "/");
+    expect(screen.getByRole("button", { name: /open menu/i })).toBeVisible();
+  });
+
+  it("renders nothing during the welcome flow", () => {
+    mockPathname = "/welcome/profile";
+    const { container } = render(
+      <AuthProvider initialUser={user}>
+        <SiteHeader displayName={null} isAdmin={false} />
+      </AuthProvider>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it("renders nothing when there is no user", () => {
     const { container } = render(
       <AuthProvider initialUser={null}>

--- a/tests/functional/server/api-me.test.ts
+++ b/tests/functional/server/api-me.test.ts
@@ -38,8 +38,11 @@ const mockCaptureException = vi.mocked(Sentry.captureException);
 
 // Unique per run: upsertProfile derives the profile slug via toSlug,
 // which hits a global unique constraint, and parallel test files share
-// one DB — a fixed "Test User" collides with profiles.test.ts.
-const TEST_DISPLAY_NAME = `Test User ${randomUUID().slice(0, 8)}`;
+// one DB — a fixed "Test User" collides with profiles.test.ts. The
+// trailing letter keeps the slug from ending in digits: nextSlug
+// increments a trailing number ("…-639" → "…-640") instead of
+// appending the -2/-3 the permutation tests assert.
+const TEST_DISPLAY_NAME = `Test User ${randomUUID().slice(0, 8)}z`;
 
 const makeUser = (id: string, email: string): User =>
   ({

--- a/tests/functional/server/profiles.test.ts
+++ b/tests/functional/server/profiles.test.ts
@@ -19,8 +19,11 @@ import { profiles } from "@/server/schema";
 
 // Unique per run: toSlug(displayName) feeds the global profiles slug
 // unique constraint, and parallel test files share one DB — a fixed
-// "Test User" collides with api-me.test.ts on the derived slug.
-const TEST_DISPLAY_NAME = `Test User ${randomUUID().slice(0, 8)}`;
+// "Test User" collides with api-me.test.ts on the derived slug. The
+// trailing letter keeps the slug from ending in digits: nextSlug
+// increments a trailing number ("…-639" → "…-640") instead of
+// appending the -2 these tests assert.
+const TEST_DISPLAY_NAME = `Test User ${randomUUID().slice(0, 8)}z`;
 
 describe("upsertProfile", () => {
   let testUserId: string;


### PR DESCRIPTION
Summary: The welcome flow now ends explicitly — the settings tab opens itself after a profile save, a home icon anchors every page, and a farewell capstone closes the tour — and page titles join the icons in one unified top bar.

Why: Member onboarding feedback (#399): the "your settings live here" message pointed at a tab the member never found, and the flow trailed off with no obvious end. The home icon then exposed the staggered title/icon diagonals the layout work removes.

Behavior:
- Saving the welcome profile opens the Settings tab itself; the "Profile saved!" tour step spotlights the revealed panel.
- A home icon (real anchor) sits top-left on every authenticated page; all header chrome hides during /welcome so the guided steps stay exit-free.
- The first Done on /myweb fires a farewell capstone lighting the home icon and menu together; the page title hides while it runs.
- react-joyride v3 completion is detected via status "finished" — a last-step primary click emits action "update", which the previous action-verb filter missed.
- New shared PageHeader puts every page title + breadcrumb in the top band (pt-3 mains, full-width baseline rows); admin subpages adopt the history-aware breadcrumb; /intentions intro copy moves into the visualization's column.
- Member changelog: "Home button".
- Test fixtures: slug fixtures get a trailing letter so nextSlug's digit-increment behavior can't break the -2/-3 assertions (latent ~2% flake, surfaced by this PR's gate run).

Closes #399.

Test Plan:
- ran `npm test` locally — fully green: 488/488 functional, 32/32 e2e (the /admin 500 of #400 afflicts long-lived dev servers only; it did not reproduce on the fresh server this run spawned)
- Playwright visual verification: settings step, farewell capstone, title bar at 1280/900/700/390 widths
- manual welcome-flow walkthroughs (James)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
