### PR TITLE
fix: center initials and circle-crop avatars in programs facepile (#426)

### DIFF
--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -79,7 +79,7 @@ function ProgramCard({
                 name={member.displayName}
                 url={member.avatarUrl}
                 sizes="28px"
-                className="h-full w-full rounded-full text-[10px]"
+                className="flex h-full w-full items-center justify-center overflow-hidden rounded-full text-[10px] font-semibold text-muted-foreground"
               />
             </div>
           ))}


### PR DESCRIPTION
## Summary

The programs list facepile rendered no-avatar members with their initials jammed into the top-left corner, poking out of the grey circle. Real avatars also weren't clipped to the circle.

The facepile's `<Avatar>` was the only one of ~12 call sites missing `flex items-center justify-center overflow-hidden`. Adding it centers the initials and circle-crops avatar images, matching every other Avatar usage. This is option 1 from the issue.

UI-only change — one className in `programs-list.tsx`, no backend, schema, or API changes.

## Test plan

- [ ] Go to `/programs` — a program card with an avatarless member shows the initial centered in the grey circle (not poking out the top-left)
- [ ] A member with a profile photo renders cleanly circle-cropped
- [ ] CI lint + functional tests pass

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)