### PR TITLE
chore(setup): document + check Windows Supabase port reservation

### DIFF
--- a/docs/doc-local-setup.md
+++ b/docs/doc-local-setup.md
@@ -125,7 +125,7 @@ Stopping is optional — the containers are lightweight and persist safely betwe
 : Docker Desktop must be running. Check `docker ps` to confirm it's up.
 
 **Port conflicts**
-: Ports 54321–54324 and 3000 must be free. Stop other Supabase projects or local Postgres instances that may be using them.
+: Ports 54321–54327 and 3000 must be free. Stop other Supabase projects or local Postgres instances that may be using them. On Windows, a `supabase start` `Error status 404` rollback usually means a process grabbed `54321` from the ephemeral range — reserve the span once (see [setup-dev-machine.md](setup-dev-machine.md#windows-reserve-the-local-supabase-ports)).
 
 **Migration errors on startup**
 : The `dev:db` script treats migration failures as non-fatal (`|| true`). If you see schema-related errors in the app, run `npx drizzle-kit migrate` manually to see the error output.

--- a/docs/setup-dev-machine.md
+++ b/docs/setup-dev-machine.md
@@ -38,6 +38,32 @@ Install from [docker.com/products/docker-desktop](https://www.docker.com/product
 
 Docker Desktop must be **running** before `npm run dev` — the dev script starts Supabase containers automatically.
 
+### Windows: reserve the local Supabase ports
+
+The local Supabase stack binds a fixed span of 7 ports, `54321–54327` (API gateway, Postgres, Studio, Inbucket, and analytics at `54327`; `54325`/`54326` are unused gaps). On Windows these fall inside the *ephemeral* range (`49152–65535`), so another process can be auto-assigned one — `54321` (the API gateway / Kong) in particular — before Docker binds it. (Nothing else needs reserving: the dev server `3000` and inspector `8083` sit below the ephemeral range — a `3000` clash is instead a visible "port in use" from a server you started — and the shadow DB `54320` and pooler `54329` are in-range but not host-bound.) `supabase start` then health-checks the squatter, gets an `Error status 404`, and rolls the whole stack back. Every container was healthy; the rollback killed them. `--ignore-health-check` does not bypass it (the failing call is in post-start setup, not the health loop).
+
+Reserve the block once so Windows never hands those ports out. With the stack stopped (`npm run dev:db:stop`) and any port holder closed, in an **elevated** PowerShell:
+
+```powershell
+netsh int ipv4 add excludedportrange protocol=tcp startport=54321 numberofports=7
+```
+
+Verify — `54321 → 54327` should be listed:
+
+```powershell
+netsh int ipv4 show excludedportrange protocol=tcp
+```
+
+Explicit Docker binds still succeed on reserved ports; only automatic ephemeral hand-out is blocked. The reservation survives reboots, and `npm run setup` re-checks it and reprints this command if it's missing.
+
+**Diagnosing a 404-rollback:** with the stack stopped, `curl http://127.0.0.1:54321/anything` still returning a 404 proves a non-Supabase process owns the port. Identify it with:
+
+```powershell
+Get-Process -Id (Get-NetTCPConnection -LocalPort 54321 -State Listen).OwningProcess
+```
+
+**Worktree lanes** shift the span by `N×100` (lane 2 → `54521–54527`, lane 3 → `54621–54627`, …) and each need their own reservation; `npm run make_lane_inside_worktree` prints the exact `netsh` command for the lane. See [strategy-worktree-lanes.md](strategy-worktree-lanes.md).
+
 ## Git
 
 **Windows:** Install from [git-scm.com](https://git-scm.com/). Includes Git Bash.

--- a/docs/strategy-worktree-lanes.md
+++ b/docs/strategy-worktree-lanes.md
@@ -112,9 +112,9 @@ session *and* an e2e run at once, use two lanes (each lane is one Supabase stack
   loop cliffs after ~5. If a lane's `.next` wedges, delete it to rebuild.
 - **Stop a lane's stack:** `npm run dev:db:stop` from that worktree.
 - **Remove a lane:** `git worktree remove ../is-app-worktrees/is-app-2`.
-- **Windows port grabbing:** reserve a lane's Supabase block once in an admin
-  shell (the script prints the exact command):
-  `netsh int ipv4 add excludedportrange protocol=tcp startport=54520 numberofports=10`.
+- **Windows port grabbing:** reserve a lane's Supabase ports once in an admin
+  shell (the script prints the exact command — lane 2 shown):
+  `netsh int ipv4 add excludedportrange protocol=tcp startport=54521 numberofports=7`.
 - **If `config.toml` changes upstream:** because the file is `--skip-worktree`
   in lanes, a pull won't update it there. Run `git update-index
   --no-skip-worktree supabase/config.toml`, pull, then re-run

--- a/scripts/make-lane-inside-worktree.mjs
+++ b/scripts/make-lane-inside-worktree.mjs
@@ -200,5 +200,5 @@ if (skip.status !== 0) {
 process.stdout.write(`${summary}\n\nConfigured. Start it with:  npm run dev\n`);
 process.stdout.write(
   `Windows only — reserve this lane's Supabase ports (admin shell, once):\n` +
-    `  netsh int ipv4 add excludedportrange protocol=tcp startport=${SUPABASE_PORTS.shadow.base + off} numberofports=10\n`,
+    `  netsh int ipv4 add excludedportrange protocol=tcp startport=${SUPABASE_PORTS.api.base + off} numberofports=7\n`,
 );

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -3,8 +3,8 @@
 // Extend by adding more step functions below and calling them from main().
 
 import { spawnSync } from "node:child_process";
-import { copyFileSync, existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { copyFileSync, existsSync, readFileSync } from "node:fs";
+import { basename, resolve } from "node:path";
 
 const repoRoot = resolve(import.meta.dirname, "..");
 
@@ -59,6 +59,72 @@ function ensureLocalEnv() {
   console.log("  created .env.local from .env.local.example");
 }
 
+// The base Supabase stack binds 7 contiguous host ports, 54321–54327 (API,
+// Postgres, Studio, Inbucket, and analytics at 54327; 54325/54326 are unused
+// gaps). The shadow DB (54320) is only spun up transiently for `db diff` and
+// the pooler (54329) is disabled, so neither is host-bound and neither needs
+// reserving. Lanes shift this span by N*100 and get their reservation reminder
+// from make_lane_inside_worktree (it knows the lane's ports at assignment), so
+// this check runs in the base worktree only.
+const SUPABASE_API_PORT = 54321;
+const SUPABASE_BLOCK_SIZE = 7;
+
+// A lane worktree is named "<package>-N" (e.g. is-app-2); the base worktree's
+// directory matches the package name. Same signal make-lane-inside-worktree.mjs
+// uses to derive the lane.
+function isBaseWorktree() {
+  const baseName = JSON.parse(readFileSync(resolve(repoRoot, "package.json"), "utf8")).name;
+  return basename(repoRoot) === baseName;
+}
+
+function checkWindowsSupabasePortReservation() {
+  // Windows hands out 49152–65535 as ephemeral ports, and the 54321–54327 span
+  // sits inside that range. If a process grabs the API/Kong port before Docker
+  // binds it, `supabase start` health-checks the squatter, gets a 404, and
+  // rolls the whole stack back (issue #345). Reserving the span stops Windows
+  // from auto-assigning those ports. This is detect-and-recommend only: the
+  // `netsh add` needs an elevated shell and the ports free, so we never run it.
+  const blockStart = SUPABASE_API_PORT;
+  const blockEnd = blockStart + SUPABASE_BLOCK_SIZE - 1;
+
+  const res = spawnSync("netsh", ["int", "ipv4", "show", "excludedportrange", "protocol=tcp"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (res.status !== 0 || typeof res.stdout !== "string") {
+    console.log("  couldn't read reserved ranges via netsh — skipping (advisory only)");
+    return;
+  }
+
+  // Each data row is "<startPort> <endPort>", sometimes with a trailing "*"
+  // marking an administered (admin-added) exclusion — match the two leading
+  // numbers and ignore the rest of the line. The union of rows is reserved.
+  const ranges = [];
+  for (const line of res.stdout.split("\n")) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\b/);
+    if (m) ranges.push([Number(m[1]), Number(m[2])]);
+  }
+  const isReserved = (p) => ranges.some(([s, e]) => p >= s && p <= e);
+
+  // Any bound port in this span grabbed from the ephemeral range breaks
+  // startup. 54321/Kong is the worst (silent 404-rollback); the rest fail
+  // louder but still fail. List what's still open.
+  const open = [];
+  for (let p = blockStart; p <= blockEnd; p++) if (!isReserved(p)) open.push(p);
+
+  if (open.length === 0) {
+    console.log(`  Supabase ports ${blockStart}–${blockEnd} are reserved — good.`);
+    return;
+  }
+  console.log(
+    `  Supabase ports ${blockStart}–${blockEnd} are not fully reserved (open: ${open.join(", ")}).\n` +
+      `  Windows can grab one — e.g. ${blockStart}/Kong — and 404-roll the stack on start.\n` +
+      `  Reserve the span ONCE in an elevated PowerShell (stack stopped; survives reboots):\n` +
+      `    netsh int ipv4 add excludedportrange protocol=tcp startport=${blockStart} numberofports=${SUPABASE_BLOCK_SIZE}\n` +
+      `  Details: docs/setup-dev-machine.md`,
+  );
+}
+
 function main() {
   console.log("Setting up is-app for local development...\n");
 
@@ -70,6 +136,15 @@ function main() {
 
   console.log("\n3. Git blame ignore-revs config");
   ensureGitBlameIgnoreConfig();
+
+  if (process.platform === "win32") {
+    console.log("\n4. Windows Supabase port reservation (advisory)");
+    if (isBaseWorktree()) {
+      checkWindowsSupabasePortReservation();
+    } else {
+      console.log("  lane worktree — `npm run make_lane_inside_worktree` prints this lane's reservation command.");
+    }
+  }
 
   console.log("\nDone. Next: run `npm run dev` (Docker Desktop must be running).");
 }


### PR DESCRIPTION
Summary: Document the Windows netsh reservation for the local Supabase
ports and have `npm run setup` flag it, so the `supabase start`
404-rollback stops surprising Windows devs.

Why: On Windows the stack's ports 54321-54327 sit inside the ephemeral
range (49152-65535), so another process can be auto-assigned 54321/Kong
before Docker binds it. `supabase start` then health-checks the squatter,
gets a 404, and silently rolls the whole stack back -- looking like a
corrupted install rather than a port collision.

Behavior:
- docs/setup-dev-machine.md gains a Windows section: the
  `netsh ... startport=54321 numberofports=7` reservation, the verify
  command, the curl/Get-Process diagnosis, and a worktree-lane note.
- `npm run setup` adds a Windows-only, read-only step 4. In the base
  worktree it reports whether 54321-54327 are reserved and prints the
  netsh command if not; in a lane worktree it defers to
  make_lane_inside_worktree (which owns the lane's reservation).
- The reservation is the precise 7 host-bound ports (54321-54327),
  starting at the API port -- shadow 54320 and pooler 54329 aren't
  host-bound. make_lane and the lanes/local-setup docs match.

Test Plan:
- ran `npm test` locally on the rebased branch -- lint, typecheck,
  510 functional + 37 e2e all pass
- exercised `npm run setup` in a lane worktree (defers to make_lane) and
  confirmed the base-worktree branch reports "54321-54327 reserved"
  against the live netsh exclusion table

Closes #345

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
