### PR TITLE
fix(avatar): fall back to JPEG when the browser can't encode WebP

### DIFF
--- a/src/components/avatar-uploader.tsx
+++ b/src/components/avatar-uploader.tsx
@@ -41,7 +41,7 @@ const boundSource = async (file: File): Promise<string> => {
   bitmap.close();
 
   // The bounded image is both what the cropper displays and what
-  // cropToWebp extracts the final crop from, so its quality is a real
+  // cropToUpload extracts the final crop from, so its quality is a real
   // link in the chain — but it only needs to sit above the final
   // encode (0.88) to not be the limiting generation; higher just grows
   // the blob. The object URL is revoked when the modal closes.
@@ -58,17 +58,34 @@ const loadImage = (src: string): Promise<HTMLImageElement> =>
     img.src = src;
   });
 
-// Draws the chosen crop rectangle into a square OUTPUT_DIMENSION canvas
-// and exports it as a WebP blob. `area` is in the bounded source's
+// Exports a canvas, but resolves null unless the browser actually
+// produced the requested type. canvas.toBlob silently substitutes PNG
+// when it can't encode the type asked for, so comparing blob.type is
+// the only way to notice — and the null signal lets the caller fall
+// back rather than ship a surprise PNG.
+const encodeCanvas = (canvas: HTMLCanvasElement, type: string, quality: number): Promise<Blob | null> =>
+  new Promise((resolve) => canvas.toBlob((blob) => resolve(blob?.type === type ? blob : null), type, quality));
+
+// Draws the chosen crop into a square OUTPUT_DIMENSION canvas and
+// returns a compact upload blob. `area` is in the bounded source's
 // pixel space, so it lines up with the image loaded here.
