### PR TITLE
refactor: convert Sentry namespace imports to named imports (#256)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -45,6 +45,9 @@
     "enabled": true,
     "rules": {
       "recommended": true,
+      "performance": {
+        "noNamespaceImport": "error"
+      },
       "style": {
         "noNonNullAssertion": "error"
       },

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { captureRouterTransitionStart, init, replayIntegration } from "@sentry/nextjs";
 
 import { scrubClientEvent } from "@/lib/sentry-scrub";
 
@@ -18,7 +18,7 @@ const debugReplay = (() => {
   }
 })();
 
-Sentry.init({
+init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   // Report from production deploys only: preview e2e runs were sending
   // thousands of tunnel POSTs per run (Vercel traffic-spike alerts), and
@@ -30,7 +30,7 @@ Sentry.init({
   replaysOnErrorSampleRate: debugReplay ? 1.0 : 0,
   integrations: debugReplay
     ? [
-        Sentry.replayIntegration({
+        replayIntegration({
           maskAllText: true,
           blockAllMedia: true,
         }),
@@ -39,4 +39,4 @@ Sentry.init({
   beforeSend: scrubClientEvent,
 });
 
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+export const onRouterTransitionStart = captureRouterTransitionStart;

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,4 +1,8 @@
-import { captureRouterTransitionStart, init, replayIntegration } from "@sentry/nextjs";
+import {
+  captureRouterTransitionStart as Sentry_captureRouterTransitionStart,
+  init as Sentry_init,
+  replayIntegration as Sentry_replayIntegration,
+} from "@sentry/nextjs";
 
 import { scrubClientEvent } from "@/lib/sentry-scrub";
 
@@ -18,7 +22,7 @@ const debugReplay = (() => {
   }
 })();
 
-init({
+Sentry_init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   // Report from production deploys only: preview e2e runs were sending
   // thousands of tunnel POSTs per run (Vercel traffic-spike alerts), and
@@ -30,7 +34,7 @@ init({
   replaysOnErrorSampleRate: debugReplay ? 1.0 : 0,
   integrations: debugReplay
     ? [
-        replayIntegration({
+        Sentry_replayIntegration({
           maskAllText: true,
           blockAllMedia: true,
         }),
@@ -39,4 +43,4 @@ init({
   beforeSend: scrubClientEvent,
 });
 
-export const onRouterTransitionStart = captureRouterTransitionStart;
+export const onRouterTransitionStart = Sentry_captureRouterTransitionStart;

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { captureRequestError } from "@sentry/nextjs";
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
@@ -6,4 +6,4 @@ export async function register() {
   }
 }
 
-export const onRequestError = Sentry.captureRequestError;
+export const onRequestError = captureRequestError;

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,4 +1,4 @@
-import { captureRequestError } from "@sentry/nextjs";
+import { captureRequestError as Sentry_captureRequestError } from "@sentry/nextjs";
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
@@ -6,4 +6,4 @@ export async function register() {
   }
 }
 
-export const onRequestError = captureRequestError;
+export const onRequestError = Sentry_captureRequestError;

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,8 +1,8 @@
-import * as Sentry from "@sentry/nextjs";
+import { init } from "@sentry/nextjs";
 
 import { scrubServerEvent } from "@/lib/sentry-scrub";
 
-Sentry.init({
+init({
   dsn: process.env.SENTRY_DSN,
   // Report from production deploys only — mirrors the client gate in
   // instrumentation-client.ts.

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,8 +1,8 @@
-import { init } from "@sentry/nextjs";
+import { init as Sentry_init } from "@sentry/nextjs";
 
 import { scrubServerEvent } from "@/lib/sentry-scrub";
 
-init({
+Sentry_init({
   dsn: process.env.SENTRY_DSN,
   // Report from production deploys only — mirrors the client gate in
   // instrumentation-client.ts.

--- a/src/app/about/system-metrics.tsx
+++ b/src/app/about/system-metrics.tsx
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { captureException } from "@sentry/nextjs";
 
 import { serverApiClient } from "@/lib/api-server";
 
@@ -117,7 +117,7 @@ export async function SystemMetrics() {
       </div>
     );
   } catch (err) {
-    Sentry.captureException(err);
+    captureException(err);
     return <p className="text-sm text-muted-foreground">System metrics unavailable.</p>;
   }
 }

--- a/src/app/about/system-metrics.tsx
+++ b/src/app/about/system-metrics.tsx
@@ -1,4 +1,4 @@
-import { captureException } from "@sentry/nextjs";
+import { captureException as Sentry_captureException } from "@sentry/nextjs";
 
 import { serverApiClient } from "@/lib/api-server";
 
@@ -117,7 +117,7 @@ export async function SystemMetrics() {
       </div>
     );
   } catch (err) {
-    captureException(err);
+    Sentry_captureException(err);
     return <p className="text-sm text-muted-foreground">System metrics unavailable.</p>;
   }
 }

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,4 +1,4 @@
-import { captureException } from "@sentry/nextjs";
+import { captureException as Sentry_captureException } from "@sentry/nextjs";
 import { and, eq, gt, isNull, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 import { log } from "next-axiom";
@@ -17,7 +17,7 @@ const tryAutoSubscribe = async (userId: string): Promise<void> => {
   try {
     await autoSubscribeNewMember(userId);
   } catch (err) {
-    captureException(err);
+    Sentry_captureException(err);
   }
 };
 
@@ -134,7 +134,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
       result = await upsertProfile(data.user);
     } catch (err) {
-      captureException(err, {
+      Sentry_captureException(err, {
         tags: { feature: "auth-callback", path: "profile-upsert" },
         extra: { userId: data.user.id },
       });
@@ -234,7 +234,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // "did a redemption ever fail in prod?" question has no answer there.
     // `pgCode` surfaces the SQLSTATE (e.g. 25P02) the #149 pooler hazard
     // would raise.
-    captureException(err, {
+    Sentry_captureException(err, {
       tags: { feature: "auth-callback", path: "invite-redemption" },
       extra: { inviteCode: invite, userId },
     });

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { captureException } from "@sentry/nextjs";
 import { and, eq, gt, isNull, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 import { log } from "next-axiom";
@@ -17,7 +17,7 @@ const tryAutoSubscribe = async (userId: string): Promise<void> => {
   try {
     await autoSubscribeNewMember(userId);
   } catch (err) {
-    Sentry.captureException(err);
+    captureException(err);
   }
 };
 
@@ -134,7 +134,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
       result = await upsertProfile(data.user);
     } catch (err) {
-      Sentry.captureException(err, {
+      captureException(err, {
         tags: { feature: "auth-callback", path: "profile-upsert" },
         extra: { userId: data.user.id },
       });
@@ -234,7 +234,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // "did a redemption ever fail in prod?" question has no answer there.
     // `pgCode` surfaces the SQLSTATE (e.g. 25P02) the #149 pooler hazard
     // would raise.
-    Sentry.captureException(err, {
+    captureException(err, {
       tags: { feature: "auth-callback", path: "invite-redemption" },
       extra: { inviteCode: invite, userId },
     });

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
+import { captureException } from "@sentry/nextjs";
 import NextError from "next/error";
 import { useEffect } from "react";
 
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
-    Sentry.captureException(error);
+    captureException(error);
   }, [error]);
 
   return (

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { captureException } from "@sentry/nextjs";
+import { captureException as Sentry_captureException } from "@sentry/nextjs";
 import NextError from "next/error";
 import { useEffect } from "react";
 
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
-    captureException(error);
+    Sentry_captureException(error);
   }, [error]);
 
   return (

--- a/src/server/buttondown-runner.ts
+++ b/src/server/buttondown-runner.ts
@@ -6,7 +6,7 @@
 // `acquiredBy` per scheduled run) and the admin "Sync now" buttons
 // (one per click, identified by the admin's profile id).
 
-import { captureException, captureMessage } from "@sentry/nextjs";
+import { captureException as Sentry_captureException, captureMessage as Sentry_captureMessage } from "@sentry/nextjs";
 import { log } from "next-axiom";
 
 import { createButtondownClient } from "./buttondown";
@@ -87,7 +87,7 @@ export const runButtondownSyncForServer = async (options: RunButtondownSyncOptio
     // that's a real signal, not just noise. Send it to Sentry so it
     // pages; the fingerprint stays stable so an operator sees one
     // issue per ongoing overlap, not one per cron.
-    captureMessage("buttondown.sync_lock_held", {
+    Sentry_captureMessage("buttondown.sync_lock_held", {
       level: "warning",
       tags: { feature: "buttondown-sync", action: "skipped-lock-held", acquiredBy: runId },
       extra: { attempts, waitedMs },
@@ -127,7 +127,7 @@ export const runButtondownSyncForServer = async (options: RunButtondownSyncOptio
         // and we re-raise here as a Sentry exception so the alert
         // story doesn't depend on parsing Axiom logs.
         if (event.action === "error") {
-          captureException(new Error("buttondown.sync_profile_error"), {
+          Sentry_captureException(new Error("buttondown.sync_profile_error"), {
             tags: {
               feature: "buttondown-sync",
               action: "sync-error",
@@ -142,7 +142,7 @@ export const runButtondownSyncForServer = async (options: RunButtondownSyncOptio
         // Captured as an exception so Sentry's email-on-error alerting
         // fires; the fingerprint stays stable across runs so an admin
         // sees one issue per affected member rather than per cron.
-        captureException(new Error("buttondown.unsubscribed_member"), {
+        Sentry_captureException(new Error("buttondown.unsubscribed_member"), {
           extra: {
             profileId: alert.profileId,
             email: alert.email,
@@ -186,7 +186,7 @@ export const runFirstProfileSaveForServer = async (params: {
       email: params.email,
       client,
       raiseUnsubscribeAlert: (alert: UnsubscribeAlert) => {
-        captureException(new Error("buttondown.unsubscribed_member"), {
+        Sentry_captureException(new Error("buttondown.unsubscribed_member"), {
           extra: {
             profileId: alert.profileId,
             email: alert.email,
@@ -210,7 +210,7 @@ export const runFirstProfileSaveForServer = async (params: {
       runId,
       message: err instanceof Error ? err.message : String(err),
     });
-    captureException(err, {
+    Sentry_captureException(err, {
       tags: { feature: "buttondown-sync", path: "first-profile-save", runId },
       extra: { profileId: params.profileId },
     });
@@ -266,7 +266,7 @@ export const runProfileResyncForServer = async (params: {
       reason: params.reason,
       message: err instanceof Error ? err.message : String(err),
     });
-    captureException(err, {
+    Sentry_captureException(err, {
       tags: { feature: "buttondown-sync", path: "profile-resync", reason: params.reason },
       extra: { profileId: params.profileId },
     });

--- a/src/server/buttondown-runner.ts
+++ b/src/server/buttondown-runner.ts
@@ -6,7 +6,7 @@
 // `acquiredBy` per scheduled run) and the admin "Sync now" buttons
 // (one per click, identified by the admin's profile id).
 
-import * as Sentry from "@sentry/nextjs";
+import { captureException, captureMessage } from "@sentry/nextjs";
 import { log } from "next-axiom";
 
 import { createButtondownClient } from "./buttondown";
@@ -87,7 +87,7 @@ export const runButtondownSyncForServer = async (options: RunButtondownSyncOptio
     // that's a real signal, not just noise. Send it to Sentry so it
     // pages; the fingerprint stays stable so an operator sees one
     // issue per ongoing overlap, not one per cron.
-    Sentry.captureMessage("buttondown.sync_lock_held", {
+    captureMessage("buttondown.sync_lock_held", {
       level: "warning",
       tags: { feature: "buttondown-sync", action: "skipped-lock-held", acquiredBy: runId },
       extra: { attempts, waitedMs },
@@ -127,7 +127,7 @@ export const runButtondownSyncForServer = async (options: RunButtondownSyncOptio
         // and we re-raise here as a Sentry exception so the alert
         // story doesn't depend on parsing Axiom logs.
         if (event.action === "error") {
-          Sentry.captureException(new Error("buttondown.sync_profile_error"), {
+          captureException(new Error("buttondown.sync_profile_error"), {
             tags: {
               feature: "buttondown-sync",
               action: "sync-error",
@@ -142,7 +142,7 @@ export const runButtondownSyncForServer = async (options: RunButtondownSyncOptio
         // Captured as an exception so Sentry's email-on-error alerting
         // fires; the fingerprint stays stable across runs so an admin
         // sees one issue per affected member rather than per cron.
-        Sentry.captureException(new Error("buttondown.unsubscribed_member"), {
+        captureException(new Error("buttondown.unsubscribed_member"), {
           extra: {
             profileId: alert.profileId,
             email: alert.email,
@@ -186,7 +186,7 @@ export const runFirstProfileSaveForServer = async (params: {
       email: params.email,
       client,
       raiseUnsubscribeAlert: (alert: UnsubscribeAlert) => {
-        Sentry.captureException(new Error("buttondown.unsubscribed_member"), {
+        captureException(new Error("buttondown.unsubscribed_member"), {
           extra: {
             profileId: alert.profileId,
             email: alert.email,
@@ -210,7 +210,7 @@ export const runFirstProfileSaveForServer = async (params: {
       runId,
       message: err instanceof Error ? err.message : String(err),
     });
-    Sentry.captureException(err, {
+    captureException(err, {
       tags: { feature: "buttondown-sync", path: "first-profile-save", runId },
       extra: { profileId: params.profileId },
     });
@@ -266,7 +266,7 @@ export const runProfileResyncForServer = async (params: {
       reason: params.reason,
       message: err instanceof Error ? err.message : String(err),
     });
-    Sentry.captureException(err, {
+    captureException(err, {
       tags: { feature: "buttondown-sync", path: "profile-resync", reason: params.reason },
       extra: { profileId: params.profileId },
     });

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { captureException } from "@sentry/nextjs";
 import type { User } from "@supabase/supabase-js";
 import { and, asc, eq, isNotNull, isNull, or, sql } from "drizzle-orm";
 
@@ -160,7 +160,7 @@ export const syncDisplayNameToAuthMetadata = async (
     });
     if (error) throw error;
   } catch (err) {
-    Sentry.captureException(err, {
+    captureException(err, {
       tags: { area: "profile.metadata_sync" },
       extra: { userId },
     });

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -1,4 +1,4 @@
-import { captureException } from "@sentry/nextjs";
+import { captureException as Sentry_captureException } from "@sentry/nextjs";
 import type { User } from "@supabase/supabase-js";
 import { and, asc, eq, isNotNull, isNull, or, sql } from "drizzle-orm";
 
@@ -160,7 +160,7 @@ export const syncDisplayNameToAuthMetadata = async (
     });
     if (error) throw error;
   } catch (err) {
-    captureException(err, {
+    Sentry_captureException(err, {
       tags: { area: "profile.metadata_sync" },
       extra: { userId },
     });

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { captureException } from "@sentry/nextjs";
 import { and, asc, desc, eq, inArray, isNull, ne, notExists, sql } from "drizzle-orm";
 
 import { isUuid } from "./auth-middleware";
@@ -26,7 +26,7 @@ export const autoSubscribeNewMember = async (userId: string): Promise<void> => {
   const found = new Set(rows.map((r) => r.slug));
   for (const slug of AUTO_SUBSCRIBE_SLUGS) {
     if (!found.has(slug)) {
-      Sentry.captureException(new Error(`autoSubscribeNewMember: program slug "${slug}" not found in database`));
+      captureException(new Error(`autoSubscribeNewMember: program slug "${slug}" not found in database`));
     }
   }
 

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -1,4 +1,4 @@
-import { captureException } from "@sentry/nextjs";
+import { captureException as Sentry_captureException } from "@sentry/nextjs";
 import { and, asc, desc, eq, inArray, isNull, ne, notExists, sql } from "drizzle-orm";
 
 import { isUuid } from "./auth-middleware";
@@ -26,7 +26,7 @@ export const autoSubscribeNewMember = async (userId: string): Promise<void> => {
   const found = new Set(rows.map((r) => r.slug));
   for (const slug of AUTO_SUBSCRIBE_SLUGS) {
     if (!found.has(slug)) {
-      captureException(new Error(`autoSubscribeNewMember: program slug "${slug}" not found in database`));
+      Sentry_captureException(new Error(`autoSubscribeNewMember: program slug "${slug}" not found in database`));
     }
   }
 

--- a/tests/functional/server/api-me.test.ts
+++ b/tests/functional/server/api-me.test.ts
@@ -23,7 +23,6 @@ vi.mock("@sentry/nextjs", () => ({
   captureMessage: vi.fn(),
 }));
 
-import { captureException as Sentry_captureException } from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 
 import { toSlug } from "@/lib/slug";

--- a/tests/functional/server/api-me.test.ts
+++ b/tests/functional/server/api-me.test.ts
@@ -23,7 +23,7 @@ vi.mock("@sentry/nextjs", () => ({
   captureMessage: vi.fn(),
 }));
 
-import * as Sentry from "@sentry/nextjs";
+import { captureException } from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 
 import { toSlug } from "@/lib/slug";
@@ -34,7 +34,7 @@ import { profiles } from "@/server/schema";
 
 const mockCreateServerClient = vi.mocked(createServerClient);
 const mockUpdateUserById = vi.mocked(supabaseAdmin.auth.admin.updateUserById);
-const mockCaptureException = vi.mocked(Sentry.captureException);
+const mockCaptureException = vi.mocked(captureException);
 
 // Unique per run: upsertProfile derives the profile slug via toSlug,
 // which hits a global unique constraint, and parallel test files share

--- a/tests/functional/server/api-me.test.ts
+++ b/tests/functional/server/api-me.test.ts
@@ -23,6 +23,7 @@ vi.mock("@sentry/nextjs", () => ({
   captureMessage: vi.fn(),
 }));
 
+import { captureException as Sentry_captureException } from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 
 import { toSlug } from "@/lib/slug";
@@ -33,7 +34,7 @@ import { profiles } from "@/server/schema";
 
 const mockCreateServerClient = vi.mocked(createServerClient);
 const mockUpdateUserById = vi.mocked(supabaseAdmin.auth.admin.updateUserById);
-const mockCaptureException = vi.mocked(captureException);
+const mockCaptureException = vi.mocked(Sentry_captureException);
 
 // Unique per run: upsertProfile derives the profile slug via toSlug,
 // which hits a global unique constraint, and parallel test files share

--- a/tests/functional/server/api-me.test.ts
+++ b/tests/functional/server/api-me.test.ts
@@ -23,7 +23,7 @@ vi.mock("@sentry/nextjs", () => ({
   captureMessage: vi.fn(),
 }));
 
-import { captureException } from "@sentry/nextjs";
+import { captureException as Sentry_captureException } from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 
 import { toSlug } from "@/lib/slug";

--- a/tests/functional/server/programs.test.ts
+++ b/tests/functional/server/programs.test.ts
@@ -14,7 +14,7 @@ vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
 }));
 
-import { captureException } from "@sentry/nextjs";
+import { captureException as Sentry_captureException } from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 
 import app from "@/server/api";

--- a/tests/functional/server/programs.test.ts
+++ b/tests/functional/server/programs.test.ts
@@ -14,7 +14,6 @@ vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
 }));
 
-import { captureException as Sentry_captureException } from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 
 import app from "@/server/api";

--- a/tests/functional/server/programs.test.ts
+++ b/tests/functional/server/programs.test.ts
@@ -14,7 +14,7 @@ vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
 }));
 
-import * as Sentry from "@sentry/nextjs";
+import { captureException } from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 
 import app from "@/server/api";
@@ -405,7 +405,7 @@ describe("autoSubscribeNewMember", () => {
     await db.delete(programs).where(eq(programs.id, weeklyProgramId));
 
     try {
-      const captureMock = vi.mocked(Sentry.captureException);
+      const captureMock = vi.mocked(captureException);
       captureMock.mockClear();
 
       await expect(autoSubscribeNewMember(userId)).resolves.toBeUndefined();

--- a/tests/functional/server/programs.test.ts
+++ b/tests/functional/server/programs.test.ts
@@ -14,6 +14,7 @@ vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
 }));
 
+import { captureException as Sentry_captureException } from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 
 import app from "@/server/api";
@@ -404,7 +405,7 @@ describe("autoSubscribeNewMember", () => {
     await db.delete(programs).where(eq(programs.id, weeklyProgramId));
 
     try {
-      const captureMock = vi.mocked(captureException);
+      const captureMock = vi.mocked(Sentry_captureException);
       captureMock.mockClear();
 
       await expect(autoSubscribeNewMember(userId)).resolves.toBeUndefined();


### PR DESCRIPTION
## Summary

Replaces all 11 `import * as Sentry from "@sentry/nextjs"` with named imports. Only 5 distinct names are used across the codebase: `captureException`, `captureMessage`, `captureRequestError`, `captureRouterTransitionStart`, `init`, `replayIntegration`. Named imports are recognizable without a namespace prefix.

Enables `performance/noNamespaceImport` in `biome.json` to prevent drift.

## Test plan
- [ ] CI lint passes (Biome rule now enforced)
- [ ] No runtime regressions (Sentry still captures errors)

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)