### PR TITLE
fix: slide-out menu scroll, spacing, and width

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -91,7 +91,7 @@ function MenuSheet({ displayName, isAdmin }: { displayName: string | null; isAdm
         <SheetContent
           side="right"
           showCloseButton={false}
-          className="data-[side=right]:w-[40%] data-[side=right]:sm:max-w-[12.5rem]"
+          className="data-[side=right]:w-[45%] data-[side=right]:sm:max-w-[14rem] gap-2"
         >
           <SheetHeader>
             <div className="flex items-center gap-1">
@@ -150,7 +150,7 @@ function MenuSheet({ displayName, isAdmin }: { displayName: string | null; isAdm
               />
             ) : null}
           </SheetHeader>
-          <nav className="flex flex-col gap-1 px-4 pb-4">
+          <nav className="flex flex-1 flex-col gap-1 overflow-y-auto px-4 pb-4">
             <MenuLink href="/">Home</MenuLink>
             <MenuLink href="/programs">Programs</MenuLink>
             <MenuLink href="/members">Member directory</MenuLink>


### PR DESCRIPTION
## Summary

Fix the slide-out nav menu so it scrolls on small screens, tighten the gap between header and links, and widen it slightly.

## Why

On mobile (e.g. iPhone), the nav list is long enough to overflow the viewport but the menu was not scrollable — items below the fold were unreachable. The spacing between the user name and the first link was also visually large, and the panel was a bit narrow for comfortable tap targets.

## Behavior

- Nav list is now `overflow-y-auto` with `flex-1`, so it scrolls when content exceeds the viewport height.
- Gap between SheetHeader and nav reduced from `gap-4` to `gap-2`.
- Panel width bumped from 40%/12.5rem to 45%/14rem.

## Test Plan

- Verified on localhost with seeded account (Aria Chen) on simulated mobile viewport — menu scrolls, all items reachable
- Checked desktop — no visual regression, slightly wider panel looks proportional

## Checklist

- [ ] If this PR changes `.claude/skills/**/SKILL.md`, smoke-test the affected Skill on a realistic prompt.