-const cropToWebp = async (src: string, area: Area): Promise<Blob> => {
+//
+// We want WebP, but some browsers (Safari/iOS historically) can't
+// encode it via canvas.toBlob and fall back to PNG — and a 1024² photo
+// as PNG is several MB, which the upload cap then rejects as "too
+// large", however small the source was. So when WebP doesn't come
+// back, encode JPEG instead: small, lossy, universally supported. The
+// server re-encodes to WebP regardless (docs/design-profile-pictures.md),
+// so the wire format only has to be compact and decodable.
+const cropToUpload = async (src: string, area: Area): Promise<Blob> => {
   const img = await loadImage(src);
   const canvas = document.createElement("canvas");
   canvas.width = OUTPUT_DIMENSION;
   canvas.height = OUTPUT_DIMENSION;
   getContext(canvas).drawImage(img, area.x, area.y, area.width, area.height, 0, 0, OUTPUT_DIMENSION, OUTPUT_DIMENSION);
-  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/webp", 0.88));
-  if (!blob) throw new Error("could not encode image");
+
+  const blob = (await encodeCanvas(canvas, "image/webp", 0.88)) ?? (await encodeCanvas(canvas, "image/jpeg", 0.85));
+  if (!blob) throw new Error("We couldn't process that photo. Please try another image.");
   return blob;
 };
 
@@ -109,7 +126,7 @@ export function AvatarUploader({ name, initialUrl }: { name: string | null; init
       setArea(null);
       setCropSrc(bounded);
     } catch {
-      setStatus({ kind: "error", message: "Couldn't read that image. Try a PNG or JPEG." });
+      setStatus({ kind: "error", message: "We couldn't read that image. Please try a JPEG or PNG." });
     }
   };
 
@@ -117,14 +134,18 @@ export function AvatarUploader({ name, initialUrl }: { name: string | null; init
     if (!cropSrc || !area) return;
     setStatus({ kind: "busy" });
     try {
-      const blob = await cropToWebp(cropSrc, area);
+      const blob = await cropToUpload(cropSrc, area);
       const form = new FormData();
-      form.append("file", blob, "avatar.webp");
+      const ext = blob.type === "image/webp" ? "webp" : "jpg";
+      form.append("file", blob, `avatar.${ext}`);
 
       const res = await fetch("/api/me/avatar", { method: "POST", body: form, credentials: "include" });
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? "Upload failed.");
+        throw new Error(
+          body.error ??
+            "Something went wrong saving your photo. Try once more — if it keeps failing, please let us know with the Give Feedback link in the menu.",
+        );
       }
       const { avatarUrl } = (await res.json()) as { avatarUrl: string };
 
@@ -132,7 +153,13 @@ export function AvatarUploader({ name, initialUrl }: { name: string | null; init
       setStatus({ kind: "idle" });
       closeCropper();
     } catch (err) {
-      setStatus({ kind: "error", message: err instanceof Error ? err.message : "Upload failed." });
+      setStatus({
+        kind: "error",
+        message:
+          err instanceof Error
+            ? err.message
+            : "Something went wrong saving your photo. Try once more — if it keeps failing, please let us know with the Give Feedback link in the menu.",
+      });
     }
   };
 
@@ -140,11 +167,20 @@ export function AvatarUploader({ name, initialUrl }: { name: string | null; init
     setStatus({ kind: "busy" });
     try {
       const res = await fetch("/api/me/avatar", { method: "DELETE", credentials: "include" });
-      if (!res.ok) throw new Error("Couldn't remove the photo.");
+      if (!res.ok)
+        throw new Error(
+          "Something went wrong removing your photo. Try once more — if it keeps failing, please let us know with the Give Feedback link in the menu.",
+        );
       setUrl(null);
       setStatus({ kind: "idle" });
     } catch (err) {
-      setStatus({ kind: "error", message: err instanceof Error ? err.message : "Couldn't remove the photo." });
+      setStatus({
+        kind: "error",
+        message:
+          err instanceof Error
+            ? err.message
+            : "Something went wrong removing your photo. Try once more — if it keeps failing, please let us know with the Give Feedback link in the menu.",
+      });
     }
   };
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -494,17 +494,23 @@ const api = new Hono<{ Variables: ApiVariables }>()
 
     const form = await c.req.parseBody().catch(() => null);
     if (!form) {
-      return c.json({ error: "invalid form body" }, 400);
+      return c.json(
+        {
+          error:
+            "We couldn't read that upload. Try once more — if it keeps failing, please let us know with the Give Feedback link in the menu.",
+        },
+        400,
+      );
     }
     const file = form.file;
     if (!(file instanceof File)) {
-      return c.json({ error: "missing file field" }, 400);
+      return c.json({ error: "No image was attached. Please choose a photo." }, 400);
     }
     if (file.size > MAX_AVATAR_UPLOAD_BYTES) {
-      return c.json({ error: "file too large" }, 400);
+      return c.json({ error: "That image is too large. Please choose a smaller photo." }, 400);
     }
     if (!file.type.startsWith("image/")) {
-      return c.json({ error: "file must be an image" }, 400);
+      return c.json({ error: "That file isn't an image. Please choose a JPEG, PNG, or WebP." }, 400);
     }
 
     let webp: Buffer;
@@ -512,7 +518,16 @@ const api = new Hono<{ Variables: ApiVariables }>()
       webp = await encodeAvatar(Buffer.from(await file.arrayBuffer()));
     } catch {
       // sharp throws on bytes that do not decode as an image.
-      return c.json({ error: "could not decode image" }, 400);
+      return c.json({ error: "We couldn't read that image. Please try a JPEG or PNG." }, 400);
+    }
+
+    // A browser that can't encode WebP via canvas.toBlob falls back to
+    // JPEG (the client switches formats; see avatar-uploader.tsx), so a
+    // non-WebP arrival is that fallback firing. Log the rate to size who's
+    // affected — Safari/iOS historically — and to catch a regression.
+    // The received content type is the signal; see docs/doc-axiom.md.
+    if (!file.type.includes("webp")) {
+      log.info("avatar webp fallback", { userId: user.id, receivedType: file.type, bytes: file.size });
     }
 
     // Ensure a profile row exists before pointing it at the object —

--- a/tests/functional/server/avatar.test.ts
+++ b/tests/functional/server/avatar.test.ts
@@ -110,6 +110,20 @@ describe("POST/DELETE /api/me/avatar", () => {
     expect(await objectsFor(userId)).toHaveLength(1);
   });
 
+  it("accepts a JPEG upload (the browser webp-fallback path) and stores it as webp", async () => {
+    // When a browser can't encode WebP via canvas.toBlob, the client
+    // falls back to JPEG (avatar-uploader.tsx). The server must accept
+    // it and canonicalize to the same 1024² webp object as any other.
+    const jpeg = await sharp({ create: { width: 64, height: 64, channels: 3, background: { r: 10, g: 200, b: 90 } } })
+      .jpeg()
+      .toBuffer();
+    const res = await postAvatar(jpeg, "image/jpeg");
+
+    expect(res.status).toBe(200);
+    const [row] = await db.select({ avatarPath: profiles.avatarPath }).from(profiles).where(eq(profiles.id, userId));
+    expect(row.avatarPath).toMatch(new RegExp(`^${userId}/[0-9a-f-]+\\.webp$`));
+  });
+
   it("rejects a non-image content type", async () => {
     const res = await postAvatar(new TextEncoder().encode("not an image"), "text/plain");
     expect(res.status).toBe(400);


### PR DESCRIPTION
Summary: Profile-photo upload no longer fails with a confusing "too
large" error on browsers that can't encode WebP in a canvas.

Why: canvas.toBlob("image/webp") silently falls back to PNG when the
browser can't encode WebP (Safari/iOS historically). A 1024-square
photo as PNG is several MB, which trips the 1 MB upload cap — so the
upload failed however small the member shrank their source. A member
hit exactly this: "too large" even on an 815 KB JPEG.

Behavior:
- The uploader compares the produced blob.type to the type it
  requested; on the silent PNG substitution it re-encodes as JPEG
  (small, lossy, universal). The server still re-encodes to WebP, so
  the stored 1024-square object is unchanged.
- POST /me/avatar logs log.info("avatar webp fallback", { userId,
  receivedType, bytes }) when a non-WebP upload arrives, so the
  fallback rate is queryable in Axiom.
- Error copy reworked: actionable cases (wrong format, too large,
  undecodable) keep specific guidance; genuine failures now say "try
  once more — if it keeps failing, use the Give Feedback link" instead
  of promising a retry will help.

Test Plan:
- ran `npm test` locally — 489 functional (vitest) + 32 e2e
  (Playwright) passed
- new functional test: a JPEG upload (the fallback wire format) is
  accepted and stored as the canonical webp

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
