### PR TITLE
feat: program key facts — schedule, facilitator, duration, etc.

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-18 | Ola | Programs gain key-facts fields
+
+Programs now carry five optional key facts — schedule, duration, commitment, facilitator, and contact — set by admins (create + edit) and shown to members on the list card and the detail page. Additive expand (one migration, five nullable columns); the prod schema is expanded ahead of merge via the gated `prod:db:expand`, so the merge-deploy migrate is a no-op.
+
 ## 2026-06-18 | James | Rich text: markdown storage, react-markdown render, MDXEditor authoring
 
 Program copy (`description`/`blurb`) and member prose (`bio`/`currentIntention`/`supplementaryInfo`) are now formatted: stored as markdown in the existing `text` columns (no migration), rendered by a shared `<Markdown>` (full + constrained-inline variants, react-markdown + remark-gfm, no rehype-raw → XSS-safe), and authored in a lazy `ssr:false` MDXEditor (full + inline configs). See docs/design-richtext.md. (#432)

--- a/drizzle/0016_tense_wong.sql
+++ b/drizzle/0016_tense_wong.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "programs" ADD COLUMN "schedule" text;--> statement-breakpoint
+ALTER TABLE "programs" ADD COLUMN "duration" text;--> statement-breakpoint
+ALTER TABLE "programs" ADD COLUMN "commitment" text;--> statement-breakpoint
+ALTER TABLE "programs" ADD COLUMN "facilitator" text;--> statement-breakpoint
+ALTER TABLE "programs" ADD COLUMN "contact" text;

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,764 @@
+{
+  "id": "5d4f753f-2b80-4f43-bfe5-054bdffef99a",
+  "prevId": "96f29156-ad2c-45a6-b3a4-dfe339e39691",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_hints": {
+      "name": "invite_hints",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_hints_invite_id_invites_id_fk": {
+          "name": "invite_hints_invite_id_invites_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "invites",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_hints_ratee_id_profiles_id_fk": {
+          "name": "invite_hints_ratee_id_profiles_id_fk",
+          "tableFrom": "invite_hints",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_hints_invite_id_ratee_id_pk": {
+          "name": "invite_hints_invite_id_ratee_id_pk",
+          "columns": [
+            "invite_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by": {
+          "name": "redeemed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_value": {
+          "name": "creator_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_profiles_id_fk": {
+          "name": "invites_created_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_profiles_id_fk": {
+          "name": "invites_redeemed_by_profiles_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "redeemed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_redemption_pair": {
+          "name": "invites_redemption_pair",
+          "value": "(\"invites\".\"redeemed_by\" IS NULL) = (\"invites\".\"redeemed_at\" IS NULL)"
+        },
+        "invites_expires_after_created": {
+          "name": "invites_expires_after_created",
+          "value": "\"invites\".\"expires_at\" > \"invites\".\"created_at\""
+        },
+        "invites_creator_value_range": {
+          "name": "invites_creator_value_range",
+          "value": "\"invites\".\"creator_value\" IS NULL OR (\"invites\".\"creator_value\" BETWEEN 1 AND 4)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.profile_programs": {
+      "name": "profile_programs",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_programs_profile_id_profiles_id_fk": {
+          "name": "profile_programs_profile_id_profiles_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_programs_program_id_programs_id_fk": {
+          "name": "profile_programs_program_id_programs_id_fk",
+          "tableFrom": "profile_programs",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_programs_profile_id_program_id_pk": {
+          "name": "profile_programs_profile_id_program_id_pk",
+          "columns": [
+            "profile_id",
+            "program_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplementary_info": {
+          "name": "supplementary_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by": {
+          "name": "referred_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by_legacy": {
+          "name": "referred_by_legacy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_signed_agreements": {
+          "name": "last_signed_agreements",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_profile": {
+          "name": "last_updated_profile",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reviewed_programs": {
+          "name": "last_reviewed_programs",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_intention": {
+          "name": "current_intention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intention_updated_at": {
+          "name": "intention_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_web": {
+          "name": "last_updated_web",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttondown_subscriber_id": {
+          "name": "buttondown_subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_password": {
+          "name": "has_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profiles_referred_by_profiles_id_fk": {
+          "name": "profiles_referred_by_profiles_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "referred_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_slug_unique": {
+          "name": "profiles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blurb": {
+          "name": "blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commitment": {
+          "name": "commitment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facilitator": {
+          "name": "facilitator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signups_open": {
+          "name": "signups_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "buttondown_tag": {
+          "name": "buttondown_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_slug_unique": {
+          "name": "programs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "rater_id": {
+          "name": "rater_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ratee_id": {
+          "name": "ratee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hint": {
+          "name": "is_hint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hinted_by": {
+          "name": "hinted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "relations_rater_id_profiles_id_fk": {
+          "name": "relations_rater_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "rater_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_ratee_id_profiles_id_fk": {
+          "name": "relations_ratee_id_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "ratee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "relations_hinted_by_profiles_id_fk": {
+          "name": "relations_hinted_by_profiles_id_fk",
+          "tableFrom": "relations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "hinted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "relations_rater_id_ratee_id_pk": {
+          "name": "relations_rater_id_ratee_id_pk",
+          "columns": [
+            "rater_id",
+            "ratee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relations_no_self": {
+          "name": "relations_no_self",
+          "value": "\"relations\".\"rater_id\" != \"relations\".\"ratee_id\""
+        },
+        "relations_value_range": {
+          "name": "relations_value_range",
+          "value": "\"relations\".\"value\" IS NULL OR (\"relations\".\"value\" BETWEEN 1 AND 4)"
+        },
+        "relations_hint_state": {
+          "name": "relations_hint_state",
+          "value": "(NOT \"relations\".\"is_hint\" AND \"relations\".\"value\" IS NOT NULL)\n       OR (\"relations\".\"is_hint\" AND \"relations\".\"value\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.sync_locks": {
+      "name": "sync_locks",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_by": {
+          "name": "acquired_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1781525261129,
       "tag": "0015_mean_crusher_hogan",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1781867445085,
+      "tag": "0016_tense_wong",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/admin/programs/[id]/program-detail.tsx
+++ b/src/app/admin/programs/[id]/program-detail.tsx
@@ -56,6 +56,11 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
   const [name, setName] = useState(program.name);
   const [slug, setSlug] = useState(program.slug);
   const [blurb, setBlurb] = useState(program.blurb ?? "");
+  const [schedule, setSchedule] = useState(program.schedule ?? "");
+  const [duration, setDuration] = useState(program.duration ?? "");
+  const [commitment, setCommitment] = useState(program.commitment ?? "");
+  const [facilitator, setFacilitator] = useState(program.facilitator ?? "");
+  const [contact, setContact] = useState(program.contact ?? "");
   const [description, setDescription] = useState(program.description ?? "");
   const [buttondownTag, setButtondownTag] = useState(program.buttondownTag ?? "");
   const [editError, setEditError] = useState<string | null>(null);
@@ -70,6 +75,11 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
       name?: string;
       slug?: string;
       blurb?: string | null;
+      schedule?: string | null;
+      duration?: string | null;
+      commitment?: string | null;
+      facilitator?: string | null;
+      contact?: string | null;
       description?: string | null;
       archived?: boolean;
       signupsOpen?: boolean;
@@ -177,6 +187,11 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
     trimmedName !== program.name ||
     trimmedSlug !== program.slug ||
     blurb.trim() !== (program.blurb ?? "") ||
+    schedule.trim() !== (program.schedule ?? "") ||
+    duration.trim() !== (program.duration ?? "") ||
+    commitment.trim() !== (program.commitment ?? "") ||
+    facilitator.trim() !== (program.facilitator ?? "") ||
+    contact.trim() !== (program.contact ?? "") ||
     description.trim() !== (program.description ?? "") ||
     trimmedButtondownTag !== (program.buttondownTag ?? "");
 
@@ -193,6 +208,11 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
       name: trimmedName,
       slug: trimmedSlug,
       blurb: blurb.trim() || null,
+      schedule: schedule.trim() || null,
+      duration: duration.trim() || null,
+      commitment: commitment.trim() || null,
+      facilitator: facilitator.trim() || null,
+      contact: contact.trim() || null,
       description: description.trim() || null,
       buttondownTag: trimmedButtondownTag || null,
     });
@@ -237,6 +257,56 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
             placeholder="One sentence shown on the program card"
           />
           <p className="text-xs text-muted-foreground">Short tagline shown on the programs list. Max 200 characters.</p>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-schedule">Schedule</Label>
+          <Input
+            id="program-schedule"
+            value={schedule}
+            onChange={(e) => setSchedule(e.target.value)}
+            disabled={updateMutation.isPending}
+            placeholder="e.g. Tuesdays 7pm UTC"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-duration">Duration</Label>
+          <Input
+            id="program-duration"
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+            disabled={updateMutation.isPending}
+            placeholder="e.g. 6 weeks"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-commitment">Commitment</Label>
+          <Input
+            id="program-commitment"
+            value={commitment}
+            onChange={(e) => setCommitment(e.target.value)}
+            disabled={updateMutation.isPending}
+            placeholder="e.g. ~2 hrs/week"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-facilitator">Facilitator</Label>
+          <Input
+            id="program-facilitator"
+            value={facilitator}
+            onChange={(e) => setFacilitator(e.target.value)}
+            disabled={updateMutation.isPending}
+            placeholder="e.g. James Baker"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-contact">Contact for questions</Label>
+          <Input
+            id="program-contact"
+            value={contact}
+            onChange={(e) => setContact(e.target.value)}
+            disabled={updateMutation.isPending}
+            placeholder="e.g. james@intentionalsociety.org"
+          />
         </div>
         <div className="flex flex-col gap-1.5">
           <Label>Full description</Label>

--- a/src/app/admin/programs/[id]/program-detail.tsx
+++ b/src/app/admin/programs/[id]/program-detail.tsx
@@ -305,7 +305,7 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
             value={contact}
             onChange={(e) => setContact(e.target.value)}
             disabled={updateMutation.isPending}
-            placeholder="e.g. james@intentionalsociety.org"
+            placeholder="e.g. questions@intentionalsociety.org"
           />
         </div>
         <div className="flex flex-col gap-1.5">

--- a/src/app/admin/programs/programs-admin.tsx
+++ b/src/app/admin/programs/programs-admin.tsx
@@ -24,13 +24,27 @@ export function ProgramsAdmin() {
   const queryClient = useQueryClient();
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
+  const [schedule, setSchedule] = useState("");
+  const [duration, setDuration] = useState("");
+  const [commitment, setCommitment] = useState("");
+  const [facilitator, setFacilitator] = useState("");
+  const [contact, setContact] = useState("");
   const [description, setDescription] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const programsQuery = useQuery({ queryKey: PROGRAMS_QUERY_KEY, queryFn: fetchPrograms });
 
   const createMutation = useMutation({
-    mutationFn: async (vars: { name: string; slug: string; description: string | null }) => {
+    mutationFn: async (vars: {
+      name: string;
+      slug: string;
+      schedule: string | null;
+      duration: string | null;
+      commitment: string | null;
+      facilitator: string | null;
+      contact: string | null;
+      description: string | null;
+    }) => {
       const res = await apiClient.api.admin.programs.$post({ json: vars });
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string };
@@ -45,6 +59,11 @@ export function ProgramsAdmin() {
     onSuccess: () => {
       setName("");
       setSlug("");
+      setSchedule("");
+      setDuration("");
+      setCommitment("");
+      setFacilitator("");
+      setContact("");
       setDescription("");
       setErrorMessage(null);
       queryClient.invalidateQueries({ queryKey: PROGRAMS_QUERY_KEY });
@@ -68,6 +87,11 @@ export function ProgramsAdmin() {
     createMutation.mutate({
       name: trimmedName,
       slug: trimmedSlug,
+      schedule: schedule.trim() || null,
+      duration: duration.trim() || null,
+      commitment: commitment.trim() || null,
+      facilitator: facilitator.trim() || null,
+      contact: contact.trim() || null,
       description: description.trim() || null,
     });
   };
@@ -96,6 +120,56 @@ export function ProgramsAdmin() {
             disabled={createMutation.isPending}
           />
           <p className="text-xs text-muted-foreground">Used in URLs — lowercase letters, numbers, and hyphens.</p>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-schedule">Schedule</Label>
+          <Input
+            id="program-schedule"
+            value={schedule}
+            onChange={(e) => setSchedule(e.target.value)}
+            disabled={createMutation.isPending}
+            placeholder="e.g. Tuesdays 7pm UTC"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-duration">Duration</Label>
+          <Input
+            id="program-duration"
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+            disabled={createMutation.isPending}
+            placeholder="e.g. 6 weeks"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-commitment">Commitment</Label>
+          <Input
+            id="program-commitment"
+            value={commitment}
+            onChange={(e) => setCommitment(e.target.value)}
+            disabled={createMutation.isPending}
+            placeholder="e.g. ~2 hrs/week"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-facilitator">Facilitator</Label>
+          <Input
+            id="program-facilitator"
+            value={facilitator}
+            onChange={(e) => setFacilitator(e.target.value)}
+            disabled={createMutation.isPending}
+            placeholder="e.g. James Baker"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="program-contact">Contact for questions</Label>
+          <Input
+            id="program-contact"
+            value={contact}
+            onChange={(e) => setContact(e.target.value)}
+            disabled={createMutation.isPending}
+            placeholder="e.g. james@intentionalsociety.org"
+          />
         </div>
         <div className="flex flex-col gap-1.5">
           {/* Editor renders a contenteditable div (no labelable control), so the

--- a/src/app/admin/programs/programs-admin.tsx
+++ b/src/app/admin/programs/programs-admin.tsx
@@ -168,7 +168,7 @@ export function ProgramsAdmin() {
             value={contact}
             onChange={(e) => setContact(e.target.value)}
             disabled={createMutation.isPending}
-            placeholder="e.g. james@intentionalsociety.org"
+            placeholder="e.g. questions@intentionalsociety.org"
           />
         </div>
         <div className="flex flex-col gap-1.5">

--- a/src/app/programs/[slug]/program-slug-detail.tsx
+++ b/src/app/programs/[slug]/program-slug-detail.tsx
@@ -96,6 +96,41 @@ function ProgramBody({ program }: { program: ProgramDetail }) {
         </p>
       </header>
 
+      {(program.facilitator || program.schedule || program.duration || program.commitment || program.contact) && (
+        <dl className="flex flex-col gap-1.5 text-sm">
+          {program.facilitator && (
+            <div className="flex gap-3">
+              <dt className="w-24 shrink-0 text-muted-foreground">Facilitator</dt>
+              <dd>{program.facilitator}</dd>
+            </div>
+          )}
+          {program.schedule && (
+            <div className="flex gap-3">
+              <dt className="w-24 shrink-0 text-muted-foreground">Schedule</dt>
+              <dd>{program.schedule}</dd>
+            </div>
+          )}
+          {program.duration && (
+            <div className="flex gap-3">
+              <dt className="w-24 shrink-0 text-muted-foreground">Duration</dt>
+              <dd>{program.duration}</dd>
+            </div>
+          )}
+          {program.commitment && (
+            <div className="flex gap-3">
+              <dt className="w-24 shrink-0 text-muted-foreground">Commitment</dt>
+              <dd>{program.commitment}</dd>
+            </div>
+          )}
+          {program.contact && (
+            <div className="flex gap-3">
+              <dt className="w-24 shrink-0 text-muted-foreground">Questions</dt>
+              <dd>{program.contact}</dd>
+            </div>
+          )}
+        </dl>
+      )}
+
       {program.description && <Markdown>{program.description}</Markdown>}
 
       <div className="flex items-center gap-3">

--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -70,6 +70,12 @@ function ProgramCard({
         <MarkdownInline className="font-serif text-sm text-muted-foreground leading-relaxed">{cardText}</MarkdownInline>
       )}
 
+      {(program.duration || program.schedule || program.commitment) && (
+        <p className="text-xs text-muted-foreground">
+          {[program.duration, program.schedule, program.commitment].filter(Boolean).join(" · ")}
+        </p>
+      )}
+
       {/* Facepile and action button are bottom-pinned together so the
           avatar row lands on the same baseline across cards regardless of
           how long each card's blurb runs. */}

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -49,6 +49,11 @@ export type ProgramWithMembership = {
   slug: string;
   name: string;
   blurb: string | null;
+  schedule: string | null;
+  duration: string | null;
+  commitment: string | null;
+  facilitator: string | null;
+  contact: string | null;
   description: string | null;
   signupsOpen: boolean;
   memberCount: number;
@@ -77,6 +82,11 @@ export const listPrograms = async (userId: string): Promise<ProgramWithMembershi
       slug: programs.slug,
       name: programs.name,
       blurb: programs.blurb,
+      schedule: programs.schedule,
+      duration: programs.duration,
+      commitment: programs.commitment,
+      facilitator: programs.facilitator,
+      contact: programs.contact,
       description: programs.description,
       signupsOpen: programs.signupsOpen,
       memberCount: sql<number>`(
@@ -249,6 +259,11 @@ export type ProgramDetailForMember = {
   slug: string;
   name: string;
   blurb: string | null;
+  schedule: string | null;
+  duration: string | null;
+  commitment: string | null;
+  facilitator: string | null;
+  contact: string | null;
   description: string | null;
   signupsOpen: boolean;
   memberCount: number;
@@ -267,6 +282,11 @@ export const getProgramBySlug = async (
       slug: programs.slug,
       name: programs.name,
       blurb: programs.blurb,
+      schedule: programs.schedule,
+      duration: programs.duration,
+      commitment: programs.commitment,
+      facilitator: programs.facilitator,
+      contact: programs.contact,
       description: programs.description,
       signupsOpen: programs.signupsOpen,
       archivedAt: programs.archivedAt,
@@ -308,6 +328,11 @@ export const getProgramBySlug = async (
       slug: program.slug,
       name: program.name,
       blurb: program.blurb,
+      schedule: program.schedule,
+      duration: program.duration,
+      commitment: program.commitment,
+      facilitator: program.facilitator,
+      contact: program.contact,
       description: program.description,
       signupsOpen: program.signupsOpen,
       memberCount: members.length,
@@ -330,6 +355,11 @@ export type AdminProgram = {
   slug: string;
   name: string;
   blurb: string | null;
+  schedule: string | null;
+  duration: string | null;
+  commitment: string | null;
+  facilitator: string | null;
+  contact: string | null;
   description: string | null;
   archivedAt: string | null;
   signupsOpen: boolean;
@@ -351,6 +381,11 @@ export type ProgramDetail = AdminProgram & { participants: ProgramParticipant[] 
 const MAX_PROGRAM_NAME = 120;
 const MAX_PROGRAM_SLUG = 80;
 const MAX_PROGRAM_BLURB = 200;
+const MAX_PROGRAM_SCHEDULE = 120;
+const MAX_PROGRAM_DURATION = 80;
+const MAX_PROGRAM_COMMITMENT = 120;
+const MAX_PROGRAM_FACILITATOR = 120;
+const MAX_PROGRAM_CONTACT = 200;
 const MAX_PROGRAM_DESCRIPTION = 2000;
 // Buttondown tag names are short by convention; the cap is well above
 // anything Buttondown surfaces in its UI and keeps the column index-friendly.
@@ -377,7 +412,18 @@ const validateSlug = (slug: string): { slug: string } | { error: string } => {
 export const parseProgramCreate = (
   body: unknown,
 ):
-  | { name: string; slug: string; blurb: string | null; description: string | null; buttondownTag: string | null }
+  | {
+      name: string;
+      slug: string;
+      blurb: string | null;
+      schedule: string | null;
+      duration: string | null;
+      commitment: string | null;
+      facilitator: string | null;
+      contact: string | null;
+      description: string | null;
+      buttondownTag: string | null;
+    }
   | { error: string } => {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     return { error: "body must be a JSON object" };
@@ -397,6 +443,31 @@ export const parseProgramCreate = (
     return { error: "blurb is too long" };
   }
 
+  const schedule = trimmedString(obj.schedule);
+  if (schedule && schedule.length > MAX_PROGRAM_SCHEDULE) {
+    return { error: "schedule is too long" };
+  }
+
+  const duration = trimmedString(obj.duration);
+  if (duration && duration.length > MAX_PROGRAM_DURATION) {
+    return { error: "duration is too long" };
+  }
+
+  const commitment = trimmedString(obj.commitment);
+  if (commitment && commitment.length > MAX_PROGRAM_COMMITMENT) {
+    return { error: "commitment is too long" };
+  }
+
+  const facilitator = trimmedString(obj.facilitator);
+  if (facilitator && facilitator.length > MAX_PROGRAM_FACILITATOR) {
+    return { error: "facilitator is too long" };
+  }
+
+  const contact = trimmedString(obj.contact);
+  if (contact && contact.length > MAX_PROGRAM_CONTACT) {
+    return { error: "contact is too long" };
+  }
+
   const description = trimmedString(obj.description);
   if (description && description.length > MAX_PROGRAM_DESCRIPTION) {
     return { error: "description is too long" };
@@ -410,6 +481,11 @@ export const parseProgramCreate = (
     name,
     slug,
     blurb: blurb || null,
+    schedule: schedule || null,
+    duration: duration || null,
+    commitment: commitment || null,
+    facilitator: facilitator || null,
+    contact: contact || null,
     description: description || null,
     buttondownTag: buttondownTag || null,
   };
@@ -424,6 +500,11 @@ export type ProgramUpdate = {
   name?: string;
   slug?: string;
   blurb?: string | null;
+  schedule?: string | null;
+  duration?: string | null;
+  commitment?: string | null;
+  facilitator?: string | null;
+  contact?: string | null;
   description?: string | null;
   archived?: boolean;
   signupsOpen?: boolean;
@@ -459,6 +540,41 @@ export const parseProgramUpdate = (body: unknown): ProgramUpdate | { error: stri
       return { error: "blurb is too long" };
     }
     result.blurb = blurb || null;
+  }
+  if ("schedule" in obj) {
+    const schedule = trimmedString(obj.schedule);
+    if (schedule && schedule.length > MAX_PROGRAM_SCHEDULE) {
+      return { error: "schedule is too long" };
+    }
+    result.schedule = schedule || null;
+  }
+  if ("duration" in obj) {
+    const duration = trimmedString(obj.duration);
+    if (duration && duration.length > MAX_PROGRAM_DURATION) {
+      return { error: "duration is too long" };
+    }
+    result.duration = duration || null;
+  }
+  if ("commitment" in obj) {
+    const commitment = trimmedString(obj.commitment);
+    if (commitment && commitment.length > MAX_PROGRAM_COMMITMENT) {
+      return { error: "commitment is too long" };
+    }
+    result.commitment = commitment || null;
+  }
+  if ("facilitator" in obj) {
+    const facilitator = trimmedString(obj.facilitator);
+    if (facilitator && facilitator.length > MAX_PROGRAM_FACILITATOR) {
+      return { error: "facilitator is too long" };
+    }
+    result.facilitator = facilitator || null;
+  }
+  if ("contact" in obj) {
+    const contact = trimmedString(obj.contact);
+    if (contact && contact.length > MAX_PROGRAM_CONTACT) {
+      return { error: "contact is too long" };
+    }
+    result.contact = contact || null;
   }
   if ("description" in obj) {
     const description = trimmedString(obj.description);
@@ -502,6 +618,11 @@ export const listAllProgramsForAdmin = async (): Promise<AdminProgram[]> => {
       slug: programs.slug,
       name: programs.name,
       blurb: programs.blurb,
+      schedule: programs.schedule,
+      duration: programs.duration,
+      commitment: programs.commitment,
+      facilitator: programs.facilitator,
+      contact: programs.contact,
       description: programs.description,
       archivedAt: sql<string | null>`to_json(${programs.archivedAt}) #>> '{}'`,
       signupsOpen: programs.signupsOpen,
@@ -521,6 +642,11 @@ export const createProgram = async (input: {
   name: string;
   slug: string;
   blurb: string | null;
+  schedule: string | null;
+  duration: string | null;
+  commitment: string | null;
+  facilitator: string | null;
+  contact: string | null;
   description: string | null;
   buttondownTag: string | null;
 }): Promise<{ program: AdminProgram } | { error: "slug_conflict" }> => {
@@ -533,6 +659,11 @@ export const createProgram = async (input: {
       slug: input.slug,
       name: input.name,
       blurb: input.blurb,
+      schedule: input.schedule,
+      duration: input.duration,
+      commitment: input.commitment,
+      facilitator: input.facilitator,
+      contact: input.contact,
       description: input.description,
       buttondownTag: input.buttondownTag,
     })
@@ -544,6 +675,11 @@ export const createProgram = async (input: {
       slug: row.slug,
       name: row.name,
       blurb: row.blurb,
+      schedule: row.schedule,
+      duration: row.duration,
+      commitment: row.commitment,
+      facilitator: row.facilitator,
+      contact: row.contact,
       description: row.description,
       archivedAt: row.archivedAt ? row.archivedAt.toISOString() : null,
       signupsOpen: row.signupsOpen,
@@ -568,6 +704,11 @@ export const updateProgram = async (
   const update: Record<string, unknown> = {};
   if (input.name !== undefined) update.name = input.name;
   if (input.blurb !== undefined) update.blurb = input.blurb;
+  if (input.schedule !== undefined) update.schedule = input.schedule;
+  if (input.duration !== undefined) update.duration = input.duration;
+  if (input.commitment !== undefined) update.commitment = input.commitment;
+  if (input.facilitator !== undefined) update.facilitator = input.facilitator;
+  if (input.contact !== undefined) update.contact = input.contact;
   if (input.description !== undefined) update.description = input.description;
   if (input.archived !== undefined) {
     update.archivedAt = input.archived ? sql`now()` : null;
@@ -605,6 +746,11 @@ export const getProgramDetail = async (
       slug: programs.slug,
       name: programs.name,
       blurb: programs.blurb,
+      schedule: programs.schedule,
+      duration: programs.duration,
+      commitment: programs.commitment,
+      facilitator: programs.facilitator,
+      contact: programs.contact,
       description: programs.description,
       archivedAt: programs.archivedAt,
       signupsOpen: programs.signupsOpen,
@@ -643,6 +789,11 @@ export const getProgramDetail = async (
       slug: program.slug,
       name: program.name,
       blurb: program.blurb,
+      schedule: program.schedule,
+      duration: program.duration,
+      commitment: program.commitment,
+      facilitator: program.facilitator,
+      contact: program.contact,
       description: program.description,
       archivedAt: program.archivedAt ? program.archivedAt.toISOString() : null,
       signupsOpen: program.signupsOpen,

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -80,6 +80,11 @@ export const programs = pgTable("programs", {
   name: text("name").notNull(),
   blurb: text("blurb"),
   description: text("description"),
+  schedule: text("schedule"),
+  duration: text("duration"),
+  commitment: text("commitment"),
+  facilitator: text("facilitator"),
+  contact: text("contact"),
   // Archived programs are hidden from member-facing listings (admins
   // still see them in /admin/programs). Set the timestamp instead of
   // a boolean — it's strictly more information.


### PR DESCRIPTION
## Summary

- **Key-facts fields**: five new optional program details — schedule, duration, commitment, facilitator, and contact — alongside the existing blurb/description.
- **Admin entry**: both the create and edit forms gain inputs for all five.
- **Member display**: the detail page shows them as a labeled list; the programs list card adds a compact "duration · schedule · commitment" line, hidden when none are set.
- **Schema**: five nullable text columns on `programs` (migrations 0015/0016). Additive expand — `npm run prod:db:expand` (maintainer-gated) must be approved before merge so the preview/e2e hit a prod DB that has the columns.
- **Contact placeholder** uses a role-based example (`questions@intentionalsociety.org`), not a personal address.

## Test plan

- [ ] `/admin/programs` → New program → fill Schedule / Duration / Commitment / Facilitator / Contact → Create
- [ ] Open an existing program → the five fields are editable and persist on save
- [ ] `/programs` → card shows the "duration · schedule · commitment" summary line
- [ ] Click into the program → detail page lists Facilitator / Schedule / Duration / Commitment / Questions
- [ ] CI lint + functional + e2e pass (e2e requires the prod schema expand to be approved first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)