### PR TITLE
fix(avatar): degrade to initials when Storage signing fails

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-17 | James | Avatar signing degrades instead of 500ing under Storage load
+
+A directory browse prefetched every member card, and each prefetch render signed that member's avatar via a separate Supabase Storage call; the burst exhausted Storage's DB pool (429), which `resolveAvatarUrls` rethrew into a page 500. Signing is now best-effort — it logs `avatar sign failed` and falls back to initials — and member cards no longer prefetch. Shipped urgent (advanced `urgentReleasedAt`) so open tabs reload off the crashing build.
+
 ## 2026-06-16 | James | Update handling for active sessions
 
 The home page auto-reloads a stale tab, everywhere else a persistent bottom banner offers a member-initiated reload. Deploys now fall into one of three tiers: patch (default, notif held until the running build is 6h old, then once per 8h), feature (held until build is 2h old, then once per 8h, dismissible — whenever a changelog is added), urgent (immediate, non-dismissible — gated by `urgentReleasedAt` marker in code).  Full rationale: docs/strategy-deployment.md.

--- a/src/app/members/members-list.tsx
+++ b/src/app/members/members-list.tsx
@@ -13,8 +13,14 @@ import { scoreMember } from "@/lib/member-search";
 function MemberCard({ member }: { member: MemberSummary }) {
   const href: UrlObject = { pathname: `/members/${member.slug ?? member.id}` };
   return (
+    // prefetch={false}: the grid can hold dozens of cards, and Next prefetches
+    // each one's target page server-side — every render signing that member's
+    // avatar via its own Supabase Storage round-trip. That burst can exhaust
+    // Storage's DB pool (429). The list already carries everything a card
+    // shows; defer the per-page work to an actual click.
     <Link
       href={href}
+      prefetch={false}
       className="flex h-full flex-col rounded-sm border border-border hover:bg-muted/50 transition-colors overflow-hidden"
     >
       <Avatar

--- a/src/lib/changelog.tsx
+++ b/src/lib/changelog.tsx
@@ -186,7 +186,7 @@ export const appVersion = changelog[0]?.date ?? "";
 // the same day still compare strictly (the tab tests
 // NEXT_PUBLIC_BUILD_TIME < urgentReleasedAt). The epoch baseline means
 // "no urgent deploy on record."
-export const urgentReleasedAt = "1970-01-01T00:00:00.000Z";
+export const urgentReleasedAt = "2026-06-17T18:31:26.000Z";
 
 // Format an entry's "YYYY-MM-DD" date as e.g. "May 29, 2026". Pinned to
 // UTC so the rendered date matches the string regardless of the

--- a/src/server/avatars.ts
+++ b/src/server/avatars.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
+import { log } from "next-axiom";
 import sharp from "sharp";
 
 import { supabaseAdmin } from "@/lib/supabase/admin";
@@ -50,7 +51,18 @@ export const resolveAvatarUrls = async (
 
   if (misses.length > 0) {
     const { data, error } = await supabaseAdmin.storage.from(AVATAR_BUCKET).createSignedUrls(misses, SIGN_TTL_SECONDS);
-    if (error) throw error;
+    if (error) {
+      // Signing is best-effort. A transient Storage error — most often a
+      // 429 "too many connections" when a burst of renders all sign at
+      // once — must not 500 a page over a decorative avatar. Report it,
+      // then leave the misses unsigned so they fall back to initials.
+      log.error("avatar sign failed", {
+        count: misses.length,
+        message: error.message,
+        statusCode: (error as { statusCode?: string }).statusCode,
+      });
+      return result;
+    }
     for (const row of data ?? []) {
       if (row.error || !row.path || !row.signedUrl) continue;
       signedUrlCache.set(row.path, { url: row.signedUrl, expiresAt: now + CACHE_TTL_MS });

--- a/tests/functional/server/avatar.test.ts
+++ b/tests/functional/server/avatar.test.ts
@@ -12,7 +12,7 @@ import { createServerClient } from "@supabase/ssr";
 
 import { supabaseAdmin } from "@/lib/supabase/admin";
 import app from "@/server/api";
-import { AVATAR_BUCKET, MAX_AVATAR_UPLOAD_BYTES } from "@/server/avatars";
+import { AVATAR_BUCKET, attachAvatarUrls, MAX_AVATAR_UPLOAD_BYTES, resolveAvatarUrls } from "@/server/avatars";
 import { db } from "@/server/db";
 import { profiles } from "@/server/schema";
 
@@ -168,5 +168,37 @@ describe("POST/DELETE /api/me/avatar", () => {
     const [row] = await db.select({ avatarPath: profiles.avatarPath }).from(profiles).where(eq(profiles.id, userId));
     expect(row.avatarPath).toBeNull();
     expect(await objectsFor(userId)).toHaveLength(0);
+  });
+});
+
+describe("resolveAvatarUrls — a Storage failure degrades to initials", () => {
+  it("returns a partial map instead of throwing when a batch sign fails", async () => {
+    // The bug this guards against: a batch-level Storage error — typically a
+    // 429 "too many connections" when a burst of renders all sign at once —
+    // used to throw, 500ing the whole page over a decorative avatar. Signing
+    // is best-effort, so a failure must leave the path unsigned (→ initials).
+    const error = {
+      name: "StorageApiError",
+      message: "Too many connections issued to the database",
+      statusCode: "429",
+    };
+    const fromSpy = vi.spyOn(supabaseAdmin.storage, "from").mockReturnValue({
+      createSignedUrls: vi.fn().mockResolvedValue({ data: null, error }),
+      // biome-ignore lint/suspicious/noExplicitAny: minimal Storage bucket stub
+    } as any);
+
+    try {
+      // A unique path is always a cache miss, so the (mocked, failing) sign runs.
+      const path = `${randomUUID()}/${randomUUID()}.webp`;
+
+      const signed = await resolveAvatarUrls([path]);
+      expect(signed.has(path)).toBe(false);
+
+      // attachAvatarUrls surfaces the miss as a null avatarUrl, not an exception.
+      const [row] = await attachAvatarUrls([{ avatarPath: path }]);
+      expect(row.avatarUrl).toBeNull();
+    } finally {
+      fromSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Summary: A Supabase Storage signing error (429 "too many connections") no longer 500s a page — avatars fall back to initials — and the members grid stops prefetching every member page.

Why: A directory browse prefetched every visible member card; each prefetch server-rendered that member's page and signed their avatar via a separate Storage round-trip. The burst exhausted Storage's DB connection pool, which returned 429. resolveAvatarUrls rethrew it, turning a decorative-avatar hiccup into a Server Components render error (surfaced in Sentry / Vercel logs). Signing an avatar should never be able to take a page down.

Behavior:
- Avatar signing is best-effort: a batch Storage error logs `avatar sign failed` to Axiom and leaves those paths unsigned, so they render as initials instead of failing the render.
- Member-list cards no longer prefetch, removing the signing stampede; the list already carries everything a card shows.
- Ships urgent: advances `urgentReleasedAt`, so open tabs on the crashing build get an immediate, non-dismissible reload (docs/strategy-deployment.md).

Test Plan:
- `npm test` green locally: 503 functional + 35 e2e.
- New functional test asserts a batch signing failure yields a partial map (initials) rather than throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
