### PR TITLE
chore(observability): log auth-callback failures, keep prepare:false

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-17 | James | #149 audit: auth-callback redemption holds in prod; keep `prepare: false`, add Axiom logging
+
+A three-window audit of the still-unhardened invited-sign-in transaction found zero #149 occurrences: 22/22 prod redemptions clean on a DB integrity check, a normal auth/profile gap, and an empty Sentry `25P02` history (error capture works — #152 is only about missing perf transactions). Kept `prepare: false` (limbo resolved) and instrumented the failure redirect with `log.warn "invite redemption failed"` so the path is queryable in Axiom; pattern-2 hardening deferred until/unless it fires. (#149)
+
 ## 2026-06-17 | James | Per-page HTML titles for usable tab names and browser history
 
 Root layout sets `title.template = "IS Web: %s"`. Per-page titles live in one `src/lib/page-titles.ts` dictionary that feeds both each page's `metadata.title` and the breadcrumb back-labels (which no longer keep a separate list); detail pages set the entity name via `generateMetadata`. New pages add a dictionary entry. (#425)

--- a/docs/strategy-db-transactions.md
+++ b/docs/strategy-db-transactions.md
@@ -276,7 +276,9 @@ This is the `#149` bug. A single `await db.insert(...)` is fine; the
 postgres-js options worth knowing: `max` (pool size), `idle_timeout` (close idle
 connections — the key to bounding session-mode backends), `prepare` (defaults
 true; harmless on the transaction pooler in practice — Supavisor emulates
-prepared-statement support).
+prepared-statement support). The default `db` client nonetheless sets
+`prepare: false` as a #149 variable-reduction measure, kept after the 2026-06
+audit found the redemption path clean under it — see the comment in `db.ts`.
 
 ## Recognizing this in the wild
 
@@ -295,7 +297,7 @@ Keep this current as transactions are added or changed.
 |---|---|
 | `resetE2EUsers` (`src/server/test-reset.ts`) | Fixed — `db.transaction` dropped; two autocommit statements (it never needed atomicity). |
 | `createInvite` (`src/server/invites.ts`) | Hardened — pattern 1 (writable CTE): invite + hint rows written in one statement, no transaction. |
-| invited sign-in (`src/app/auth/callback/route.ts`) | Exposed — needs atomicity (profile insert + invite redemption + relations). Candidate for pattern 2 or 3. Not yet hardened. |
+| invited sign-in (`src/app/auth/callback/route.ts`) | Exposed but monitored — multi-statement txn (profile insert + invite redemption + relations). A 2026-06 audit found **zero** occurrences across all 22 prod redemptions (DB integrity check), a normal auth/profile gap, and an empty Sentry `25P02` history; the redirect is now instrumented (`log.warn "invite redemption failed"`, queryable in Axiom). Left as-is under `prepare: false`; pattern 2 (a `redeem_invite` function) is the fix if it ever fires. |
 
 ## References
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 import { and, eq, gt, isNull, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
+import { log } from "next-axiom";
 
 import { createClient } from "@/lib/supabase/server";
 import { db } from "@/server/db";
@@ -133,7 +134,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
       result = await upsertProfile(data.user);
     } catch (err) {
-      Sentry.captureException(err);
+      Sentry.captureException(err, {
+        tags: { feature: "auth-callback", path: "profile-upsert" },
+        extra: { userId: data.user.id },
+      });
+      log.warn("profile upsert failed", {
+        userId: data.user.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      await log.flush();
       return NextResponse.redirect(new URL("/signin?error=profile_error", request.url), 303);
     }
     if (result.created) {
@@ -220,7 +229,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Anything other than InviteInvalid (the routine "code already
     // redeemed/expired" path) is a real Postgres/transaction failure —
     // capture it instead of swallowing it behind the generic redirect.
-    Sentry.captureException(err);
+    // Also log to Axiom: this route isn't under the Hono request logger
+    // and the failure leaves a 303 (not a 5xx), so without this the
+    // "did a redemption ever fail in prod?" question has no answer there.
+    // `pgCode` surfaces the SQLSTATE (e.g. 25P02) the #149 pooler hazard
+    // would raise.
+    Sentry.captureException(err, {
+      tags: { feature: "auth-callback", path: "invite-redemption" },
+      extra: { inviteCode: invite, userId },
+    });
+    log.warn("invite redemption failed", {
+      inviteCode: invite,
+      userId,
+      error: err instanceof Error ? err.message : String(err),
+      pgCode: err instanceof Error ? (err as Error & { code?: string }).code : undefined,
+    });
+    await log.flush();
     return NextResponse.redirect(new URL("/signin?error=profile_error", request.url), 303);
   }
 

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -20,12 +20,14 @@ declare global {
   var __pgClient: ReturnType<typeof postgres> | undefined;
 }
 
-// `prepare: false` — Variable reduction for #149. Supavisor's
-// transaction-pooler prepared-statement support is "partial" (see the
-// FAQ + supavisor#239). If a per-connection prepared-statement cache
-// in postgres-js is interacting badly with Supavisor re-preparing
-// against fresh backends, dropping prepared statements could eliminate
-// the issue. May revert if no difference.
+// `prepare: false` — kept deliberately. Supavisor's transaction-pooler
+// prepared-statement support is only "partial" (Supabase FAQ +
+// supavisor#239); dropping prepared statements removes a plausible #149
+// aggravator (postgres-js re-preparing against rotating backends) at no
+// measured cost — Supavisor emulates them anyway. A 2026-06 audit of the
+// auth-callback redemption path found zero #149 occurrences in prod under
+// this setting, so we keep it rather than re-introduce the variable.
+// See docs/strategy-db-transactions.md.
 const client = globalThis.__pgClient ?? postgres(connectionString, { prepare: false });
 if (process.env.NODE_ENV !== "production") {
   globalThis.__pgClient = client;


### PR DESCRIPTION
Summary: The auth-callback profile-write failure paths now emit structured
Axiom logs and enriched Sentry captures, and db.ts records the decision to
keep `prepare: false`.

Why: The #149 transaction-pooler hazard is still structurally present on the
invited-sign-in transaction, but its failure redirect — a 303 on a route
outside the Hono request logger — was invisible to Axiom, so answering "did a
redemption ever fail in prod?" took three dashboards. A 2026-06 audit found
zero occurrences across all 22 prod redemptions (DB integrity check, normal
auth/profile gap, empty Sentry 25P02 history), so the path is kept under
`prepare: false` and monitored rather than hardened now.

Behavior:
- On a profile-upsert or invite-redemption failure, the route emits log.warn
  ("profile upsert failed" / "invite redemption failed") to Axiom — the
  redemption event carries pgCode (SQLSTATE) — and flushes before the 303,
  since this route isn't under the middleware that auto-flushes.
- Both Sentry.captureException calls gain feature/path tags and extra context,
  matching the buttondown-runner dual-sink idiom.
- No change to the success path or any user-facing behavior.
- db.ts keeps `prepare: false` with its rationale documented;
  strategy-db-transactions.md updates the transaction inventory and prepare
  note; a devjournal entry records the audit.

Test Plan:
- ran `npm test` locally — functional + e2e (37) all green

(#149)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

