### PR TITLE
feat: enhanced program descriptions and status indicators (#403)

### DIFF
--- a/drizzle/0014_massive_firelord.sql
+++ b/drizzle/0014_massive_firelord.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "programs" ADD COLUMN "blurb" text;

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,727 @@
+{
+  "id": "63d35da5-e105-4b14-a629-b2bf648bc603",
+  "prevId": "415505cb-bdf6-4606-9e10-0f9196c0c6cb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_hints": {
+      "name": "invite_hints",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_hints_invite_id_invites_id_fk": {
+          "name": "invite_hints_invite_id_invites_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "invites",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_hints_ratee_id_profiles_id_fk": {
+          "name": "invite_hints_ratee_id_profiles_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_hints_invite_id_ratee_id_pk": {
+          "name": "invite_hints_invite_id_ratee_id_pk",
+          "columns": [
+            "invite_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by": {
+          "name": "redeemed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_value": {
+          "name": "creator_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_profiles_id_fk": {
+          "name": "invites_created_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_profiles_id_fk": {
+          "name": "invites_redeemed_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "redeemed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_redemption_pair": {
+          "name": "invites_redemption_pair",
+          "value": "(\"invites\".\"redeemed_by\" IS NULL) = (\"invites\".\"redeemed_at\" IS NULL)"
+        },
+        "invites_expires_after_created": {
+          "name": "invites_expires_after_created",
+          "value": "\"invites\".\"expires_at\" > \"invites\".\"created_at\""
+        },
+        "invites_creator_value_range": {
+          "name": "invites_creator_value_range",
+          "value": "\"invites\".\"creator_value\" IS NULL OR (\"invites\".\"creator_value\" BETWEEN 1 AND 4)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profile_programs": {
+      "name": "profile_programs",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_programs_profile_id_profiles_id_fk": {
+          "name": "profile_programs_profile_id_profiles_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_programs_program_id_programs_id_fk": {
+          "name": "profile_programs_program_id_programs_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_programs_profile_id_program_id_pk": {
+          "name": "profile_programs_profile_id_program_id_pk",
+          "columns": [
+            "profile_id",
+            "program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplementary_info": {
+          "name": "supplementary_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by": {
+          "name": "referred_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by_legacy": {
+          "name": "referred_by_legacy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_signed_agreements": {
+          "name": "last_signed_agreements",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_profile": {
+          "name": "last_updated_profile",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reviewed_programs": {
+          "name": "last_reviewed_programs",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_intention": {
+          "name": "current_intention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intention_updated_at": {
+          "name": "intention_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_web": {
+          "name": "last_updated_web",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttondown_subscriber_id": {
+          "name": "buttondown_subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profiles_referred_by_profiles_id_fk": {
+          "name": "profiles_referred_by_profiles_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "referred_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_slug_unique": {
+          "name": "profiles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blurb": {
+          "name": "blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signups_open": {
+          "name": "signups_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "buttondown_tag": {
+          "name": "buttondown_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_slug_unique": {
+          "name": "programs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "rater_id": {
+          "name": "rater_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hint": {
+          "name": "is_hint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hinted_by": {
+          "name": "hinted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "relations_rater_id_profiles_id_fk": {
+          "name": "relations_rater_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "rater_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_ratee_id_profiles_id_fk": {
+          "name": "relations_ratee_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_hinted_by_profiles_id_fk": {
+          "name": "relations_hinted_by_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "hinted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "relations_rater_id_ratee_id_pk": {
+          "name": "relations_rater_id_ratee_id_pk",
+          "columns": [
+            "rater_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relations_no_self": {
+          "name": "relations_no_self",
+          "value": "\"relations\".\"rater_id\" != \"relations\".\"ratee_id\""
+        },
+        "relations_value_range": {
+          "name": "relations_value_range",
+          "value": "\"relations\".\"value\" IS NULL OR (\"relations\".\"value\" BETWEEN 1 AND 4)"
+        },
+        "relations_hint_state": {
+          "name": "relations_hint_state",
+          "value": "(NOT \"relations\".\"is_hint\" AND \"relations\".\"value\" IS NOT NULL)\n       OR (\"relations\".\"is_hint\" AND \"relations\".\"value\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.sync_locks": {
+      "name": "sync_locks",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_by": {
+          "name": "acquired_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1780506291419,
       "tag": "0013_add_profile_deactivated_at",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1781267777169,
+      "tag": "0014_massive_firelord",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/admin/programs/[id]/program-detail.tsx
+++ b/src/app/admin/programs/[id]/program-detail.tsx
@@ -68,6 +68,7 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
     mutationFn: async (vars: {
       name?: string;
       slug?: string;
+      blurb?: string | null;
       description?: string | null;
       archived?: boolean;
       signupsOpen?: boolean;

--- a/src/app/admin/programs/[id]/program-detail.tsx
+++ b/src/app/admin/programs/[id]/program-detail.tsx
@@ -54,6 +54,7 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
   const router = useRouter();
   const [name, setName] = useState(program.name);
   const [slug, setSlug] = useState(program.slug);
+  const [blurb, setBlurb] = useState(program.blurb ?? "");
   const [description, setDescription] = useState(program.description ?? "");
   const [buttondownTag, setButtondownTag] = useState(program.buttondownTag ?? "");
   const [editError, setEditError] = useState<string | null>(null);
@@ -173,6 +174,7 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
   const dirty =
     trimmedName !== program.name ||
     trimmedSlug !== program.slug ||
+    blurb.trim() !== (program.blurb ?? "") ||
     description.trim() !== (program.description ?? "") ||
     trimmedButtondownTag !== (program.buttondownTag ?? "");
 
@@ -188,6 +190,7 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
     updateMutation.mutate({
       name: trimmedName,
       slug: trimmedSlug,
+      blurb: blurb.trim() || null,
       description: description.trim() || null,
       buttondownTag: trimmedButtondownTag || null,
     });
@@ -220,12 +223,25 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
           <p className="text-xs text-muted-foreground">Used in URLs — lowercase letters, numbers, and hyphens.</p>
         </div>
         <div className="flex flex-col gap-1.5">
-          <Label htmlFor="program-description">Description</Label>
+          <Label htmlFor="program-blurb">Blurb</Label>
+          <Input
+            id="program-blurb"
+            value={blurb}
+            onChange={(e) => setBlurb(e.target.value)}
+            disabled={updateMutation.isPending}
+            placeholder="One sentence shown on the program card"
+          />
+          <p className="text-xs text-muted-foreground">Short tagline shown on the programs list. Max 200 characters.</p>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-description">Full description</Label>
           <Textarea
             id="program-description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             disabled={updateMutation.isPending}
+            placeholder="Shown on the program detail page"
+            rows={5}
           />
         </div>
         <div className="flex flex-col gap-1.5">

--- a/src/app/programs/[slug]/program-slug-detail.tsx
+++ b/src/app/programs/[slug]/program-slug-detail.tsx
@@ -85,15 +85,14 @@ function ProgramBody({ program }: { program: ProgramDetail }) {
     <div className="flex w-full max-w-3xl flex-col gap-6">
       <header className="flex flex-col gap-2">
         <h2 className="text-3xl font-semibold">{program.name}</h2>
+        {program.blurb && <p className="font-serif text-base text-muted-foreground">{program.blurb}</p>}
         <p className="text-xs text-muted-foreground">
           {program.memberCount} {program.memberCount === 1 ? "member" : "members"}
           {program.joined && program.joinedAt && <> · Joined {formatDate(program.joinedAt)}</>}
         </p>
       </header>
 
-      {program.description && (
-        <p className="font-serif text-base text-muted-foreground leading-relaxed">{program.description}</p>
-      )}
+      {program.description && <p className="font-serif text-base leading-relaxed">{program.description}</p>}
 
       <div className="flex items-center gap-3">
         {program.joined ? (

--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -4,6 +4,7 @@ import type { UrlObject } from "node:url";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { Avatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api";
 import type { Program } from "@/lib/api-types";
@@ -21,42 +22,69 @@ function ProgramCard({
   onLeave: (id: string) => void;
   pending: boolean;
 }) {
-  const [expanded, setExpanded] = useState(false);
-  const DESCRIPTION_LIMIT = 120;
-  const description = program.description ?? "";
-  const isLong = description.length > DESCRIPTION_LIMIT;
-  const visibleDescription = isLong && !expanded ? `${description.slice(0, DESCRIPTION_LIMIT)}…` : description;
+  const cardText = program.blurb ?? program.description ?? "";
+  const isOngoing = program.memberCount > 0;
+  const isGearingUp = !isOngoing && program.signupsOpen;
+
+  const statusBlip = isOngoing ? (
+    <span className="relative flex h-2 w-2 shrink-0" title="Ongoing">
+      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
+      <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
+    </span>
+  ) : isGearingUp ? (
+    <span className="relative flex h-2 w-2 shrink-0" title="Gearing up">
+      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-amber-400 opacity-75" />
+      <span className="relative inline-flex h-2 w-2 rounded-full bg-amber-500" />
+    </span>
+  ) : (
+    <span className="relative flex h-2 w-2 shrink-0" title="Ready">
+      <span className="relative inline-flex h-2 w-2 rounded-full bg-muted-foreground/30" />
+    </span>
+  );
 
   return (
     <li
       className={`flex flex-col gap-3 rounded-xl bg-card p-5 ${program.joined ? "border border-transparent ring-3 ring-ring/50" : "border border-border"}`}
     >
       <div className="flex flex-col gap-1">
-        <h2 className="text-lg font-semibold">
-          <Link
-            href={{ pathname: `/programs/${program.slug}` } satisfies UrlObject}
-            className="hover:underline focus-visible:underline"
-          >
-            {program.name}
-          </Link>
-        </h2>
+        <div className="flex items-center gap-2">
+          {statusBlip}
+          <h2 className="text-lg font-semibold">
+            <Link
+              href={{ pathname: `/programs/${program.slug}` } satisfies UrlObject}
+              className="hover:underline focus-visible:underline"
+            >
+              {program.name}
+            </Link>
+          </h2>
+        </div>
         <p className="text-xs text-muted-foreground">
           {program.memberCount} {program.memberCount === 1 ? "member" : "members"}
           {program.joined && program.joinedAt && <> · Joined {formatDate(program.joinedAt)}</>}
         </p>
       </div>
 
-      {description && (
-        <div className="flex flex-col gap-1">
-          <p className="font-serif text-sm text-muted-foreground leading-relaxed">{visibleDescription}</p>
-          {isLong && (
-            <button
-              type="button"
-              onClick={() => setExpanded((e) => !e)}
-              className="self-start text-xs text-muted-foreground underline hover:no-underline"
+      {cardText && <p className="font-serif text-sm text-muted-foreground leading-relaxed">{cardText}</p>}
+
+      {program.memberAvatars.length > 0 && (
+        <div className="flex items-center">
+          {program.memberAvatars.map((member, i) => (
+            <div
+              key={member.id}
+              className="relative h-7 w-7 shrink-0 rounded-full border-2 border-card bg-muted"
+              style={{ marginLeft: i === 0 ? 0 : "-8px", zIndex: program.memberAvatars.length - i }}
+              title={member.displayName ?? undefined}
             >
-              {expanded ? "Show less" : "Show more"}
-            </button>
+              <Avatar
+                name={member.displayName}
+                url={member.avatarUrl}
+                sizes="28px"
+                className="h-full w-full rounded-full text-[10px]"
+              />
+            </div>
+          ))}
+          {program.memberCount > 5 && (
+            <span className="ml-1 text-xs text-muted-foreground">+{program.memberCount - 5}</span>
           )}
         </div>
       )}

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
-import { and, asc, eq, inArray, isNull, ne, notExists, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, ne, notExists, sql } from "drizzle-orm";
 
 import { isUuid } from "./auth-middleware";
 import { attachAvatarUrls } from "./avatars";
@@ -110,7 +110,7 @@ export const listPrograms = async (userId: string): Promise<ProgramWithMembershi
           .from(profilePrograms)
           .innerJoin(profiles, eq(profiles.id, profilePrograms.profileId))
           .where(and(inArray(profilePrograms.programId, programIds), isNull(profilePrograms.leftAt)))
-          .orderBy(asc(profilePrograms.assignedAt))
+          .orderBy(desc(profilePrograms.assignedAt))
       : [];
 
   const withAvatarUrls = await attachAvatarUrls(avatarRows);

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -38,15 +38,23 @@ export const autoSubscribeNewMember = async (userId: string): Promise<void> => {
     .onConflictDoNothing();
 };
 
+export type ProgramMemberAvatar = {
+  id: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+};
+
 export type ProgramWithMembership = {
   id: string;
   slug: string;
   name: string;
+  blurb: string | null;
   description: string | null;
   signupsOpen: boolean;
   memberCount: number;
   joined: boolean;
   joinedAt: string | null;
+  memberAvatars: ProgramMemberAvatar[];
 };
 
 // Note: memberCount and joinedAt use correlated subqueries which is
@@ -68,6 +76,7 @@ export const listPrograms = async (userId: string): Promise<ProgramWithMembershi
       id: programs.id,
       slug: programs.slug,
       name: programs.name,
+      blurb: programs.blurb,
       description: programs.description,
       signupsOpen: programs.signupsOpen,
       memberCount: sql<number>`(
@@ -86,9 +95,39 @@ export const listPrograms = async (userId: string): Promise<ProgramWithMembershi
     .where(isNull(programs.archivedAt))
     .orderBy(programs.name);
 
+  // Fetch up to 5 current members per program for the avatar facepile.
+  const programIds = rows.map((r) => r.id);
+  const avatarRows =
+    programIds.length > 0
+      ? await db
+          .select({
+            programId: profilePrograms.programId,
+            id: profiles.id,
+            displayName: profiles.displayName,
+            avatarPath: profiles.avatarPath,
+            assignedAt: profilePrograms.assignedAt,
+          })
+          .from(profilePrograms)
+          .innerJoin(profiles, eq(profiles.id, profilePrograms.profileId))
+          .where(and(inArray(profilePrograms.programId, programIds), isNull(profilePrograms.leftAt)))
+          .orderBy(asc(profilePrograms.assignedAt))
+      : [];
+
+  const withAvatarUrls = await attachAvatarUrls(avatarRows);
+
+  const avatarsByProgram = new Map<string, ProgramMemberAvatar[]>();
+  for (const row of withAvatarUrls) {
+    const existing = avatarsByProgram.get(row.programId) ?? [];
+    if (existing.length < 5) {
+      existing.push({ id: row.id, displayName: row.displayName, avatarUrl: row.avatarUrl });
+      avatarsByProgram.set(row.programId, existing);
+    }
+  }
+
   return rows.map((r) => ({
     ...r,
     joined: r.joinedAt !== null,
+    memberAvatars: avatarsByProgram.get(r.id) ?? [],
   }));
 };
 
@@ -209,6 +248,7 @@ export type ProgramDetailForMember = {
   id: string;
   slug: string;
   name: string;
+  blurb: string | null;
   description: string | null;
   signupsOpen: boolean;
   memberCount: number;
@@ -226,6 +266,7 @@ export const getProgramBySlug = async (
       id: programs.id,
       slug: programs.slug,
       name: programs.name,
+      blurb: programs.blurb,
       description: programs.description,
       signupsOpen: programs.signupsOpen,
       archivedAt: programs.archivedAt,
@@ -266,6 +307,7 @@ export const getProgramBySlug = async (
       id: program.id,
       slug: program.slug,
       name: program.name,
+      blurb: program.blurb,
       description: program.description,
       signupsOpen: program.signupsOpen,
       memberCount: members.length,
@@ -287,6 +329,7 @@ export type AdminProgram = {
   id: string;
   slug: string;
   name: string;
+  blurb: string | null;
   description: string | null;
   archivedAt: string | null;
   signupsOpen: boolean;
@@ -307,6 +350,7 @@ export type ProgramDetail = AdminProgram & { participants: ProgramParticipant[] 
 
 const MAX_PROGRAM_NAME = 120;
 const MAX_PROGRAM_SLUG = 80;
+const MAX_PROGRAM_BLURB = 200;
 const MAX_PROGRAM_DESCRIPTION = 2000;
 // Buttondown tag names are short by convention; the cap is well above
 // anything Buttondown surfaces in its UI and keeps the column index-friendly.
@@ -332,7 +376,9 @@ const validateSlug = (slug: string): { slug: string } | { error: string } => {
 // buttondownTag is also optional; blank is normalized to null.
 export const parseProgramCreate = (
   body: unknown,
-): { name: string; slug: string; description: string | null; buttondownTag: string | null } | { error: string } => {
+):
+  | { name: string; slug: string; blurb: string | null; description: string | null; buttondownTag: string | null }
+  | { error: string } => {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     return { error: "body must be a JSON object" };
   }
@@ -346,6 +392,11 @@ export const parseProgramCreate = (
   const slugCheck = validateSlug(slug);
   if ("error" in slugCheck) return slugCheck;
 
+  const blurb = trimmedString(obj.blurb);
+  if (blurb && blurb.length > MAX_PROGRAM_BLURB) {
+    return { error: "blurb is too long" };
+  }
+
   const description = trimmedString(obj.description);
   if (description && description.length > MAX_PROGRAM_DESCRIPTION) {
     return { error: "description is too long" };
@@ -358,6 +409,7 @@ export const parseProgramCreate = (
   return {
     name,
     slug,
+    blurb: blurb || null,
     description: description || null,
     buttondownTag: buttondownTag || null,
   };
@@ -371,6 +423,7 @@ export const parseProgramCreate = (
 export type ProgramUpdate = {
   name?: string;
   slug?: string;
+  blurb?: string | null;
   description?: string | null;
   archived?: boolean;
   signupsOpen?: boolean;
@@ -399,6 +452,13 @@ export const parseProgramUpdate = (body: unknown): ProgramUpdate | { error: stri
     const slugCheck = validateSlug(slug);
     if ("error" in slugCheck) return slugCheck;
     result.slug = slug;
+  }
+  if ("blurb" in obj) {
+    const blurb = trimmedString(obj.blurb);
+    if (blurb && blurb.length > MAX_PROGRAM_BLURB) {
+      return { error: "blurb is too long" };
+    }
+    result.blurb = blurb || null;
   }
   if ("description" in obj) {
     const description = trimmedString(obj.description);
@@ -441,6 +501,7 @@ export const listAllProgramsForAdmin = async (): Promise<AdminProgram[]> => {
       id: programs.id,
       slug: programs.slug,
       name: programs.name,
+      blurb: programs.blurb,
       description: programs.description,
       archivedAt: sql<string | null>`to_json(${programs.archivedAt}) #>> '{}'`,
       signupsOpen: programs.signupsOpen,
@@ -459,6 +520,7 @@ export const listAllProgramsForAdmin = async (): Promise<AdminProgram[]> => {
 export const createProgram = async (input: {
   name: string;
   slug: string;
+  blurb: string | null;
   description: string | null;
   buttondownTag: string | null;
 }): Promise<{ program: AdminProgram } | { error: "slug_conflict" }> => {
@@ -470,6 +532,7 @@ export const createProgram = async (input: {
     .values({
       slug: input.slug,
       name: input.name,
+      blurb: input.blurb,
       description: input.description,
       buttondownTag: input.buttondownTag,
     })
@@ -480,6 +543,7 @@ export const createProgram = async (input: {
       id: row.id,
       slug: row.slug,
       name: row.name,
+      blurb: row.blurb,
       description: row.description,
       archivedAt: row.archivedAt ? row.archivedAt.toISOString() : null,
       signupsOpen: row.signupsOpen,
@@ -503,6 +567,7 @@ export const updateProgram = async (
   // want now()/null, so split the type out from the validated input.
   const update: Record<string, unknown> = {};
   if (input.name !== undefined) update.name = input.name;
+  if (input.blurb !== undefined) update.blurb = input.blurb;
   if (input.description !== undefined) update.description = input.description;
   if (input.archived !== undefined) {
     update.archivedAt = input.archived ? sql`now()` : null;
@@ -539,6 +604,7 @@ export const getProgramDetail = async (
       id: programs.id,
       slug: programs.slug,
       name: programs.name,
+      blurb: programs.blurb,
       description: programs.description,
       archivedAt: programs.archivedAt,
       signupsOpen: programs.signupsOpen,
@@ -576,6 +642,7 @@ export const getProgramDetail = async (
       id: program.id,
       slug: program.slug,
       name: program.name,
+      blurb: program.blurb,
       description: program.description,
       archivedAt: program.archivedAt ? program.archivedAt.toISOString() : null,
       signupsOpen: program.signupsOpen,

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -77,6 +77,7 @@ export const programs = pgTable("programs", {
   id: uuid("id").primaryKey().defaultRandom(),
   slug: text("slug").notNull().unique(),
   name: text("name").notNull(),
+  blurb: text("blurb"),
   description: text("description"),
   // Archived programs are hidden from member-facing listings (admins
   // still see them in /admin/programs). Set the timestamp instead of


### PR DESCRIPTION
## Summary

- **Two-level descriptions**: new `blurb` field (short card tagline, max 200 chars) + existing `description` kept as full detail on the program page. Falls back to `description` on the card if no blurb set. Admin edit form gains separate fields for both.
- **Status indicators**: green pulse (ongoing, has members), amber pulse (gearing up, signups open), grey static (ready). Member avatar facepile (up to 5 faces) on active program cards.

## Test plan

- [ ] Go to `/admin/programs` → open a program → fill in Blurb and Full description → save
- [ ] Go to `/programs` → card shows blurb + correct status dot + member avatars
- [ ] Click through to detail page → full description shown
- [ ] Program with no members + signups open → amber dot
- [ ] Program with no members + signups closed → grey dot

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)