### PR TITLE
feat(myweb): expand canvas, reveal names/values, add spacing slider

### DIFF
--- a/src/app/members/[id]/profile-mini-map.tsx
+++ b/src/app/members/[id]/profile-mini-map.tsx
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 
 import { relationMiniMapQueryKey } from "@/app/myweb/query-keys";
 import { WebGraphCanvas } from "@/app/myweb/web-graph-canvas";
+import { computeNormalization, type Normalize } from "@/app/myweb/web-graph-layout";
 import { apiClient } from "@/lib/api";
 import type { RelationMiniMap } from "@/lib/api-types";
 
@@ -19,10 +20,14 @@ import type { RelationMiniMap } from "@/lib/api-types";
 // needs extra margin to keep the end avatars and their labels off the edges.
 const MINI_MAP_FIT_PADDING = 0.12;
 
-// Tighter than the full graph's 600: the longer axis normalizes to fewer sim
-// units, so fitView zooms in and the fixed-px avatars and names render larger in
-// this small embed. Trades a little link breathing room for legibility.
+// Tighter than the full graph's neighbor-gap target: the longer axis normalizes
+// to fewer sim units, so fitView zooms in and the fixed-px avatars and names
+// render larger in this small embed. Trades a little link breathing room for
+// legibility. The mini-map keeps the bounding-box strategy (a short path of a
+// few nodes frames better by extent than by neighbor spacing), so it's a stable
+// module-level closure — the canvas never re-fits on its identity.
 const MINI_MAP_NORMALIZATION_TARGET = 280;
+const miniMapNormalize: Normalize = (points) => computeNormalization(points, MINI_MAP_NORMALIZATION_TARGET);
 
 const fetchMiniMap = async (profileId: string): Promise<RelationMiniMap> => {
   const res = await apiClient.api.relations["mini-map"][":profileId"].$get({ param: { profileId } });
@@ -108,7 +113,7 @@ export function ProfileMiniMap({ profileId, memberName }: { profileId: string; m
         viewerCueNodeId={subgraph.viewerId}
         interactive={false}
         fitViewPadding={MINI_MAP_FIT_PADDING}
-        normalizationTarget={MINI_MAP_NORMALIZATION_TARGET}
+        normalize={miniMapNormalize}
         // Read-only: a click opens the member's profile (no selection state).
         onNodeClick={(_event, node) => {
           const slug = node.data.slug ?? node.data.id;

--- a/src/app/members/[id]/profile-mini-map.tsx
+++ b/src/app/members/[id]/profile-mini-map.tsx
@@ -56,6 +56,10 @@ export function ProfileMiniMap({ profileId, memberName }: { profileId: string; m
 
   const litNodeIds = useMemo(() => new Set(data?.pathToViewer ?? []), [data?.pathToViewer]);
   const litEdgeIds = useMemo(() => pathEdgeIds(data?.pathToViewer ?? []), [data?.pathToViewer]);
+  // This embed is a static, read-only diagram with no hover, so every node keeps
+  // its name (the full graph hides names until hover/selection instead). Pass the
+  // whole id set so the canvas labels them all.
+  const labeledNodeIds = useMemo(() => new Set((data?.nodes ?? []).map((n) => n.id)), [data?.nodes]);
   // Memoized so the canvas's layout effect (keyed on the subgraph) doesn't
   // rebuild the simulation on every render.
   const subgraph = useMemo(
@@ -99,6 +103,7 @@ export function ProfileMiniMap({ profileId, memberName }: { profileId: string; m
         litNodeIds={litNodeIds}
         litEdgeIds={litEdgeIds}
         dimUnlit={false}
+        labeledNodeIds={labeledNodeIds}
         selectedNodeId={null}
         selectedEdgeId={null}
         viewerCueNodeId={subgraph.viewerId}

--- a/src/app/members/[id]/profile-mini-map.tsx
+++ b/src/app/members/[id]/profile-mini-map.tsx
@@ -105,7 +105,6 @@ export function ProfileMiniMap({ profileId, memberName }: { profileId: string; m
         dimUnlit={false}
         labeledNodeIds={labeledNodeIds}
         selectedNodeId={null}
-        selectedEdgeId={null}
         viewerCueNodeId={subgraph.viewerId}
         interactive={false}
         fitViewPadding={MINI_MAP_FIT_PADDING}

--- a/src/app/myweb/my-web.tsx
+++ b/src/app/myweb/my-web.tsx
@@ -4,7 +4,6 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
 
 import { PageHeader } from "@/components/page-header";
-import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api";
 import type { RelationCandidatesFeed } from "@/lib/api-types";
 
@@ -172,41 +171,28 @@ export function MyWeb({ initialLastUpdatedWeb }: { initialLastUpdatedWeb: Date |
        * introduced. visibility (not display) keeps the layout stable
        * under the tooltip. */}
       <PageHeader title="My web" className={farewellRun ? "invisible" : undefined} />
-      {/* Below 600px the graph breaks out of the page's horizontal padding to
-       * go edge-to-edge; the title/breadcrumb (above) and the Edit/Done row +
-       * feed (below) keep their padding. The negative margin equals -(50vw -
+      {/* Below 900px the graph breaks out of the page's horizontal padding to
+       * go edge-to-edge; the title/breadcrumb (above) and the feed (below, in
+       * edit mode) keep their padding. The negative margin equals -(50vw -
        * half the container), the canonical full-bleed within a padded parent. */}
-      <div className="w-full max-[600px]:mx-[calc(50%_-_50vw)] max-[600px]:w-screen">
-        <WebGraph square={mode === "view"} onOpenRelating={setRelatingTarget} onReplayTour={replayTour} />
+      <div className="w-full max-[900px]:mx-[calc(50%_-_50vw)] max-[900px]:w-screen">
+        <WebGraph
+          expanded={mode === "view"}
+          onOpenRelating={setRelatingTarget}
+          onReplayTour={replayTour}
+          mode={mode}
+          onEdit={() => setMode("edit")}
+          onDone={handleDoneClick}
+          donePending={markDone.isPending}
+          doneError={markDone.isError}
+        />
       </div>
 
-      {/* Toggle floats in the right gutter so it doesn't claim its own
-       * row. Edit and Done sit at the same coordinates across modes —
-       * same affordance, different label. Capped at max-w-5xl so the
-       * builder and toggle stay readable even though the view-mode graph
-       * above now spans wider. */}
-      <div className="relative w-full max-w-5xl">
-        <div className="absolute right-0 top-0 z-10 flex flex-col items-end gap-2">
-          {mode === "edit" ? (
-            <Button variant="secondary" data-tour="done-button" disabled={markDone.isPending} onClick={handleDoneClick}>
-              {markDone.isPending ? "Saving…" : "Done"}
-            </Button>
-          ) : (
-            <Button onClick={() => setMode("edit")}>Edit</Button>
-          )}
-          {markDone.isError && (
-            <p role="alert" className="text-sm text-destructive">
-              Couldn&apos;t save your update — your relationships are still saved.
-            </p>
-          )}
+      {mode === "edit" && (
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
+          <WebBuilder onOpenRelating={setRelatingTarget} flyingId={flying?.candidateId ?? null} />
         </div>
-
-        {mode === "edit" && (
-          <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
-            <WebBuilder onOpenRelating={setRelatingTarget} flyingId={flying?.candidateId ?? null} />
-          </div>
-        )}
-      </div>
+      )}
 
       <RelatingDialog
         target={relatingTarget}

--- a/src/app/myweb/page.tsx
+++ b/src/app/myweb/page.tsx
@@ -36,6 +36,9 @@ export default async function MyWebPage() {
   });
 
   return (
+    // The web canvas sizes its view-mode height to leave exactly this `pb-8`
+    // (2rem) below itself, so it never spills into a scrollbar — useCanvasBox's
+    // PAGE_PAD_REM mirrors this value. Change them together.
     <main className="flex min-h-screen flex-col items-center gap-6 px-8 pb-8 pt-3">
       <HydrationBoundary state={dehydrate(queryClient)}>
         <MyWeb initialLastUpdatedWeb={initialLastUpdatedWeb} />

--- a/src/app/myweb/query-keys.ts
+++ b/src/app/myweb/query-keys.ts
@@ -64,3 +64,32 @@ export function parseStoredValueFilter(raw: string | null): Set<RelationValue> |
   }
   return null;
 }
+
+// The spacing control persists a *multiplier* on the rendered neighbor-gap
+// baseline (NEIGHBOR_GAP_BASE; see computeNeighborNormalization): below 1 packs
+// neighbors closer, above 1 spreads them apart. The normalization already holds
+// density constant across node count, link strength, and clustering, so this is
+// pure taste — one value reads the same on every web. Its own key, like hops and
+// the value filter, so the choice survives reloads.
+export const SPACING_STORAGE_KEY = "isweb-graph-spacing";
+export const SPACING_MIN = 0.6;
+export const SPACING_MAX = 1.2;
+export const SPACING_STEP = 0.05;
+export const DEFAULT_SPACING = 0.9;
+
+// Permissive parser: a finite number clamped into [MIN, MAX] survives; anything
+// else (missing, NaN, ±Infinity, wrong type, garbled) falls back to null so the
+// caller keeps the default. Clamping guards a hand-edited or stale out-of-range
+// value from driving the layout off the rails.
+export function parseStoredSpacing(raw: string | null): number | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === "number" && Number.isFinite(parsed)) {
+      return Math.min(SPACING_MAX, Math.max(SPACING_MIN, parsed));
+    }
+  } catch {
+    // fall through to null
+  }
+  return null;
+}

--- a/src/app/myweb/use-canvas-box.ts
+++ b/src/app/myweb/use-canvas-box.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { type CanvasDims, fitAspectClamped } from "./web-graph-layout";
+
+// Space reserved below the canvas — the page's own padding (myweb/page.tsx's
+// `main` carries `pb-8`/`px-8`, both 2rem), so the gap under the canvas matches
+// the gap beside it and view mode never spills into a vertical scrollbar. If that
+// page padding changes, change this with it. Edit mode's feed legitimately
+// scrolls — the no-scrollbar guarantee is a view-mode one.
+const PAGE_PAD_REM = 2;
+
+// The root font-size in px. The app sets it larger than 16 (112.5%), so the
+// reserve must resolve against the live value to land on the same px the page
+// padding uses. Read once and cached by the caller — getComputedStyle forces a
+// style flush, and this value doesn't change at runtime (it's a fixed app-level
+// setting, unaffected by web-font loading). Falls back to 16 off the document.
+function rootFontPx(): number {
+  if (typeof document === "undefined") return 16;
+  return parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+}
+
+type CanvasBox = {
+  // Callback ref for the full-width wrapper whose width and viewport offset are
+  // measured to size the box inside (the box's own width is derived, so measuring
+  // it would be circular).
+  wrapRef: (el: HTMLDivElement | null) => void;
+  // The aspect-clamped view/edit dimensions, or null before the first measure.
+  dims: CanvasDims | null;
+  // Whether the height CSS transition is armed — true for mode toggles, false for
+  // the initial measure and resizes (which commit instantly). The caller applies
+  // the transition; this just gates it.
+  animateHeight: boolean;
+};
+
+// Measures the available rectangle (wrapper width × the space from its top down
+// to the viewport floor, less the bottom reserve) and derives the aspect-clamped
+// canvas dimensions. Re-measures on resize and once web fonts settle (they grow
+// the header a few px, shifting the wrapper's top). Owns the transition-arming so
+// only mode toggles ease, not resizes. See fitAspectClamped.
+export function useCanvasBox(): CanvasBox {
+  const [avail, setAvail] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
+  const lastAvailRef = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
+  const [animateHeight, setAnimateHeight] = useState(false);
+  const wrapElRef = useRef<HTMLDivElement | null>(null);
+  const resizeObsRef = useRef<ResizeObserver | null>(null);
+  const bottomReserveRef = useRef<number | null>(null);
+
+  const measure = useCallback(() => {
+    const el = wrapElRef.current;
+    if (!el) return;
+    if (bottomReserveRef.current === null) bottomReserveRef.current = PAGE_PAD_REM * rootFontPx();
+    const w = el.clientWidth;
+    const h = Math.max(0, window.innerHeight - el.getBoundingClientRect().top - bottomReserveRef.current);
+    const prev = lastAvailRef.current;
+    if (Math.abs(w - prev.w) < 0.5 && Math.abs(h - prev.h) < 0.5) return;
+    lastAvailRef.current = { w, h };
+    setAnimateHeight(false); // a resize commits instantly; only mode toggles ease
+    setAvail({ w, h });
+  }, []);
+
+  // Callback ref: attach a width observer once the wrapper mounts (it only
+  // renders after the loading/empty early-returns in WebGraph). A ResizeObserver
+  // on the full-width element catches layout-width changes; the window 'resize'
+  // listener below catches viewport-height changes the observer wouldn't see.
+  const wrapRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      resizeObsRef.current?.disconnect();
+      wrapElRef.current = el;
+      if (!el) {
+        resizeObsRef.current = null;
+        return;
+      }
+      measure();
+      const ro = new ResizeObserver(() => measure());
+      ro.observe(el);
+      resizeObsRef.current = ro;
+    },
+    [measure],
+  );
+
+  useEffect(() => {
+    window.addEventListener("resize", measure);
+    // Web fonts load after first paint and grow the header a few px, shifting the
+    // wrapper's top — a one-time drift neither observer above would catch, and
+    // which would otherwise leave the height slightly too tall (a faint
+    // scrollbar). Re-measure once fonts settle. (?. short-circuits the whole chain
+    // where FontFaceSet is absent, e.g. jsdom.)
+    document.fonts?.ready.then(() => measure());
+    return () => window.removeEventListener("resize", measure);
+  }, [measure]);
+
+  const dims = useMemo(() => fitAspectClamped(avail.w, avail.h), [avail]);
+
+  // Re-arm the transition one frame after the initial measure or a resize, so the
+  // next mode toggle eases but the size change that just committed didn't.
+  useEffect(() => {
+    if (dims && !animateHeight) {
+      const id = requestAnimationFrame(() => setAnimateHeight(true));
+      return () => cancelAnimationFrame(id);
+    }
+  }, [dims, animateHeight]);
+
+  return { wrapRef, dims, animateHeight };
+}

--- a/src/app/myweb/use-web-graph-simulation.ts
+++ b/src/app/myweb/use-web-graph-simulation.ts
@@ -11,13 +11,7 @@ import {
 import { forceCollide, forceLink, forceManyBody, forceSimulation, type Simulation } from "d3-force";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import {
-  computeNormalization,
-  edgeAvoidance,
-  linkDistance,
-  NORMALIZATION_TARGET,
-  radialSeed,
-} from "./web-graph-layout";
+import { edgeAvoidance, linkDistance, type Normalize, radialSeed } from "./web-graph-layout";
 import type { EdgeData, MemberNodeData, SubgraphNode } from "./web-graph-renderers";
 
 // d3-force mutates these objects in place; ReactFlow's Node objects are
@@ -90,7 +84,7 @@ type WebGraphSimulation = {
 export function useWebGraphSimulation(
   filtered: SimulationSubgraph | null,
   fitPadding: number = FIT_VIEW_PADDING,
-  normalizationTarget: number = NORMALIZATION_TARGET,
+  normalize: Normalize,
 ): WebGraphSimulation {
   const [nodes, setNodes] = useState<Node<MemberNodeData>[]>([]);
   // The fit padding every internal refit uses (settle fits, the "end" fit, and
@@ -99,12 +93,12 @@ export function useWebGraphSimulation(
   // roomier than the full graph (fixed-size nodes need margin in a small box).
   const fitPaddingRef = useRef(fitPadding);
   fitPaddingRef.current = fitPadding;
-  // The longer-axis span the settled layout normalizes to before fitView frames
-  // it — the map's zoom knob (smaller ⇒ fitView zooms in ⇒ everything renders
-  // larger). Held in a ref for the same reason as the padding. The mini-map runs
-  // tighter than the full graph so its fixed-px avatars and labels read larger.
-  const normalizationTargetRef = useRef(normalizationTarget);
-  normalizationTargetRef.current = normalizationTarget;
+  // The normalization strategy — how settled sim points map to render space. Held
+  // in a ref so paintFromSim and the stable callbacks read the latest without
+  // re-subscribing: the full graph swaps it as the spacing slider moves; the
+  // mini-map's is constant.
+  const normalizeRef = useRef(normalize);
+  normalizeRef.current = normalize;
   const simRef = useRef<Simulation<SimNode, SimEdge> | null>(null);
   // Captured via ReactFlow's onInit so we can refit the viewport every
   // time node positions change — fitView only auto-fires on first
@@ -276,15 +270,14 @@ export function useWebGraphSimulation(
         }
       });
 
-    // Paints React node positions from the live simNodes, normalized so
-    // the layout's longer axis spans NORMALIZATION_TARGET sim units and is
-    // centered on the origin (see computeNormalization). Combined with a manual
-    // fitView refit, this makes the rendered graph fill the viewport regardless
-    // of node count.
+    // Paints React node positions from the live simNodes, normalized (centered +
+    // scaled) by the current strategy — the full graph scales so neighbors sit a
+    // fixed gap apart (see computeNeighborNormalization). Combined with a manual
+    // fitView refit, this fills the viewport at a consistent density.
     function paintFromSim() {
       if (simNodes.length === 0) return;
       // During a drag, freeze the normalization. Recomputing it would
-      // shift cx/cy/scale based on the moving bbox, which makes the
+      // shift cx/cy/scale based on the moving cloud, which makes the
       // dragged node visually drift away from the cursor.
       let cx: number;
       let cy: number;
@@ -292,7 +285,7 @@ export function useWebGraphSimulation(
       if (draggedNodeIdRef.current && normRef.current) {
         ({ cx, cy, scale } = normRef.current);
       } else {
-        const norm = computeNormalization(simNodes, normalizationTargetRef.current);
+        const norm = normalizeRef.current(simNodes);
         if (!norm) return;
         ({ cx, cy, scale } = norm);
         normRef.current = norm;
@@ -316,10 +309,10 @@ export function useWebGraphSimulation(
         return changed ? next : prev;
       });
 
-      // Refit every paint while the initial layout settles. Normalization pins
-      // the longer axis to NORMALIZATION_TARGET, so the fit is stable from the
-      // first painted frame — the viewport tracks the settling graph rather
-      // than snapping once at the end. A one-shot fit here used to fire (via
+      // Refit every paint while the initial layout settles. Normalization keeps
+      // the neighbor gap fixed, so the fit is stable from the first painted frame
+      // — the viewport tracks the settling graph rather than snapping once at the
+      // end. A one-shot fit here used to fire (via
       // rAF) before the normalized nodes reached ReactFlow's store, fitting the
       // raw seed instead, which left the graph zoomed-out until the "end" fit
       // visibly zoomed in. Skipped during a drag (we freeze normalization then)
@@ -399,6 +392,47 @@ export function useWebGraphSimulation(
   const fitView = useCallback(() => {
     flowRef.current?.fitView({ padding: fitPaddingRef.current, duration: 0 });
   }, []);
+
+  // Re-scale the at-rest layout with the current normalization strategy and
+  // refit. The spacing slider swaps `normalize` while the sim is usually settled,
+  // so paintFromSim (which only re-reads it on a live tick) won't pick it up —
+  // this applies it directly: recompute the render scale, repaint, then reframe.
+  // Skipped before the first settle (the build effect's per-paint fit owns it
+  // until then) and during a drag (normalization is frozen).
+  const applyNormalization = useCallback(() => {
+    if (!initialSettleDoneRef.current || draggedNodeIdRef.current) return;
+    const simById = simNodesByIdRef.current;
+    if (simById.size === 0) return;
+    const norm = normalizeRef.current([...simById.values()]);
+    if (!norm) return;
+    normRef.current = norm;
+    const { cx, cy, scale } = norm;
+    setNodes((prev) =>
+      prev.map((node) => {
+        const sn = simById.get(node.id);
+        return sn ? { ...node, position: { x: (sn.x - cx) * scale, y: (sn.y - cy) * scale } } : node;
+      }),
+    );
+    // Reframe instantly (duration 0) so the view tracks the slider crisply rather
+    // than queuing an animation per tick; rAF lets the repainted nodes reach
+    // ReactFlow's store first.
+    requestAnimationFrame(() => flowRef.current?.fitView({ padding: fitPaddingRef.current, duration: 0 }));
+  }, []);
+
+  // Re-apply normalization once the layout's at rest when the strategy changes —
+  // the spacing slider swaps `normalize`, and the sim is usually settled by then,
+  // so paintFromSim wouldn't pick it up. Skips the first run (initial mount), where
+  // the build/settle path already paints + fits. `normalize` is the trigger, read
+  // inside applyNormalization via normalizeRef.
+  const densityInitRef = useRef(true);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: normalize triggers the re-scale (read via the ref)
+  useEffect(() => {
+    if (densityInitRef.current) {
+      densityInitRef.current = false;
+      return;
+    }
+    applyNormalization();
+  }, [normalize, applyNormalization]);
 
   return {
     nodes,

--- a/src/app/myweb/web-graph-canvas.tsx
+++ b/src/app/myweb/web-graph-canvas.tsx
@@ -52,6 +52,10 @@ type WebGraphCanvasProps = {
   litNodeIds: ReadonlySet<string>;
   litEdgeIds: ReadonlySet<string>;
   dimUnlit: boolean;
+  // Nodes whose name label is shown (lit path + hovered node/edge endpoints).
+  // Names are hidden otherwise. WebGraph builds the set from its hover/selection
+  // state; a read-only consumer can pass an empty set for a nameless graph.
+  labeledNodeIds: ReadonlySet<string>;
   // The clicked node (kept at hover size) and the selected editable edge
   // (cursor:pointer). Both null in read-only views like the mini-map.
   selectedNodeId: string | null;
@@ -85,6 +89,8 @@ type WebGraphCanvasProps = {
   onEdgeClick?: EdgeMouseHandler<Edge<EdgeData>>;
   onPaneClick?: (event: ReactMouseEvent) => void;
   onNodeClick?: NodeMouseHandler<Node<MemberNodeData>>;
+  onNodeMouseEnter?: NodeMouseHandler<Node<MemberNodeData>>;
+  onNodeMouseLeave?: NodeMouseHandler<Node<MemberNodeData>>;
   onNodeDoubleClick?: NodeMouseHandler<Node<MemberNodeData>>;
   // Corner panels (Controls, hints, view controls) rendered inside ReactFlow.
   children?: ReactNode;
@@ -95,6 +101,7 @@ export function WebGraphCanvas({
   litNodeIds,
   litEdgeIds,
   dimUnlit,
+  labeledNodeIds,
   selectedNodeId,
   selectedEdgeId,
   viewerCueNodeId = null,
@@ -108,6 +115,8 @@ export function WebGraphCanvas({
   onEdgeClick,
   onPaneClick,
   onNodeClick,
+  onNodeMouseEnter,
+  onNodeMouseLeave,
   onNodeDoubleClick,
   children,
 }: WebGraphCanvasProps) {
@@ -157,8 +166,8 @@ export function WebGraphCanvas({
   // Carries the node decoration to MemberNode via context (kept out of node.data
   // so a selection doesn't trigger a setNodes pass). See NodeInteraction.
   const nodeInteraction = useMemo<NodeInteraction>(
-    () => ({ litNodeIds, dimUnlit, selectedNodeId, viewerCueNodeId }),
-    [litNodeIds, dimUnlit, selectedNodeId, viewerCueNodeId],
+    () => ({ litNodeIds, dimUnlit, selectedNodeId, labeledNodeIds, viewerCueNodeId }),
+    [litNodeIds, dimUnlit, selectedNodeId, labeledNodeIds, viewerCueNodeId],
   );
 
   // Light the selected edge and the lit path; dim the rest when asked. The
@@ -218,6 +227,8 @@ export function WebGraphCanvas({
           elementsSelectable={false}
           proOptions={{ hideAttribution: true }}
           onNodeClick={onNodeClick}
+          onNodeMouseEnter={onNodeMouseEnter}
+          onNodeMouseLeave={onNodeMouseLeave}
           onNodeDoubleClick={onNodeDoubleClick}
         >
           {children}

--- a/src/app/myweb/web-graph-canvas.tsx
+++ b/src/app/myweb/web-graph-canvas.tsx
@@ -18,7 +18,7 @@ import {
   nodeTypes,
   type SubgraphNode,
 } from "./web-graph-renderers";
-import { decorateEdges, decorateNodes } from "./web-graph-selection";
+import { decorateEdges, decorateNodes, edgeId } from "./web-graph-selection";
 
 // Stable empty hover set for read-only consumers that omit the prop, so the
 // decorateNodes memo below doesn't see a fresh Set each render.
@@ -61,8 +61,8 @@ type WebGraphCanvasProps = {
   // state; a read-only consumer can pass an empty set for a nameless graph.
   labeledNodeIds: ReadonlySet<string>;
   // The clicked node, kept at hover size. Null in read-only views like the
-  // mini-map. (The selected edge reaches the renderer via edgeInteraction; the
-  // canvas no longer needs it, since every edge now reads as clickable.)
+  // mini-map. (Edge selection reaches the renderer via edgeInteraction, so the
+  // canvas only tracks the node here.)
   selectedNodeId: string | null;
   // The live pointer focus, lifted to the top of the stack: the nodes under it
   // (the hovered node, plus a hovered edge's two endpoints) and the hovered
@@ -138,7 +138,7 @@ export function WebGraphCanvas({
       const isOutgoing = e.relatorId === viewerId;
       const relatee = nodeById.get(e.relateeId);
       return {
-        id: `${e.relatorId}->${e.relateeId}`,
+        id: edgeId(e.relatorId, e.relateeId),
         source: e.relatorId,
         target: e.relateeId,
         type: "numbered",

--- a/src/app/myweb/web-graph-canvas.tsx
+++ b/src/app/myweb/web-graph-canvas.tsx
@@ -6,7 +6,7 @@ import { type Edge, type EdgeMouseHandler, type Node, type NodeMouseHandler, Rea
 import { type MouseEvent as ReactMouseEvent, type ReactNode, useEffect, useMemo } from "react";
 
 import { FIT_VIEW_PADDING, useWebGraphSimulation } from "./use-web-graph-simulation";
-import { edgeStrokeOpacity, edgeStrokeWidth } from "./web-graph-layout";
+import { edgeStrokeOpacity, edgeStrokeWidth, type Normalize } from "./web-graph-layout";
 import {
   type EdgeData,
   type EdgeInteraction,
@@ -79,11 +79,10 @@ type WebGraphCanvasProps = {
   edgeInteraction?: EdgeInteraction | null;
   // Fraction of the canvas kept as breathing room on every fitView.
   fitViewPadding?: number;
-  // Sim-unit span the settled layout's longer axis normalizes to before fitView
-  // frames it — the map's zoom knob. Smaller ⇒ fitView zooms in ⇒ avatars,
-  // labels, and link gaps all render larger (the mini-map runs tighter than the
-  // full graph). Defaults to the full-graph target.
-  normalizationTarget?: number;
+  // How the settled layout maps into render space — the wrapper's density knob.
+  // The full graph scales by neighbor spacing (its spacing slider lives in this
+  // function's identity, so a drag re-fits); the mini-map scales by bounding box.
+  normalize: Normalize;
   // When false, pan/zoom/drag are locked (the mini-map never hijacks page
   // scroll). Defaults to the fully-interactive full graph.
   interactive?: boolean;
@@ -117,7 +116,7 @@ export function WebGraphCanvas({
   viewerCueNodeId = null,
   edgeInteraction = null,
   fitViewPadding = FIT_VIEW_PADDING,
-  normalizationTarget,
+  normalize,
   interactive = true,
   onReady,
   onEdgeMouseEnter,
@@ -168,7 +167,7 @@ export function WebGraphCanvas({
   // normalized render positions into `nodes`, fits the viewport as it settles,
   // and integrates node dragging. See useWebGraphSimulation.
   const { nodes, onNodesChange, onNodeDragStart, onNodeDrag, onNodeDragStop, registerFlow, markUserMoved, fitView } =
-    useWebGraphSimulation(subgraph, fitViewPadding, normalizationTarget);
+    useWebGraphSimulation(subgraph, fitViewPadding, normalize);
 
   // Surface fitView to the wrapper once (the hook returns a stable callback).
   useEffect(() => onReady?.(fitView), [onReady, fitView]);

--- a/src/app/myweb/web-graph-canvas.tsx
+++ b/src/app/myweb/web-graph-canvas.tsx
@@ -20,6 +20,10 @@ import {
 } from "./web-graph-renderers";
 import { decorateEdges, decorateNodes } from "./web-graph-selection";
 
+// Stable empty hover set for read-only consumers that omit the prop, so the
+// decorateNodes memo below doesn't see a fresh Set each render.
+const NO_HOVER_NODE_IDS: ReadonlySet<string> = new Set();
+
 // The reusable rendering surface beneath WebGraph: it owns the d3-force layout,
 // the ReactFlow canvas, the member/edge renderer contexts, and the lit/dim
 // decoration. The full graph (WebGraph) and a future controls-free mini-map both
@@ -56,10 +60,15 @@ type WebGraphCanvasProps = {
   // Names are hidden otherwise. WebGraph builds the set from its hover/selection
   // state; a read-only consumer can pass an empty set for a nameless graph.
   labeledNodeIds: ReadonlySet<string>;
-  // The clicked node (kept at hover size) and the selected editable edge
-  // (cursor:pointer). Both null in read-only views like the mini-map.
+  // The clicked node, kept at hover size. Null in read-only views like the
+  // mini-map. (The selected edge reaches the renderer via edgeInteraction; the
+  // canvas no longer needs it, since every edge now reads as clickable.)
   selectedNodeId: string | null;
-  selectedEdgeId: string | null;
+  // The live pointer focus, lifted to the top of the stack: the nodes under it
+  // (the hovered node, plus a hovered edge's two endpoints) and the hovered
+  // edge's line. Omitted in read-only views (the mini-map has no hover state).
+  hoverNodeIds?: ReadonlySet<string>;
+  hoverEdgeId?: string | null;
   // The viewer's node — its name label reads "You" (the mini-map's viewer at the
   // end of the lit path). Null in the full graph, where you're obviously the
   // center.
@@ -103,7 +112,8 @@ export function WebGraphCanvas({
   dimUnlit,
   labeledNodeIds,
   selectedNodeId,
-  selectedEdgeId,
+  hoverNodeIds = NO_HOVER_NODE_IDS,
+  hoverEdgeId = null,
   viewerCueNodeId = null,
   edgeInteraction = null,
   fitViewPadding = FIT_VIEW_PADDING,
@@ -170,16 +180,26 @@ export function WebGraphCanvas({
     [litNodeIds, dimUnlit, selectedNodeId, labeledNodeIds, viewerCueNodeId],
   );
 
-  // Light the selected edge and the lit path; dim the rest when asked. The
-  // stroke transition on the base style eases the recolor. See decorateEdges.
+  // Edges are clickable exactly when the wrapper wired up a click handler — the
+  // full graph does (select / open the relating dialog), the read-only mini-map
+  // doesn't. A stable boolean so the memo below doesn't churn on the handler's
+  // changing identity.
+  const edgesClickable = onEdgeClick != null;
+
+  // Light the lit path and dim the rest when asked; mark every edge clickable.
+  // The stroke transition on the base style eases the recolor. See decorateEdges.
   const decoratedEdges = useMemo(
-    () => decorateEdges(baseEdges, { litEdgeIds, dimUnlit, selectedEdgeId }),
-    [baseEdges, litEdgeIds, dimUnlit, selectedEdgeId],
+    () => decorateEdges(baseEdges, { litEdgeIds, dimUnlit, edgesClickable, hoverEdgeId }),
+    [baseEdges, litEdgeIds, dimUnlit, edgesClickable, hoverEdgeId],
   );
 
-  // Lift the lit nodes above the dimmed graph; derived from the live `nodes`
-  // state so sim ticks and drags flow through untouched. See decorateNodes.
-  const decoratedNodes = useMemo(() => decorateNodes(nodes, { litNodeIds }), [nodes, litNodeIds]);
+  // Lift the lit nodes above the dimmed graph and the hovered nodes above that;
+  // derived from the live `nodes` state so sim ticks and drags flow through
+  // untouched. See decorateNodes.
+  const decoratedNodes = useMemo(
+    () => decorateNodes(nodes, { litNodeIds, hoverNodeIds }),
+    [nodes, litNodeIds, hoverNodeIds],
+  );
 
   // Read-only embed config: lock every gesture so the canvas never steals page
   // scroll, and drop minZoom well below ReactFlow's 0.5 default so fitView can

--- a/src/app/myweb/web-graph-controls.tsx
+++ b/src/app/myweb/web-graph-controls.tsx
@@ -2,21 +2,28 @@ import { Panel } from "@xyflow/react";
 
 import { RELATION_VALUE_LABELS, RELATION_VALUES, type RelationValue } from "@/lib/relation-value";
 
-import type { RelationValueFilter } from "./query-keys";
+import { type RelationValueFilter, SPACING_MAX, SPACING_MIN, SPACING_STEP } from "./query-keys";
 
-// The in-canvas view controls: the hops toggle and the relation-depth filter
-// pills. Presentational — all state lives in WebGraph, which owns the query and
-// the cull; this just renders it and reports intent back through the callbacks.
+// The in-canvas view controls: the hops toggle, the relation-depth filter pills,
+// and the spacing slider. Presentational — all state lives in WebGraph, which
+// owns the query, the cull, and the spacing; this just renders it and reports
+// intent back through the callbacks.
 export function WebGraphControls({
   hops,
   onHopsChange,
   valueFilter,
   onToggleValue,
+  spacing,
+  onSpacingChange,
 }: {
   hops: 1 | 2;
   onHopsChange: (hops: 1 | 2) => void;
   valueFilter: RelationValueFilter;
   onToggleValue: (value: RelationValue) => void;
+  // A multiplier on the neighbor-gap baseline: <1 denser, >1 airier (see SPACING_*
+  // in query-keys and computeNeighborNormalization in web-graph-layout).
+  spacing: number;
+  onSpacingChange: (multiplier: number) => void;
 }) {
   return (
     <Panel
@@ -55,6 +62,21 @@ export function WebGraphControls({
           })}
         </div>
       </fieldset>
+      {/* Spacing: a multiplier on the rendered neighbor gap. Left packs neighbors
+       * closer, right spreads them apart; density is otherwise held constant, so
+       * one setting reads the same on every web. The value persists in WebGraph. */}
+      <label className="flex flex-col gap-1">
+        <span className="text-xs text-muted-foreground">Spacing</span>
+        <input
+          type="range"
+          min={SPACING_MIN}
+          max={SPACING_MAX}
+          step={SPACING_STEP}
+          value={spacing}
+          onChange={(e) => onSpacingChange(Number(e.target.value))}
+          className="w-full cursor-pointer accent-primary"
+        />
+      </label>
     </Panel>
   );
 }

--- a/src/app/myweb/web-graph-layout.ts
+++ b/src/app/myweb/web-graph-layout.ts
@@ -55,18 +55,19 @@ export function edgeAvoidance(
   return { dvx: (rx / dist) * push, dvy: (ry / dist) * push };
 }
 
-// The longer-axis span (sim units) the settled layout is normalized to fill.
-export const NORMALIZATION_TARGET = 600;
+// The settled point cloud mapped into render space: a center (cx, cy) to
+// translate to the origin and a uniform scale. Null means there's nothing to
+// frame (empty cloud).
+export type Normalization = { cx: number; cy: number; scale: number };
+// A strategy for turning settled sim points into a Normalization. The full graph
+// scales by local spacing (computeNeighborNormalization); the mini-map by the
+// bounding box (computeNormalization). The simulation hook just calls whichever
+// it's handed, so the two views differ only in this function.
+export type Normalize = (points: ReadonlyArray<{ x: number; y: number }>) => Normalization | null;
 
-// Bounding-box normalization: center the point cloud on the origin and scale
-// its longer axis to `target` sim units, so the rendered graph fills the
-// viewport regardless of node count. A single point (or a sub-unit spread)
-// keeps scale 1 rather than blowing up. Returns null for an empty cloud.
-export function computeNormalization(
-  points: ReadonlyArray<{ x: number; y: number }>,
-  target: number,
-): { cx: number; cy: number; scale: number } | null {
-  if (points.length === 0) return null;
+// Axis-aligned bounds of the cloud — shared by both normalizers (each frames on
+// the bbox center).
+function bounds(points: ReadonlyArray<{ x: number; y: number }>) {
   let minX = points[0].x;
   let maxX = minX;
   let minY = points[0].y;
@@ -78,8 +79,70 @@ export function computeNormalization(
     if (p.y < minY) minY = p.y;
     else if (p.y > maxY) maxY = p.y;
   }
+  return { minX, maxX, minY, maxY };
+}
+
+// Bounding-box normalization: center the cloud and scale its longer axis to
+// `target` sim units, so the rendered graph fills the viewport regardless of node
+// count. A single point (or sub-unit spread) keeps scale 1 rather than blowing
+// up. Null for an empty cloud. Used by the read-only mini-map; the full graph
+// uses computeNeighborNormalization instead.
+export function computeNormalization(
+  points: ReadonlyArray<{ x: number; y: number }>,
+  target: number,
+): Normalization | null {
+  if (points.length === 0) return null;
+  const { minX, maxX, minY, maxY } = bounds(points);
   const longer = Math.max(maxX - minX, maxY - minY);
   const scale = longer > 1 ? target / longer : 1;
+  return { cx: (maxX + minX) / 2, cy: (maxY + minY) / 2, scale };
+}
+
+// The median distance from each node to its nearest neighbor (sim units): a
+// topology-aware read of how tight the settled layout actually is, which the
+// bounding box misses (it sees only the extent, not the internal spacing). O(n²),
+// but it runs only on the throttled settle ticks and at rest, over a personal
+// web's tens-to-low-hundreds of nodes. Returns 0 for fewer than two points (the
+// caller falls back to scale 1).
+export function medianNearestNeighbor(points: ReadonlyArray<{ x: number; y: number }>): number {
+  if (points.length < 2) return 0;
+  const nearest: number[] = [];
+  for (let i = 0; i < points.length; i++) {
+    let best = Number.POSITIVE_INFINITY;
+    for (let j = 0; j < points.length; j++) {
+      if (i === j) continue;
+      const dx = points[i].x - points[j].x;
+      const dy = points[i].y - points[j].y;
+      const d2 = dx * dx + dy * dy;
+      if (d2 < best) best = d2;
+    }
+    nearest.push(Math.sqrt(best));
+  }
+  nearest.sort((a, b) => a - b);
+  const mid = Math.floor(nearest.length / 2);
+  return nearest.length % 2 === 1 ? nearest[mid] : (nearest[mid - 1] + nearest[mid]) / 2;
+}
+
+// The rendered center-to-center neighbor gap (render units) the layout fills to
+// at spacing 1. A regular avatar is h-12 = 3rem = 54px at the app's 112.5% root,
+// so this is ~2× an avatar of spacing. The user's spacing multiplier rides on
+// top; this is the knob for the default feel.
+export const NEIGHBOR_GAP_BASE = 110;
+
+// Neighbor-spacing normalization: center the cloud and scale so its *median
+// nearest-neighbor* distance renders as `targetGap` units. Because the avatars
+// are a fixed size, fixing the neighbor gap fixes the perceived density —
+// invariant to node count, link strength, and clustering, none of which the
+// bounding box captures. A degenerate spread keeps scale 1. Null for an empty
+// cloud. This is what the full graph feeds the simulation.
+export function computeNeighborNormalization(
+  points: ReadonlyArray<{ x: number; y: number }>,
+  targetGap: number,
+): Normalization | null {
+  if (points.length === 0) return null;
+  const { minX, maxX, minY, maxY } = bounds(points);
+  const nn = medianNearestNeighbor(points);
+  const scale = nn > 1 ? targetGap / nn : 1;
   return { cx: (maxX + minX) / 2, cy: (maxY + minY) / 2, scale };
 }
 

--- a/src/app/myweb/web-graph-layout.ts
+++ b/src/app/myweb/web-graph-layout.ts
@@ -146,6 +146,45 @@ export function computeNeighborNormalization(
   return { cx: (maxX + minX) / 2, cy: (maxY + minY) / 2, scale };
 }
 
+// View-mode canvas sizing. The box fills the available rectangle but clamps its
+// aspect ratio to [3:4, 4:3]: a roughly square area is used whole, and only a
+// viewport more extreme than 4:3 (wide desktop) or 3:4 (portrait phone) gets
+// letterboxed — in its long direction, so the canvas still fills the short one
+// and never overflows. Width is shared by both modes (the toggle only animates
+// height), so it's returned once here.
+export const CANVAS_MAX_ASPECT = 4 / 3; // widest allowed (width:height) — 4:3 landscape
+export const CANVAS_MIN_ASPECT = 3 / 4; // tallest allowed (width:height) — 3:4 portrait
+// Edit mode's strip is this fraction of the view-mode height, so it scales with
+// the viewport (a taller window gets a taller strip) instead of a fixed px. The
+// remaining ~40% leaves room for the suggestion feed below.
+export const EDIT_HEIGHT_FRACTION = 0.6;
+
+export type CanvasDims = { width: number; viewH: number; editH: number };
+
+// The largest aspect-clamped box (see above) that fits a `w`×`h` rectangle,
+// plus the shorter edit-mode height. Null for a non-positive rectangle (nothing
+// measured yet).
+export function fitAspectClamped(w: number, h: number): CanvasDims | null {
+  if (w <= 0 || h <= 0) return null;
+  const ratio = w / h;
+  let width: number;
+  let viewH: number;
+  if (ratio > CANVAS_MAX_ASPECT) {
+    // Wider than 4:3 — fill the height, narrow the width to 4:3.
+    viewH = h;
+    width = h * CANVAS_MAX_ASPECT;
+  } else if (ratio < CANVAS_MIN_ASPECT) {
+    // Taller than 3:4 — fill the width, shorten the height to 3:4.
+    width = w;
+    viewH = w / CANVAS_MIN_ASPECT;
+  } else {
+    // In range — fill the whole rectangle.
+    width = w;
+    viewH = h;
+  }
+  return { width, viewH, editH: viewH * EDIT_HEIGHT_FRACTION };
+}
+
 // First-hop ring radius (sim units) and the gap added per additional hop. The
 // first ring sits near linkDistance's range (110..230) so the force layout
 // barely has to move it; normalization rescales the whole cloud to the viewport

--- a/src/app/myweb/web-graph-renderers.tsx
+++ b/src/app/myweb/web-graph-renderers.tsx
@@ -88,6 +88,10 @@ function MemberNode({ id, data }: NodeProps<Node<MemberNodeData>>) {
   // emphasized node is primary-teal, rest default.
   const onLitPath = selection?.litNodeIds.has(id) === true;
   const borderClass = onLitPath ? "border-success" : data.emphasized ? "border-primary" : "border-border";
+  // The emphasized (root/you) avatar is 1.18× the regular h-12 (3rem) base — an
+  // arbitrary 3.54rem, since 1.18× isn't a Tailwind spacing step (h-14 = 3.5rem is
+  // the nearest). Both keep border-2, so the ring adds equally either way.
+  const sizeClass = data.emphasized ? "h-[3.54rem] w-[3.54rem]" : "h-12 w-12";
   return (
     // Only the Avatar is a click target: the wrapper is pointer-events-none and
     // .react-flow__node is !pointer-events-none (set per-node above), so clicks on
@@ -101,9 +105,7 @@ function MemberNode({ id, data }: NodeProps<Node<MemberNodeData>>) {
         <Avatar
           name={data.displayName}
           url={data.avatarUrl}
-          className={`pointer-events-auto flex cursor-pointer items-center justify-center overflow-hidden rounded-full border-2 [clip-path:circle()] ${
-            data.emphasized ? "h-16 w-16" : "h-12 w-12"
-          } ${borderClass} bg-muted text-base font-semibold text-muted-foreground`}
+          className={`pointer-events-auto flex cursor-pointer items-center justify-center overflow-hidden rounded-full border-2 [clip-path:circle()] ${sizeClass} ${borderClass} bg-muted text-base font-semibold text-muted-foreground`}
         />
         {/* Dim wash clipped to the avatar circle (rounded-full, never a square
             over the edges behind), blended over the opaque avatar so endpoints

--- a/src/app/myweb/web-graph-renderers.tsx
+++ b/src/app/myweb/web-graph-renderers.tsx
@@ -150,6 +150,11 @@ export type EdgeInteraction = {
   // number shows when its id matches either.
   hoverEdgeId: string | null;
   selectedEdgeId: string | null;
+  // The selected node's lit path-to-center edges, whose numbers also show so a
+  // highlighted path reads its relation values. Direction-stamped both ways, so
+  // an edge id (one direction) matches by set membership. Empty when no node is
+  // selected.
+  litEdgeIds: ReadonlySet<string>;
   previewEdge: (id: string) => void;
   endPreviewSoon: () => void;
 };
@@ -172,7 +177,9 @@ function NumberedEdge({ id, sourceX, sourceY, targetX, targetY, style, data }: E
   const [edgePath, labelX, labelY] = getStraightPath({ sourceX, sourceY, targetX, targetY });
   const interaction = useContext(EdgeInteractionContext);
   const isClickable = data?.isOutgoing === true && interaction !== null;
-  const isVisible = interaction !== null && (interaction.hoverEdgeId === id || interaction.selectedEdgeId === id);
+  const isVisible =
+    interaction !== null &&
+    (interaction.hoverEdgeId === id || interaction.selectedEdgeId === id || interaction.litEdgeIds.has(id));
   const handleClick = isClickable
     ? () =>
         interaction?.openRelating({

--- a/src/app/myweb/web-graph-renderers.tsx
+++ b/src/app/myweb/web-graph-renderers.tsx
@@ -18,7 +18,7 @@ import type { RelationSubgraph } from "@/lib/api-types";
 import { isRelationValue } from "@/lib/relation-value";
 
 import type { RelatingTarget } from "./relating-dialog";
-import { DIM_KEEP } from "./web-graph-selection";
+import { DIM_KEEP, EDGE_LABEL_Z } from "./web-graph-selection";
 
 // The two custom ReactFlow renderers — the member node and the numbered edge —
 // plus the data shapes they read and the interaction contexts WebGraph fills.
@@ -196,6 +196,11 @@ function NumberedEdge({ id, sourceX, sourceY, targetX, targetY, style, data }: E
           style={{
             position: "absolute",
             transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            // Lift the revealed pill above the hover tier so its halo never tucks
+            // under a lifted avatar. The edge-label layer is stacking-transparent,
+            // so this competes in the viewport (see EDGE_LABEL_Z). Hidden pills
+            // stay at auto — they're invisible and capture no clicks anyway.
+            zIndex: isVisible ? EDGE_LABEL_Z : undefined,
           }}
           className={`flex h-5 w-5 items-center justify-center rounded-full bg-canvas/80 text-xs font-semibold text-canvas-foreground transition-opacity duration-150 ${
             isVisible ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"

--- a/src/app/myweb/web-graph-renderers.tsx
+++ b/src/app/myweb/web-graph-renderers.tsx
@@ -63,6 +63,11 @@ export type NodeInteraction = {
   // The clicked node, kept at hover size so a selection reads as "this one's it."
   // Null in read-only views (the mini-map navigates on click instead).
   selectedNodeId: string | null;
+  // Nodes whose name label is shown. Names are hidden by default and revealed
+  // for the lit path (a node selection) plus transient hover — a node, or a
+  // connected edge (its two endpoints); everything else stays nameless. Mirrors
+  // the edge-number reveal. WebGraph builds the set.
+  labeledNodeIds: ReadonlySet<string>;
   // The viewer's node — its name label reads "You" in place of the member name
   // (how the mini-map marks you). Null in the full graph, where you're the
   // obvious center.
@@ -74,6 +79,9 @@ function MemberNode({ id, data }: NodeProps<Node<MemberNodeData>>) {
   const selection = useContext(NodeInteractionContext);
   const isSelected = selection?.selectedNodeId === id;
   const isViewer = selection?.viewerCueNodeId === id;
+  // Names are hidden by default; this node's shows only while it's labeled
+  // (lit path, or hovered directly / via a connected edge).
+  const labeled = selection?.labeledNodeIds.has(id) === true;
   // When dimming is on, every node off the lit set dims (see DIM_KEEP).
   const isDimmed = selection?.dimUnlit === true && !selection.litNodeIds.has(id);
   // Every lit node gets the green border to match the links; otherwise the
@@ -106,14 +114,23 @@ function MemberNode({ id, data }: NodeProps<Node<MemberNodeData>>) {
           style={{ opacity: isDimmed ? 1 - DIM_KEEP : 0 }}
         />
       </div>
-      {/* The name dims by mixing its text color toward the canvas — color paints
-          only the glyphs, so no covering box (square) and no bleed-through. The
+      {/* Hidden by default, faded in when labeled (hover or lit path). Kept
+          mounted at opacity 0 rather than unmounted so the node's height never
+          shifts as names appear (no reflow against the fixed layout). The
           viewer's own node reads "You" in place of their name (mini-map cue). */}
       <div
-        className="pointer-events-none max-w-[8rem] truncate text-sm font-medium transition-colors duration-150"
-        style={
-          isDimmed ? { color: `color-mix(in srgb, currentColor ${DIM_KEEP * 100}%, var(--color-canvas))` } : undefined
-        }
+        aria-hidden={!labeled}
+        className="pointer-events-none max-w-[8rem] truncate text-sm font-medium transition-opacity duration-150"
+        style={{
+          opacity: labeled ? 1 : 0,
+          // Canvas-colored halo so the name reads over the dense edge lines
+          // behind it — those strokes are canvas-foreground, the same color
+          // family as the text, so without a moat the glyphs blend in.
+          // paint-order:stroke draws the stroke behind the fill, so it's a true
+          // outline (glyphs stay crisp) rather than a thinned weight.
+          paintOrder: "stroke",
+          WebkitTextStroke: "3px var(--color-canvas)",
+        }}
       >
         {isViewer ? "You" : (data.displayName ?? "—")}
       </div>

--- a/src/app/myweb/web-graph-selection.ts
+++ b/src/app/myweb/web-graph-selection.ts
@@ -97,35 +97,41 @@ type EdgeDecoration = {
   // WebGraph dims off-path on a click; the mini-map leaves the rest at full
   // strength (the lit path is co-equal content, not a spotlight).
   dimUnlit: boolean;
-  // Whether a click on an edge does anything in this canvas — true in the full
-  // graph (a click selects the edge and reveals its number; an outgoing edge's
-  // second click opens the relating dialog), false in the read-only mini-map.
-  // Drives cursor:pointer, since every edge is equally clickable.
+  // Whether clicks on edges do anything in this canvas — true in the full graph
+  // (a click selects the edge and reveals its number; an outgoing edge's second
+  // click opens the relating dialog), false in the read-only mini-map. Gates the
+  // cursor:pointer that marks the editable (outgoing) edges.
   edgesClickable: boolean;
   // The edge under the pointer, lifted above the tangle so it's traceable end to
   // end. Null when nothing is hovered / in read-only views.
   hoverEdgeId: string | null;
 };
 
-// Edge decorations layered onto the base edges: cursor:pointer on every edge
-// when the canvas's edges are clickable; the lit edges painted success-green and
-// lifted above the rest; every other edge dimmed by blending its stroke toward
-// the canvas when dimUnlit is set. Untouched edges are returned by reference, so
-// this stays a cheap diff. Generic so callers keep their concrete edge type.
-export function decorateEdges<E extends Edge>(
+// Edge decorations layered onto the base edges: cursor:pointer on an editable
+// (outgoing) edge when the canvas's edges are clickable — matching its value
+// bubble, so an incoming or 2nd-degree link reads as inert; the lit edges painted
+// success-green and lifted above the rest; every other edge dimmed by blending
+// its stroke toward the canvas when dimUnlit is set. Untouched edges are returned
+// by reference, so this stays a cheap diff. Generic so callers keep their
+// concrete edge type.
+export function decorateEdges<E extends Edge<{ isOutgoing?: boolean }>>(
   edges: readonly E[],
   { litEdgeIds, dimUnlit, edgesClickable, hoverEdgeId }: EdgeDecoration,
 ): E[] {
   return edges.map((e) => {
+    // Pointer only on your own (outgoing) edges — the ones whose value bubble is
+    // itself clickable; an incoming or 2nd-degree link stays cursor-default so the
+    // line and the bubble agree.
+    const cursor = edgesClickable && e.data?.isOutgoing === true;
     const onPath = litEdgeIds.has(e.id);
     const dim = dimUnlit && !onPath;
     const hovered = e.id === hoverEdgeId;
-    if (!edgesClickable && !onPath && !dim && !hovered) return e;
+    if (!cursor && !onPath && !dim && !hovered) return e;
     const next = { ...e } as E;
-    if (edgesClickable) {
+    if (cursor) {
       // ReactFlow merges className onto the edge's <g>; cursor inherits down to
       // both the visible line and the wider invisible interaction path, so the
-      // whole line signals it's clickable.
+      // whole line signals it's editable.
       next.className = "cursor-pointer";
     }
     if (onPath) {

--- a/src/app/myweb/web-graph-selection.ts
+++ b/src/app/myweb/web-graph-selection.ts
@@ -17,6 +17,20 @@ export const DIM_KEEP = 0.7;
 export const SELECTION_EDGE_Z = 1000;
 export const SELECTION_NODE_Z = 1001;
 
+// One tier above the selection: the element under the pointer is the user's live
+// focus, so a hover rides over even a lit path. The same node > edge gap keeps an
+// avatar capping the lines into it — a hovered edge's endpoints lift for their
+// names and stay above the hovered line.
+export const HOVER_EDGE_Z = 1002;
+export const HOVER_NODE_Z = 1003;
+
+// The edge's value pill renders in xyflow's edge-label layer, which sits *before*
+// the nodes in the DOM and forms no stacking context of its own — so by default
+// an avatar paints over it, and a hover-lifted endpoint (HOVER_NODE_Z) certainly
+// does. A z-index on the pill therefore competes directly in the viewport; one
+// tier above the hover nodes keeps a revealed number on top of everything.
+export const EDGE_LABEL_Z = 1004;
+
 // Breadth-first shortest-path tree from `centerId` over the (undirected) edge
 // set. Returns parent pointers (center → null); nodes unreachable from the
 // center are absent. Ties break by edge insertion order — the route BFS reaches
@@ -83,30 +97,35 @@ type EdgeDecoration = {
   // WebGraph dims off-path on a click; the mini-map leaves the rest at full
   // strength (the lit path is co-equal content, not a spotlight).
   dimUnlit: boolean;
-  // The edge to mark cursor:pointer because it's selected and editable. Null in
-  // read-only views (the mini-map doesn't edit edges).
-  selectedEdgeId: string | null;
+  // Whether a click on an edge does anything in this canvas — true in the full
+  // graph (a click selects the edge and reveals its number; an outgoing edge's
+  // second click opens the relating dialog), false in the read-only mini-map.
+  // Drives cursor:pointer, since every edge is equally clickable.
+  edgesClickable: boolean;
+  // The edge under the pointer, lifted above the tangle so it's traceable end to
+  // end. Null when nothing is hovered / in read-only views.
+  hoverEdgeId: string | null;
 };
 
-// Edge decorations layered onto the base edges: cursor:pointer on a selected
-// editable (outgoing) edge; the lit edges painted success-green and lifted above
-// the rest; every other edge dimmed by blending its stroke toward the canvas
-// when dimUnlit is set. Untouched edges are returned by reference, so this stays
-// a cheap diff. Generic so callers keep their concrete edge type.
-export function decorateEdges<E extends Edge<{ isOutgoing?: boolean }>>(
+// Edge decorations layered onto the base edges: cursor:pointer on every edge
+// when the canvas's edges are clickable; the lit edges painted success-green and
+// lifted above the rest; every other edge dimmed by blending its stroke toward
+// the canvas when dimUnlit is set. Untouched edges are returned by reference, so
+// this stays a cheap diff. Generic so callers keep their concrete edge type.
+export function decorateEdges<E extends Edge>(
   edges: readonly E[],
-  { litEdgeIds, dimUnlit, selectedEdgeId }: EdgeDecoration,
+  { litEdgeIds, dimUnlit, edgesClickable, hoverEdgeId }: EdgeDecoration,
 ): E[] {
   return edges.map((e) => {
-    const cursor = e.id === selectedEdgeId && e.data?.isOutgoing === true;
     const onPath = litEdgeIds.has(e.id);
     const dim = dimUnlit && !onPath;
-    if (!cursor && !onPath && !dim) return e;
+    const hovered = e.id === hoverEdgeId;
+    if (!edgesClickable && !onPath && !dim && !hovered) return e;
     const next = { ...e } as E;
-    if (cursor) {
+    if (edgesClickable) {
       // ReactFlow merges className onto the edge's <g>; cursor inherits down to
       // both the visible line and the wider invisible interaction path, so the
-      // whole line signals it's editable.
+      // whole line signals it's clickable.
       next.className = "cursor-pointer";
     }
     if (onPath) {
@@ -120,14 +139,26 @@ export function decorateEdges<E extends Edge<{ isOutgoing?: boolean }>>(
         stroke: `color-mix(in srgb, var(--color-canvas-foreground) ${DIM_KEEP * 100}%, var(--color-canvas))`,
       };
     }
+    // The pointer focus outranks the lit path, so apply it last — a hovered
+    // line lifts above everything (recolor untouched; hover only reveals).
+    if (hovered) next.zIndex = HOVER_EDGE_Z;
     return next;
   });
 }
 
-// Lift the lit nodes above the rest so a highlight never sits under a dimmed
-// node. Returns the same array reference when nothing is lit, so the caller's
-// memo stays stable. Generic so callers keep their concrete node type.
-export function decorateNodes<N extends Node>(nodes: N[], { litNodeIds }: { litNodeIds: ReadonlySet<string> }): N[] {
-  if (litNodeIds.size === 0) return nodes;
-  return nodes.map((n) => (litNodeIds.has(n.id) ? ({ ...n, zIndex: SELECTION_NODE_Z } as N) : n));
+// Lift the lit nodes above the dimmed rest, and the hovered nodes above even
+// that — so a highlight never sits under a dimmed node, and a hovered node (with
+// its revealed name) clears its neighbors. Hover wins when a node is both.
+// Returns the same array reference when nothing is lifted, so the caller's memo
+// stays stable. Generic so callers keep their concrete node type.
+export function decorateNodes<N extends Node>(
+  nodes: N[],
+  { litNodeIds, hoverNodeIds }: { litNodeIds: ReadonlySet<string>; hoverNodeIds: ReadonlySet<string> },
+): N[] {
+  if (litNodeIds.size === 0 && hoverNodeIds.size === 0) return nodes;
+  return nodes.map((n) => {
+    if (hoverNodeIds.has(n.id)) return { ...n, zIndex: HOVER_NODE_Z } as N;
+    if (litNodeIds.has(n.id)) return { ...n, zIndex: SELECTION_NODE_Z } as N;
+    return n;
+  });
 }

--- a/src/app/myweb/web-graph-selection.ts
+++ b/src/app/myweb/web-graph-selection.ts
@@ -31,6 +31,17 @@ export const HOVER_NODE_Z = 1003;
 // tier above the hover nodes keeps a revealed number on top of everything.
 export const EDGE_LABEL_Z = 1004;
 
+// Edge ids are direction-stamped `relator->relatee`. Member ids are UUIDs and
+// never contain the separator, so the two endpoints split back out cleanly. This
+// pair is the one home for that convention — every edge id is built with edgeId
+// and taken apart with edgeEndpoints.
+const EDGE_ID_SEP = "->";
+export const edgeId = (relatorId: string, relateeId: string): string => `${relatorId}${EDGE_ID_SEP}${relateeId}`;
+export const edgeEndpoints = (id: string): [relatorId: string, relateeId: string] => {
+  const [relatorId, relateeId] = id.split(EDGE_ID_SEP);
+  return [relatorId, relateeId];
+};
+
 // Breadth-first shortest-path tree from `centerId` over the (undirected) edge
 // set. Returns parent pointers (center → null); nodes unreachable from the
 // center are absent. Ties break by edge insertion order — the route BFS reaches
@@ -82,8 +93,8 @@ export function pathToCenter(
     pathNodeIds.add(cur);
     const par = parentByNode.get(cur);
     if (par == null) break;
-    pathEdgeIds.add(`${par}->${cur}`);
-    pathEdgeIds.add(`${cur}->${par}`);
+    pathEdgeIds.add(edgeId(par, cur));
+    pathEdgeIds.add(edgeId(cur, par));
     cur = par;
   }
   return { pathNodeIds, pathEdgeIds };

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -354,11 +354,6 @@ export function WebGraph({
   }, [clearPreviewTimer]);
   useEffect(() => clearPreviewTimer, [clearPreviewTimer]);
 
-  const edgeInteraction = useMemo<EdgeInteraction>(
-    () => ({ openRelating: onOpenRelating, hoverEdgeId, selectedEdgeId, previewEdge, endPreviewSoon }),
-    [onOpenRelating, hoverEdgeId, selectedEdgeId, previewEdge, endPreviewSoon],
-  );
-
   // Shortest-path tree from the center over the (undirected) edge set, rebuilt
   // once per subgraph. Selecting a node walks these parent pointers back to the
   // center to find the chain that should stay lit while the rest dims.
@@ -374,6 +369,21 @@ export function WebGraph({
   const { pathNodeIds, pathEdgeIds } = useMemo(
     () => pathToCenter(selectedNodeId, parentByNode),
     [selectedNodeId, parentByNode],
+  );
+
+  // The selected node's path edges (litEdgeIds) reveal their value bubbles too,
+  // alongside the hovered/selected edge — so highlighting a path shows the
+  // relation values along it. Empty unless a node is selected.
+  const edgeInteraction = useMemo<EdgeInteraction>(
+    () => ({
+      openRelating: onOpenRelating,
+      hoverEdgeId,
+      selectedEdgeId,
+      litEdgeIds: pathEdgeIds,
+      previewEdge,
+      endPreviewSoon,
+    }),
+    [onOpenRelating, hoverEdgeId, selectedEdgeId, pathEdgeIds, previewEdge, endPreviewSoon],
   );
 
   // A node selection lights its path back to you and dims everything off it; an

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -39,24 +39,56 @@ const fetchSubgraph = async (opts: SubgraphViewOptions) => {
   return res.json();
 };
 
-// View<->edit canvas animation. View is a square whose height tracks the
-// measured width; edit collapses to EDIT_HEIGHT. Width never changes between
-// modes, so only the height animates — top-anchored, so the bottom edge
-// travels while ReactFlow re-fits each frame to scale the graph with the box.
-const EDIT_HEIGHT = 500;
+// View<->edit canvas sizing. View mode fills the available rectangle as fully as
+// it can, clamping only its aspect ratio to the [3:4, 4:3] range — so a roughly
+// square area is used whole, and only a viewport more extreme than 4:3 (wide
+// desktop) or 3:4 (portrait phone) gets letterboxed in its long direction. Edit
+// mode collapses to a shorter strip so the suggestion feed below stays on
+// screen. Width is identical between modes — only the height animates on the
+// toggle (top-anchored, so the bottom edge travels while ReactFlow re-fits each
+// frame to scale the graph with the box).
+const MAX_ASPECT = 4 / 3; // widest allowed (width:height) — 4:3 landscape
+const MIN_ASPECT = 3 / 4; // tallest allowed (width:height) — 3:4 portrait
+// Edit mode's strip is this fraction of the view-mode height, so it scales with
+// the viewport (a taller window gets a taller strip) instead of a fixed px. The
+// remaining ~40% leaves room for the suggestion feed below.
+const EDIT_HEIGHT_FRACTION = 0.6;
+// Space reserved below the canvas — the page's own padding (main's pb-8 / px-8,
+// both 2rem) so the gap under the canvas matches the gap beside it. Resolved
+// from the live root font-size rather than assuming 16px (the app sets it
+// larger), so it lands on the same px the page padding uses; the canvas bottom
+// then sits exactly pb-8 above the viewport floor, totalling 100vh, so view
+// mode never spills into a vertical scrollbar. (Edit mode's feed legitimately
+// scrolls — the no-scrollbar guarantee is a view-mode one.)
+const PAGE_PAD_REM = 2;
+const bottomReserve = () => PAGE_PAD_REM * (parseFloat(getComputedStyle(document.documentElement).fontSize) || 16);
 const MODE_ANIM_MS = 1000;
 const MODE_ANIM_EASE = "cubic-bezier(0.45, 0, 0.55, 1)"; // accelerate + decelerate
 
 export function WebGraph({
-  square,
+  expanded,
   onOpenRelating,
   onReplayTour,
+  mode,
+  onEdit,
+  onDone,
+  donePending,
+  doneError,
 }: {
-  // View mode renders a tall, centered square canvas; edit mode keeps the
-  // shorter landscape strip so the suggestion feed below stays in view.
-  square: boolean;
+  // View mode expands the canvas to fill the available space (aspect clamped to
+  // the 3:4–4:3 range); edit mode keeps the shorter strip so the suggestion feed
+  // below stays in view.
+  expanded: boolean;
   onOpenRelating: (target: RelatingTarget) => void;
   onReplayTour: () => void;
+  // The Edit/Done toggle lives in the canvas's lower-left corner (a Panel
+  // below), but its state and the mark-done mutation stay in MyWeb — passed
+  // down here so the toggle travels with the graph chrome.
+  mode: "edit" | "view";
+  onEdit: () => void;
+  onDone: () => void;
+  donePending: boolean;
+  doneError: boolean;
 }) {
   const router = useRouter();
   const [view, setView] = useState<SubgraphViewOptions>(DEFAULT_SUBGRAPH_VIEW);
@@ -159,53 +191,103 @@ export function WebGraph({
     fitViewRef.current = fitView;
   }, []);
 
-  // Canvas height animation. Width is CSS-driven (w-full, capped to the
-  // viewport height); we measure the resulting width and use it as the
-  // square's height in view mode, collapsing to EDIT_HEIGHT in edit mode.
-  const [graphWidth, setGraphWidth] = useState(0);
-  const lastWidthRef = useRef(0);
+  // The available box: the full width of the canvas's wrapper, and the vertical
+  // space from the wrapper's top down to the viewport bottom (less BOTTOM_RESERVE).
+  // The wrapper top is set by the page chrome above (header + gaps), which never
+  // changes with the box height, so measuring it is stable across mode toggles.
+  const [avail, setAvail] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
+  const lastAvailRef = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
   // Transition is armed for mode toggles but disarmed for the initial measure
   // and for resizes, so the box tracks the window instantly rather than easing.
   const [animateHeight, setAnimateHeight] = useState(false);
+  const wrapElRef = useRef<HTMLDivElement | null>(null);
   const resizeObsRef = useRef<ResizeObserver | null>(null);
-  // Callback ref: attach the observer once the graph element mounts (it only
-  // renders after the loading/empty early-returns below).
-  const measureRef = useCallback((el: HTMLDivElement | null) => {
-    resizeObsRef.current?.disconnect();
-    if (!el) {
-      resizeObsRef.current = null;
-      return;
-    }
-    const ro = new ResizeObserver((entries) => {
-      const w = entries[0].contentRect.width;
-      // Ignore height-only changes (our own animation); only width changes
-      // (resize) re-derive the square's height, and should do so instantly.
-      if (Math.abs(w - lastWidthRef.current) < 0.5) return;
-      lastWidthRef.current = w;
-      setAnimateHeight(false);
-      setGraphWidth(w);
-    });
-    ro.observe(el);
-    resizeObsRef.current = ro;
+  const measure = useCallback(() => {
+    const el = wrapElRef.current;
+    if (!el) return;
+    const w = el.clientWidth;
+    const h = Math.max(0, window.innerHeight - el.getBoundingClientRect().top - bottomReserve());
+    const prev = lastAvailRef.current;
+    if (Math.abs(w - prev.w) < 0.5 && Math.abs(h - prev.h) < 0.5) return;
+    lastAvailRef.current = { w, h };
+    setAnimateHeight(false); // a resize commits instantly; only mode toggles ease
+    setAvail({ w, h });
   }, []);
+  // Callback ref: attach a width observer once the wrapper mounts (it only
+  // renders after the loading/empty early-returns below). A ResizeObserver on a
+  // full-width element catches layout-width changes; a window 'resize' listener
+  // (below) catches viewport-height changes the observer wouldn't see.
+  const wrapRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      resizeObsRef.current?.disconnect();
+      wrapElRef.current = el;
+      if (!el) {
+        resizeObsRef.current = null;
+        return;
+      }
+      measure();
+      const ro = new ResizeObserver(() => measure());
+      ro.observe(el);
+      resizeObsRef.current = ro;
+    },
+    [measure],
+  );
+  useEffect(() => {
+    window.addEventListener("resize", measure);
+    // Web fonts load after first paint and grow the header a few px, shifting
+    // the wrapper's top — a one-time drift neither observer above would catch,
+    // and which would otherwise leave the height slightly too tall (a faint
+    // scrollbar). Re-measure once fonts settle. (?. short-circuits the whole
+    // chain where FontFaceSet is absent, e.g. jsdom.)
+    document.fonts?.ready.then(() => measure());
+    return () => window.removeEventListener("resize", measure);
+  }, [measure]);
+
+  // The largest box that fits the available rectangle with its aspect ratio
+  // clamped to [3:4, 4:3]. When the rectangle's own ratio is already in range we
+  // use it whole (no waste — square, 4:3, whatever it is); only a more extreme
+  // viewport letterboxes, and then in its long direction so the canvas still
+  // fills the short one and never overflows (no vertical scrollbar). Width is
+  // shared by both modes so the toggle never shifts the box sideways.
+  const dims = useMemo(() => {
+    const { w, h } = avail;
+    if (w <= 0 || h <= 0) return null;
+    const ratio = w / h;
+    let width: number;
+    let viewH: number;
+    if (ratio > MAX_ASPECT) {
+      // Wider than 4:3 — fill the height, narrow the width to 4:3.
+      viewH = h;
+      width = h * MAX_ASPECT;
+    } else if (ratio < MIN_ASPECT) {
+      // Taller than 3:4 — fill the width, shorten the height to 3:4.
+      width = w;
+      viewH = w / MIN_ASPECT;
+    } else {
+      // In range — fill the whole rectangle.
+      width = w;
+      viewH = h;
+    }
+    return { width, viewH, editH: viewH * EDIT_HEIGHT_FRACTION };
+  }, [avail]);
 
   // Re-arm the transition one frame after the initial measure or a resize, so
   // the next mode toggle eases but the size change that just committed didn't.
   useEffect(() => {
-    if (graphWidth > 0 && !animateHeight) {
+    if (dims && !animateHeight) {
       const id = requestAnimationFrame(() => setAnimateHeight(true));
       return () => cancelAnimationFrame(id);
     }
-  }, [graphWidth, animateHeight]);
+  }, [dims, animateHeight]);
 
   // On a mode toggle, re-fit every frame for the duration of the height
   // transition so the graph zooms to match the shrinking/growing box. The
   // height eases via CSS, so fitting to the current box each frame inherits
   // that easing. Skips the first run (initial mount fits via the sim).
   const firstModeRef = useRef(true);
-  // `square` is the trigger, not a read value — the effect must re-run each
+  // `expanded` is the trigger, not a read value — the effect must re-run each
   // time the mode flips so the fit follows the height transition.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: square triggers the per-toggle re-fit
+  // biome-ignore lint/correctness/useExhaustiveDependencies: expanded triggers the per-toggle re-fit
   useEffect(() => {
     if (firstModeRef.current) {
       firstModeRef.current = false;
@@ -219,7 +301,7 @@ export function WebGraph({
     return () => {
       if (raf) cancelAnimationFrame(raf);
     };
-  }, [square]);
+  }, [expanded]);
 
   // Edge-number reveal. Numbers stay hidden until shown one of two ways:
   //   - hover (desktop): a transient preview while the pointer is on the line
@@ -323,130 +405,155 @@ export function WebGraph({
   // narrows the nullable memo for the canvas below.
   if (!filtered) return null;
 
-  // Width is identical in both modes — w-full capped to the viewport height,
-  // free of the page's max-w-5xl wrapper so on tall displays the square grows
-  // past 1024px. Only the height differs: the measured width (a square) in
-  // view mode, EDIT_HEIGHT in edit mode. Animating just the height keeps the
-  // box from ever widening on the toggle; the top stays put, so the bottom
-  // edge is what travels.
-  const heightPx = graphWidth > 0 ? (square ? graphWidth : Math.min(graphWidth, EDIT_HEIGHT)) : undefined;
+  // Width is shared by both modes (from `dims`); only the height differs —
+  // the full fitted height in view mode, the EDIT_HEIGHT-capped strip in edit
+  // mode. Animating just the height keeps the box from shifting sideways on
+  // the toggle; the top stays put, so the bottom edge is what travels.
+  const heightPx = dims ? (expanded ? dims.viewH : dims.editH) : undefined;
 
   return (
-    <div
-      ref={measureRef}
-      data-tour="graph"
-      style={{
-        height: heightPx ? `${heightPx}px` : undefined,
-        transition: animateHeight ? `height ${MODE_ANIM_MS}ms ${MODE_ANIM_EASE}` : undefined,
-      }}
-      className="mx-auto w-full max-w-[calc(100vh_-_12rem)] overflow-hidden rounded border border-border bg-canvas [--xy-background-color:var(--color-canvas)]"
-    >
-      <WebGraphCanvas
-        subgraph={filtered}
-        litNodeIds={pathNodeIds}
-        litEdgeIds={pathEdgeIds}
-        dimUnlit={dimUnlit}
-        selectedNodeId={selectedNodeId}
-        selectedEdgeId={selectedEdgeId}
-        edgeInteraction={edgeInteraction}
-        onReady={handleCanvasReady}
-        // Hover previews a number on desktop (off while an edge is selected).
-        onEdgeMouseEnter={(_event, edge) => previewEdge(edge.id)}
-        onEdgeMouseLeave={() => endPreviewSoon()}
-        // Click/tap a line selects it and shows its number; a second click on
-        // the selected line opens the relating dialog (clicking the number
-        // does the same). Tap within the edge's interactionWidth (±5px) on mobile.
-        onEdgeClick={(_event, edge) => {
-          clearPreviewTimer();
-          // Selecting an edge supersedes any node selection.
-          setSelectedNodeId(null);
-          if (selectedEdgeId === edge.id) {
-            const d = edge.data;
-            if (d?.isOutgoing) {
-              onOpenRelating({
-                id: d.relateeId,
-                displayName: d.relateeName,
-                currentValue: isRelationValue(d.value) ? d.value : null,
-              });
-            }
-            return;
-          }
-          setSelectedEdgeId(edge.id);
+    // Full-width wrapper: its width is the available width (clientWidth) and
+    // its top is the canvas's offset from the viewport top — both read by
+    // measure() to size the centered box inside without measuring the box's
+    // own (derived) width, which would be circular.
+    <div ref={wrapRef} className="w-full">
+      <div
+        data-tour="graph"
+        style={{
+          width: dims ? `${dims.width}px` : undefined,
+          height: heightPx ? `${heightPx}px` : undefined,
+          transition: animateHeight ? `height ${MODE_ANIM_MS}ms ${MODE_ANIM_EASE}` : undefined,
         }}
-        onPaneClick={() => clearSelection()}
-        onNodeClick={(_event, node) => {
-          // Select the node (re-click toggles off): lights its path back to
-          // you and dims the rest. No viewport pan; clears any edge
-          // selection. Double-click still opens the member's profile.
-          clearPreviewTimer();
-          setHoverEdgeId(null);
-          setSelectedEdgeId(null);
-          setSelectedNodeId((cur) => (cur === node.id ? null : node.id));
-        }}
-        onNodeDoubleClick={(_event, node) => {
-          const slug = node.data.slug ?? node.data.id;
-          router.push(`/members/${slug}`);
-        }}
+        className="mx-auto overflow-hidden rounded border border-border bg-canvas [--xy-background-color:var(--color-canvas)]"
       >
-        {/* Built-in +/-/fit-view buttons for users who can't or don't
-         * want to scroll-zoom (trackpad pinch, mouse wheel). Lock toggle
-         * is hidden — selection and connection are already disabled. */}
-        <Controls position="top-left" showInteractive={false} />
-        <Panel position="bottom-right" className="flex flex-row-reverse items-end gap-2">
-          {/* Click-to-toggle (not hover) so the hints stay reachable on
-           * touch devices where hover doesn't exist. */}
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            aria-label={hintOpen ? "Hide canvas tips" : "Show canvas tips"}
-            aria-expanded={hintOpen}
-            aria-controls="web-graph-hints"
-            onClick={() => setHintOpen((h) => !h)}
-            className="rounded-full border border-border bg-background/90 font-bold"
-          >
-            ?
-          </Button>
-          {hintOpen && (
-            <div
-              id="web-graph-hints"
-              className="flex max-w-[18rem] flex-col gap-2 rounded border border-border bg-background/90 p-2 text-sm text-muted-foreground"
-            >
-              <ul className="flex flex-col gap-1">
-                <li>Drag the background to pan.</li>
-                <li>Drag a circle to reposition it.</li>
-                <li>Scroll or pinch to zoom.</li>
-                <li>Single-click a circle to highlight its path to you.</li>
-                <li>Double-click a circle to open their profile.</li>
-                <li>
-                  <span className="font-medium text-foreground">Friends-of-friends</span> adds your connections&apos;
-                  connections.
-                </li>
-                <li>
-                  Toggle <span className="font-medium text-foreground">1–4</span> to show only those relationship
-                  depths.
-                </li>
-              </ul>
-              <button
-                type="button"
-                onClick={() => {
-                  setHintOpen(false);
-                  onReplayTour();
-                }}
-                className="self-start text-foreground underline underline-offset-2 hover:text-primary"
+        <WebGraphCanvas
+          subgraph={filtered}
+          litNodeIds={pathNodeIds}
+          litEdgeIds={pathEdgeIds}
+          dimUnlit={dimUnlit}
+          selectedNodeId={selectedNodeId}
+          selectedEdgeId={selectedEdgeId}
+          edgeInteraction={edgeInteraction}
+          onReady={handleCanvasReady}
+          // Hover previews a number on desktop (off while an edge is selected).
+          onEdgeMouseEnter={(_event, edge) => previewEdge(edge.id)}
+          onEdgeMouseLeave={() => endPreviewSoon()}
+          // Click/tap a line selects it and shows its number; a second click on
+          // the selected line opens the relating dialog (clicking the number
+          // does the same). Tap within the edge's interactionWidth (±5px) on mobile.
+          onEdgeClick={(_event, edge) => {
+            clearPreviewTimer();
+            // Selecting an edge supersedes any node selection.
+            setSelectedNodeId(null);
+            if (selectedEdgeId === edge.id) {
+              const d = edge.data;
+              if (d?.isOutgoing) {
+                onOpenRelating({
+                  id: d.relateeId,
+                  displayName: d.relateeName,
+                  currentValue: isRelationValue(d.value) ? d.value : null,
+                });
+              }
+              return;
+            }
+            setSelectedEdgeId(edge.id);
+          }}
+          onPaneClick={() => clearSelection()}
+          onNodeClick={(_event, node) => {
+            // Select the node (re-click toggles off): lights its path back to
+            // you and dims the rest. No viewport pan; clears any edge
+            // selection. Double-click still opens the member's profile.
+            clearPreviewTimer();
+            setHoverEdgeId(null);
+            setSelectedEdgeId(null);
+            setSelectedNodeId((cur) => (cur === node.id ? null : node.id));
+          }}
+          onNodeDoubleClick={(_event, node) => {
+            const slug = node.data.slug ?? node.data.id;
+            router.push(`/members/${slug}`);
+          }}
+        >
+          {/* Built-in +/-/fit-view buttons for users who can't or don't
+           * want to scroll-zoom (trackpad pinch, mouse wheel). Lock toggle
+           * is hidden — selection and connection are already disabled. */}
+          <Controls position="top-left" showInteractive={false} />
+          {/* Edit/Done in the lower-left corner so the toggle rides with the
+           * graph chrome and the page below stays clear for the feed. Same
+           * affordance in both modes, different label. The Done button carries
+           * the welcome tour's finishing-step anchor (data-tour). */}
+          <Panel position="bottom-left" className="flex flex-col items-start gap-2">
+            {doneError && (
+              <p
+                role="alert"
+                className="max-w-[16rem] rounded border border-border bg-background/90 p-2 text-sm text-destructive"
               >
-                Replay guided tour
-              </button>
-            </div>
-          )}
-        </Panel>
-        <WebGraphControls
-          hops={view.hops}
-          onHopsChange={(hops) => setView((v) => ({ ...v, hops }))}
-          valueFilter={valueFilter}
-          onToggleValue={toggleValue}
-        />
-      </WebGraphCanvas>
+                Couldn&apos;t save your update — your relationships are still saved.
+              </p>
+            )}
+            {mode === "edit" ? (
+              <Button variant="secondary" data-tour="done-button" disabled={donePending} onClick={onDone}>
+                {donePending ? "Saving…" : "Done"}
+              </Button>
+            ) : (
+              <Button onClick={onEdit}>Edit</Button>
+            )}
+          </Panel>
+          <Panel position="bottom-right" className="flex flex-row-reverse items-end gap-2">
+            {/* Click-to-toggle (not hover) so the hints stay reachable on
+             * touch devices where hover doesn't exist. */}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label={hintOpen ? "Hide canvas tips" : "Show canvas tips"}
+              aria-expanded={hintOpen}
+              aria-controls="web-graph-hints"
+              onClick={() => setHintOpen((h) => !h)}
+              className="rounded-full border border-border bg-background/90 font-bold"
+            >
+              ?
+            </Button>
+            {hintOpen && (
+              <div
+                id="web-graph-hints"
+                className="flex max-w-[18rem] flex-col gap-2 rounded border border-border bg-background/90 p-2 text-sm text-muted-foreground"
+              >
+                <ul className="flex flex-col gap-1">
+                  <li>Drag the background to pan.</li>
+                  <li>Drag a circle to reposition it.</li>
+                  <li>Scroll or pinch to zoom.</li>
+                  <li>Single-click a circle to highlight its path to you.</li>
+                  <li>Double-click a circle to open their profile.</li>
+                  <li>
+                    <span className="font-medium text-foreground">Friends-of-friends</span> adds your connections&apos;
+                    connections.
+                  </li>
+                  <li>
+                    Toggle <span className="font-medium text-foreground">1–4</span> to show only those relationship
+                    depths.
+                  </li>
+                </ul>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setHintOpen(false);
+                    onReplayTour();
+                  }}
+                  className="self-start text-foreground underline underline-offset-2 hover:text-primary"
+                >
+                  Replay guided tour
+                </button>
+              </div>
+            )}
+          </Panel>
+          <WebGraphControls
+            hops={view.hops}
+            onHopsChange={(hops) => setView((v) => ({ ...v, hops }))}
+            valueFilter={valueFilter}
+            onToggleValue={toggleValue}
+          />
+        </WebGraphCanvas>
+      </div>
     </div>
   );
 }

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -382,21 +382,35 @@ export function WebGraph({
   // canvas applies these to the rendered nodes/edges.
   const dimUnlit = selectedNodeId !== null;
 
-  // Which nodes show their name. Hidden by default; revealed for the lit path (a
-  // node selection), the hovered node, and the two endpoints of a hovered or
-  // selected edge. Edge ids are `relator->relatee` and member ids never contain
-  // "->", so a split cleanly recovers both endpoints.
-  const labeledNodeIds = useMemo(() => {
-    const ids = new Set<string>(pathNodeIds);
+  // The live pointer focus, lifted to the top of the z-stack so a revealed name
+  // reads above its neighbors: the directly-hovered node, plus both endpoints of
+  // a hovered edge (whose names appear alongside its number). Edge ids are
+  // `relator->relatee` and member ids never contain "->", so a split cleanly
+  // recovers both endpoints.
+  const hoveredNodeIds = useMemo(() => {
+    const ids = new Set<string>();
     if (hoverNodeId) ids.add(hoverNodeId);
-    for (const edgeId of [hoverEdgeId, selectedEdgeId]) {
-      if (!edgeId) continue;
-      const [relatorId, relateeId] = edgeId.split("->");
+    if (hoverEdgeId) {
+      const [relatorId, relateeId] = hoverEdgeId.split("->");
       ids.add(relatorId);
       ids.add(relateeId);
     }
     return ids;
-  }, [pathNodeIds, hoverNodeId, hoverEdgeId, selectedEdgeId]);
+  }, [hoverNodeId, hoverEdgeId]);
+
+  // Which nodes show their name. Hidden by default; revealed for the lit path (a
+  // node selection), the hover set above, and the two endpoints of a selected
+  // edge.
+  const labeledNodeIds = useMemo(() => {
+    const ids = new Set<string>(pathNodeIds);
+    for (const id of hoveredNodeIds) ids.add(id);
+    if (selectedEdgeId) {
+      const [relatorId, relateeId] = selectedEdgeId.split("->");
+      ids.add(relatorId);
+      ids.add(relateeId);
+    }
+    return ids;
+  }, [pathNodeIds, hoveredNodeIds, selectedEdgeId]);
 
   const empty = !data || data.nodes.length === 0;
 
@@ -452,7 +466,8 @@ export function WebGraph({
           dimUnlit={dimUnlit}
           labeledNodeIds={labeledNodeIds}
           selectedNodeId={selectedNodeId}
-          selectedEdgeId={selectedEdgeId}
+          hoverNodeIds={hoveredNodeIds}
+          hoverEdgeId={hoverEdgeId}
           edgeInteraction={edgeInteraction}
           onReady={handleCanvasReady}
           // Hover previews a number on desktop (off while an edge is selected).

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -318,6 +318,9 @@ export function WebGraph({
   // Node selection (click/tap a circle). Independent of edge selection but
   // mutually exclusive in practice: selecting one clears the other.
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  // Transient node hover (desktop), independent of selection — reveals just that
+  // node's name while the pointer is on its circle. Cleared on leave.
+  const [hoverNodeId, setHoverNodeId] = useState<string | null>(null);
   // Mirror of selectedEdgeId for the stable previewEdge callback to read
   // without re-creating each time the selection changes.
   const selectedEdgeRef = useRef<string | null>(null);
@@ -379,6 +382,22 @@ export function WebGraph({
   // canvas applies these to the rendered nodes/edges.
   const dimUnlit = selectedNodeId !== null;
 
+  // Which nodes show their name. Hidden by default; revealed for the lit path (a
+  // node selection), the hovered node, and the two endpoints of a hovered or
+  // selected edge. Edge ids are `relator->relatee` and member ids never contain
+  // "->", so a split cleanly recovers both endpoints.
+  const labeledNodeIds = useMemo(() => {
+    const ids = new Set<string>(pathNodeIds);
+    if (hoverNodeId) ids.add(hoverNodeId);
+    for (const edgeId of [hoverEdgeId, selectedEdgeId]) {
+      if (!edgeId) continue;
+      const [relatorId, relateeId] = edgeId.split("->");
+      ids.add(relatorId);
+      ids.add(relateeId);
+    }
+    return ids;
+  }, [pathNodeIds, hoverNodeId, hoverEdgeId, selectedEdgeId]);
+
   const empty = !data || data.nodes.length === 0;
 
   if (isError) {
@@ -431,6 +450,7 @@ export function WebGraph({
           litNodeIds={pathNodeIds}
           litEdgeIds={pathEdgeIds}
           dimUnlit={dimUnlit}
+          labeledNodeIds={labeledNodeIds}
           selectedNodeId={selectedNodeId}
           selectedEdgeId={selectedEdgeId}
           edgeInteraction={edgeInteraction}
@@ -468,6 +488,8 @@ export function WebGraph({
             setSelectedEdgeId(null);
             setSelectedNodeId((cur) => (cur === node.id ? null : node.id));
           }}
+          onNodeMouseEnter={(_event, node) => setHoverNodeId(node.id)}
+          onNodeMouseLeave={() => setHoverNodeId(null)}
           onNodeDoubleClick={(_event, node) => {
             const slug = node.data.slug ?? node.data.id;
             router.push(`/members/${slug}`);

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -12,12 +12,15 @@ import { apiClient } from "@/lib/api";
 import { isRelationValue, type RelationValue } from "@/lib/relation-value";
 
 import {
+  DEFAULT_SPACING,
   DEFAULT_SUBGRAPH_VIEW,
   defaultValueFilter,
+  parseStoredSpacing,
   parseStoredValueFilter,
   parseStoredView,
   RELATION_SUBGRAPH_QUERY_KEY,
   type RelationValueFilter,
+  SPACING_STORAGE_KEY,
   type SubgraphViewOptions,
   VALUE_FILTER_STORAGE_KEY,
   VIEW_STORAGE_KEY,
@@ -26,6 +29,7 @@ import type { RelatingTarget } from "./relating-dialog";
 import { WebGraphCanvas } from "./web-graph-canvas";
 import { WebGraphControls } from "./web-graph-controls";
 import { filterSubgraphByValue } from "./web-graph-filtering";
+import { computeNeighborNormalization, NEIGHBOR_GAP_BASE } from "./web-graph-layout";
 import type { EdgeInteraction } from "./web-graph-renderers";
 import { pathToCenter, shortestPathTree } from "./web-graph-selection";
 
@@ -102,6 +106,11 @@ export function WebGraph({
   // subgraph (see the `filtered` memo), so toggling re-filters instantly with no
   // refetch. Lazy init so the default Set isn't a shared module singleton.
   const [valueFilter, setValueFilter] = useState<RelationValueFilter>(defaultValueFilter);
+  // The spacing slider's value — a multiplier on the rendered neighbor gap (<1
+  // denser, >1 airier). The normalization holds density constant on its own, so
+  // this is pure taste. Restored from localStorage in the mount effect below;
+  // persisted on its own key.
+  const [spacing, setSpacing] = useState<number>(DEFAULT_SPACING);
 
   // Restore the user's last filter choice across reloads. Done in an
   // effect rather than the useState initializer so SSR-rendered markup
@@ -113,6 +122,8 @@ export function WebGraph({
     if (stored && stored.hops !== DEFAULT_SUBGRAPH_VIEW.hops) setView(stored);
     const storedFilter = parseStoredValueFilter(window.localStorage.getItem(VALUE_FILTER_STORAGE_KEY));
     if (storedFilter) setValueFilter(storedFilter);
+    const storedSpacing = parseStoredSpacing(window.localStorage.getItem(SPACING_STORAGE_KEY));
+    if (storedSpacing !== null) setSpacing(storedSpacing);
     setViewHydrated(true);
   }, []);
 
@@ -123,6 +134,10 @@ export function WebGraph({
   useEffect(() => {
     window.localStorage.setItem(VALUE_FILTER_STORAGE_KEY, JSON.stringify([...valueFilter]));
   }, [valueFilter]);
+
+  useEffect(() => {
+    window.localStorage.setItem(SPACING_STORAGE_KEY, JSON.stringify(spacing));
+  }, [spacing]);
   // The view options become part of the query key so toggling refetches
   // automatically and the relating-dialog's mutation invalidator (which uses the
   // bare ["relations", "subgraph"] key) still hits every variant.
@@ -171,6 +186,17 @@ export function WebGraph({
       emphasizedNodeId: data.centerId,
     };
   }, [data, valueFilter]);
+
+  // The full graph's normalization strategy: scale the settled layout so
+  // neighbors render a fixed gap apart (× the spacing multiplier), for a density
+  // that's invariant to node count, link strength, and clustering. The new
+  // function identity per spacing change is what tells the canvas to re-fit (see
+  // useWebGraphSimulation). See computeNeighborNormalization.
+  const normalize = useMemo(
+    () => (points: ReadonlyArray<{ x: number; y: number }>) =>
+      computeNeighborNormalization(points, spacing * NEIGHBOR_GAP_BASE),
+    [spacing],
+  );
 
   // Flip one depth in/out of the filter. Each toggle is independent (not a
   // threshold) and a new Set keeps the state update immutable.
@@ -479,6 +505,7 @@ export function WebGraph({
           hoverNodeIds={hoveredNodeIds}
           hoverEdgeId={hoverEdgeId}
           edgeInteraction={edgeInteraction}
+          normalize={normalize}
           onReady={handleCanvasReady}
           // Hover previews a number on desktop (off while an edge is selected).
           onEdgeMouseEnter={(_event, edge) => previewEdge(edge.id)}
@@ -598,6 +625,8 @@ export function WebGraph({
             onHopsChange={(hops) => setView((v) => ({ ...v, hops }))}
             valueFilter={valueFilter}
             onToggleValue={toggleValue}
+            spacing={spacing}
+            onSpacingChange={setSpacing}
           />
         </WebGraphCanvas>
       </div>

--- a/src/app/myweb/web-graph.tsx
+++ b/src/app/myweb/web-graph.tsx
@@ -26,12 +26,13 @@ import {
   VIEW_STORAGE_KEY,
 } from "./query-keys";
 import type { RelatingTarget } from "./relating-dialog";
+import { useCanvasBox } from "./use-canvas-box";
 import { WebGraphCanvas } from "./web-graph-canvas";
 import { WebGraphControls } from "./web-graph-controls";
 import { filterSubgraphByValue } from "./web-graph-filtering";
 import { computeNeighborNormalization, NEIGHBOR_GAP_BASE } from "./web-graph-layout";
 import type { EdgeInteraction } from "./web-graph-renderers";
-import { pathToCenter, shortestPathTree } from "./web-graph-selection";
+import { edgeEndpoints, pathToCenter, shortestPathTree } from "./web-graph-selection";
 
 const fetchSubgraph = async (opts: SubgraphViewOptions) => {
   const res = await apiClient.api.relations.subgraph.$get({
@@ -43,29 +44,12 @@ const fetchSubgraph = async (opts: SubgraphViewOptions) => {
   return res.json();
 };
 
-// View<->edit canvas sizing. View mode fills the available rectangle as fully as
-// it can, clamping only its aspect ratio to the [3:4, 4:3] range — so a roughly
-// square area is used whole, and only a viewport more extreme than 4:3 (wide
-// desktop) or 3:4 (portrait phone) gets letterboxed in its long direction. Edit
-// mode collapses to a shorter strip so the suggestion feed below stays on
+// View<->edit canvas sizing lives in useCanvasBox (measurement) and
+// fitAspectClamped (the aspect math). View mode fills the aspect-clamped box;
+// edit mode collapses to a shorter strip so the suggestion feed below stays on
 // screen. Width is identical between modes — only the height animates on the
 // toggle (top-anchored, so the bottom edge travels while ReactFlow re-fits each
 // frame to scale the graph with the box).
-const MAX_ASPECT = 4 / 3; // widest allowed (width:height) — 4:3 landscape
-const MIN_ASPECT = 3 / 4; // tallest allowed (width:height) — 3:4 portrait
-// Edit mode's strip is this fraction of the view-mode height, so it scales with
-// the viewport (a taller window gets a taller strip) instead of a fixed px. The
-// remaining ~40% leaves room for the suggestion feed below.
-const EDIT_HEIGHT_FRACTION = 0.6;
-// Space reserved below the canvas — the page's own padding (main's pb-8 / px-8,
-// both 2rem) so the gap under the canvas matches the gap beside it. Resolved
-// from the live root font-size rather than assuming 16px (the app sets it
-// larger), so it lands on the same px the page padding uses; the canvas bottom
-// then sits exactly pb-8 above the viewport floor, totalling 100vh, so view
-// mode never spills into a vertical scrollbar. (Edit mode's feed legitimately
-// scrolls — the no-scrollbar guarantee is a view-mode one.)
-const PAGE_PAD_REM = 2;
-const bottomReserve = () => PAGE_PAD_REM * (parseFloat(getComputedStyle(document.documentElement).fontSize) || 16);
 const MODE_ANIM_MS = 1000;
 const MODE_ANIM_EASE = "cubic-bezier(0.45, 0, 0.55, 1)"; // accelerate + decelerate
 
@@ -217,94 +201,12 @@ export function WebGraph({
     fitViewRef.current = fitView;
   }, []);
 
-  // The available box: the full width of the canvas's wrapper, and the vertical
-  // space from the wrapper's top down to the viewport bottom (less BOTTOM_RESERVE).
-  // The wrapper top is set by the page chrome above (header + gaps), which never
-  // changes with the box height, so measuring it is stable across mode toggles.
-  const [avail, setAvail] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
-  const lastAvailRef = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
-  // Transition is armed for mode toggles but disarmed for the initial measure
-  // and for resizes, so the box tracks the window instantly rather than easing.
-  const [animateHeight, setAnimateHeight] = useState(false);
-  const wrapElRef = useRef<HTMLDivElement | null>(null);
-  const resizeObsRef = useRef<ResizeObserver | null>(null);
-  const measure = useCallback(() => {
-    const el = wrapElRef.current;
-    if (!el) return;
-    const w = el.clientWidth;
-    const h = Math.max(0, window.innerHeight - el.getBoundingClientRect().top - bottomReserve());
-    const prev = lastAvailRef.current;
-    if (Math.abs(w - prev.w) < 0.5 && Math.abs(h - prev.h) < 0.5) return;
-    lastAvailRef.current = { w, h };
-    setAnimateHeight(false); // a resize commits instantly; only mode toggles ease
-    setAvail({ w, h });
-  }, []);
-  // Callback ref: attach a width observer once the wrapper mounts (it only
-  // renders after the loading/empty early-returns below). A ResizeObserver on a
-  // full-width element catches layout-width changes; a window 'resize' listener
-  // (below) catches viewport-height changes the observer wouldn't see.
-  const wrapRef = useCallback(
-    (el: HTMLDivElement | null) => {
-      resizeObsRef.current?.disconnect();
-      wrapElRef.current = el;
-      if (!el) {
-        resizeObsRef.current = null;
-        return;
-      }
-      measure();
-      const ro = new ResizeObserver(() => measure());
-      ro.observe(el);
-      resizeObsRef.current = ro;
-    },
-    [measure],
-  );
-  useEffect(() => {
-    window.addEventListener("resize", measure);
-    // Web fonts load after first paint and grow the header a few px, shifting
-    // the wrapper's top — a one-time drift neither observer above would catch,
-    // and which would otherwise leave the height slightly too tall (a faint
-    // scrollbar). Re-measure once fonts settle. (?. short-circuits the whole
-    // chain where FontFaceSet is absent, e.g. jsdom.)
-    document.fonts?.ready.then(() => measure());
-    return () => window.removeEventListener("resize", measure);
-  }, [measure]);
-
-  // The largest box that fits the available rectangle with its aspect ratio
-  // clamped to [3:4, 4:3]. When the rectangle's own ratio is already in range we
-  // use it whole (no waste — square, 4:3, whatever it is); only a more extreme
-  // viewport letterboxes, and then in its long direction so the canvas still
-  // fills the short one and never overflows (no vertical scrollbar). Width is
-  // shared by both modes so the toggle never shifts the box sideways.
-  const dims = useMemo(() => {
-    const { w, h } = avail;
-    if (w <= 0 || h <= 0) return null;
-    const ratio = w / h;
-    let width: number;
-    let viewH: number;
-    if (ratio > MAX_ASPECT) {
-      // Wider than 4:3 — fill the height, narrow the width to 4:3.
-      viewH = h;
-      width = h * MAX_ASPECT;
-    } else if (ratio < MIN_ASPECT) {
-      // Taller than 3:4 — fill the width, shorten the height to 3:4.
-      width = w;
-      viewH = w / MIN_ASPECT;
-    } else {
-      // In range — fill the whole rectangle.
-      width = w;
-      viewH = h;
-    }
-    return { width, viewH, editH: viewH * EDIT_HEIGHT_FRACTION };
-  }, [avail]);
-
-  // Re-arm the transition one frame after the initial measure or a resize, so
-  // the next mode toggle eases but the size change that just committed didn't.
-  useEffect(() => {
-    if (dims && !animateHeight) {
-      const id = requestAnimationFrame(() => setAnimateHeight(true));
-      return () => cancelAnimationFrame(id);
-    }
-  }, [dims, animateHeight]);
+  // The measured available box and the aspect-clamped view/edit dimensions, plus
+  // whether the height transition is armed (mode toggles ease; resizes commit
+  // instantly). The wrapper's top is set by the page chrome above, which never
+  // changes with the box height, so the measurement is stable across toggles.
+  // See useCanvasBox.
+  const { wrapRef, dims, animateHeight } = useCanvasBox();
 
   // On a mode toggle, re-fit every frame for the duration of the height
   // transition so the graph zooms to match the shrinking/growing box. The
@@ -420,14 +322,12 @@ export function WebGraph({
 
   // The live pointer focus, lifted to the top of the z-stack so a revealed name
   // reads above its neighbors: the directly-hovered node, plus both endpoints of
-  // a hovered edge (whose names appear alongside its number). Edge ids are
-  // `relator->relatee` and member ids never contain "->", so a split cleanly
-  // recovers both endpoints.
+  // a hovered edge (whose names appear alongside its number). See edgeEndpoints.
   const hoveredNodeIds = useMemo(() => {
     const ids = new Set<string>();
     if (hoverNodeId) ids.add(hoverNodeId);
     if (hoverEdgeId) {
-      const [relatorId, relateeId] = hoverEdgeId.split("->");
+      const [relatorId, relateeId] = edgeEndpoints(hoverEdgeId);
       ids.add(relatorId);
       ids.add(relateeId);
     }
@@ -441,7 +341,7 @@ export function WebGraph({
     const ids = new Set<string>(pathNodeIds);
     for (const id of hoveredNodeIds) ids.add(id);
     if (selectedEdgeId) {
-      const [relatorId, relateeId] = selectedEdgeId.split("->");
+      const [relatorId, relateeId] = edgeEndpoints(selectedEdgeId);
       ids.add(relatorId);
       ids.add(relateeId);
     }
@@ -474,17 +374,17 @@ export function WebGraph({
   // narrows the nullable memo for the canvas below.
   if (!filtered) return null;
 
-  // Width is shared by both modes (from `dims`); only the height differs —
-  // the full fitted height in view mode, the EDIT_HEIGHT-capped strip in edit
-  // mode. Animating just the height keeps the box from shifting sideways on
-  // the toggle; the top stays put, so the bottom edge is what travels.
+  // Width is shared by both modes (from `dims`); only the height differs — the
+  // full fitted height in view mode, the shorter edit strip in edit mode.
+  // Animating just the height keeps the box from shifting sideways on the toggle;
+  // the top stays put, so the bottom edge is what travels.
   const heightPx = dims ? (expanded ? dims.viewH : dims.editH) : undefined;
 
   return (
-    // Full-width wrapper: its width is the available width (clientWidth) and
-    // its top is the canvas's offset from the viewport top — both read by
-    // measure() to size the centered box inside without measuring the box's
-    // own (derived) width, which would be circular.
+    // Full-width wrapper: its width is the available width (clientWidth) and its
+    // top is the canvas's offset from the viewport top — both read by useCanvasBox
+    // to size the centered box inside without measuring the box's own (derived)
+    // width, which would be circular.
     <div ref={wrapRef} className="w-full">
       <div
         data-tour="graph"

--- a/src/app/myweb/welcome-tour.tsx
+++ b/src/app/myweb/welcome-tour.tsx
@@ -33,7 +33,9 @@ const STEPS: Step[] = [
     title: "Finish by clicking Done",
     content:
       "No notifications are sent, but your relations become hints for others. Click Done now! (You can add more anytime.)",
-    placement: "left",
+    // Done now sits in the canvas's lower-left corner, so the tooltip floats
+    // above it (left would push it off the canvas edge).
+    placement: "top",
     // No primary button on the final step — the spotlighted Done
     // button on the page is the only finisher.
     buttons: ["back", "skip"],

--- a/src/lib/changelog.tsx
+++ b/src/lib/changelog.tsx
@@ -38,6 +38,11 @@ export type ChangelogEntry = {
 export const changelog: ChangelogEntry[] = [
   {
     date: "2026-06-18",
+    title: "Spacing slider",
+    description: "My Web has a spacing slider to adjust map density, plus clarity and hover improvements.",
+  },
+  {
+    date: "2026-06-18",
     title: "Rich text arrives",
     description: "Your profile fields, and program descriptions, now support common text formatting styles.",
   },

--- a/tests/functional/client/query-keys.test.ts
+++ b/tests/functional/client/query-keys.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { parseStoredSpacing, SPACING_MAX, SPACING_MIN } from "@/app/myweb/query-keys";
+
+describe("parseStoredSpacing", () => {
+  it("accepts an in-range multiplier", () => {
+    expect(parseStoredSpacing("1.1")).toBe(1.1);
+  });
+
+  it("clamps an over-range value to the max", () => {
+    expect(parseStoredSpacing("9")).toBe(SPACING_MAX);
+  });
+
+  it("clamps an under-range value to the min", () => {
+    expect(parseStoredSpacing("0.1")).toBe(SPACING_MIN);
+  });
+
+  it("rejects ±Infinity (a JSON number that overflowed)", () => {
+    expect(parseStoredSpacing("1e999")).toBeNull();
+  });
+
+  it("rejects a missing, mistyped, or garbled value as null", () => {
+    expect(parseStoredSpacing(null)).toBeNull();
+    expect(parseStoredSpacing('"1"')).toBeNull(); // a JSON string, not a number
+    expect(parseStoredSpacing("null")).toBeNull();
+    expect(parseStoredSpacing("not json")).toBeNull();
+  });
+});

--- a/tests/functional/client/web-graph-controls.test.tsx
+++ b/tests/functional/client/web-graph-controls.test.tsx
@@ -18,6 +18,8 @@ const makeProps = (
   onHopsChange: vi.fn(),
   valueFilter: new Set<RelationValue>([1, 2, 3, 4]),
   onToggleValue: vi.fn(),
+  spacing: 1,
+  onSpacingChange: vi.fn(),
   ...over,
 });
 
@@ -46,5 +48,14 @@ describe("WebGraphControls", () => {
     render(<WebGraphControls {...makeProps({ onToggleValue })} />);
     fireEvent.click(screen.getByRole("button", { name: "Depth 2: Friend" }));
     expect(onToggleValue).toHaveBeenCalledWith(2);
+  });
+
+  it("reflects the current spacing and reports a numeric change when dragged", () => {
+    const onSpacingChange = vi.fn();
+    render(<WebGraphControls {...makeProps({ spacing: 1, onSpacingChange })} />);
+    const slider = screen.getByRole("slider");
+    expect(slider).toHaveValue("1");
+    fireEvent.change(slider, { target: { value: "1.1" } });
+    expect(onSpacingChange).toHaveBeenCalledWith(1.1);
   });
 });

--- a/tests/functional/client/web-graph-layout.test.ts
+++ b/tests/functional/client/web-graph-layout.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  computeNeighborNormalization,
   computeNormalization,
   EDGE_AVOID_THRESHOLD,
   edgeAvoidance,
   edgeStrokeOpacity,
   edgeStrokeWidth,
   linkDistance,
+  medianNearestNeighbor,
   radialSeed,
   SEED_FIRST_HOP_RADIUS,
   SEED_RING_GAP,
@@ -81,6 +83,86 @@ describe("computeNormalization", () => {
         600,
       ),
     ).toEqual({ cx: 50, cy: 150, scale: 2 });
+  });
+});
+
+describe("medianNearestNeighbor", () => {
+  it("returns 0 for fewer than two points", () => {
+    expect(medianNearestNeighbor([])).toBe(0);
+    expect(medianNearestNeighbor([{ x: 1, y: 1 }])).toBe(0);
+  });
+
+  it("measures each node's distance to its closest other", () => {
+    expect(
+      medianNearestNeighbor([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ]),
+    ).toBe(10);
+  });
+
+  it("takes the median across nodes", () => {
+    // x = 0, 10, 30 → nearest-neighbor distances 10, 10, 20 → median 10.
+    expect(
+      medianNearestNeighbor([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 30, y: 0 },
+      ]),
+    ).toBe(10);
+  });
+});
+
+describe("computeNeighborNormalization", () => {
+  it("returns null for an empty cloud", () => {
+    expect(computeNeighborNormalization([], 100)).toBeNull();
+  });
+
+  it("scales so the median neighbor gap renders as targetGap, centered on the bbox", () => {
+    // Neighbors 20 apart, targetGap 100 → scale 5.
+    expect(
+      computeNeighborNormalization(
+        [
+          { x: 0, y: 0 },
+          { x: 20, y: 0 },
+        ],
+        100,
+      ),
+    ).toEqual({ cx: 10, cy: 0, scale: 5 });
+  });
+
+  it("keeps scale 1 when the spacing is degenerate (coincident points)", () => {
+    expect(
+      computeNeighborNormalization(
+        [
+          { x: 3, y: 3 },
+          { x: 3, y: 3 },
+        ],
+        100,
+      )?.scale,
+    ).toBe(1);
+  });
+
+  it("is invariant to overall extent — same neighbor gap, same scale (the point of (b))", () => {
+    // A tight pair and a far-flung set with the SAME neighbor gap normalize to the
+    // same scale, even though their bounding boxes differ wildly.
+    const tight = computeNeighborNormalization(
+      [
+        { x: 0, y: 0 },
+        { x: 20, y: 0 },
+      ],
+      100,
+    );
+    const spread = computeNeighborNormalization(
+      [
+        { x: 0, y: 0 },
+        { x: 20, y: 0 },
+        { x: 500, y: 0 },
+        { x: 520, y: 0 },
+      ],
+      100,
+    );
+    expect(spread?.scale).toBe(tight?.scale); // both 5 — the bounding box doesn't matter
   });
 });
 

--- a/tests/functional/client/web-graph-layout.test.ts
+++ b/tests/functional/client/web-graph-layout.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CANVAS_MAX_ASPECT,
+  CANVAS_MIN_ASPECT,
   computeNeighborNormalization,
   computeNormalization,
   EDGE_AVOID_THRESHOLD,
+  EDIT_HEIGHT_FRACTION,
   edgeAvoidance,
   edgeStrokeOpacity,
   edgeStrokeWidth,
+  fitAspectClamped,
   linkDistance,
   medianNearestNeighbor,
   radialSeed,
@@ -163,6 +167,40 @@ describe("computeNeighborNormalization", () => {
       100,
     );
     expect(spread?.scale).toBe(tight?.scale); // both 5 — the bounding box doesn't matter
+  });
+});
+
+describe("fitAspectClamped", () => {
+  it("returns null for a non-positive rectangle (nothing measured yet)", () => {
+    expect(fitAspectClamped(0, 600)).toBeNull();
+    expect(fitAspectClamped(600, 0)).toBeNull();
+    expect(fitAspectClamped(-10, 600)).toBeNull();
+  });
+
+  it("uses an in-range rectangle whole (ratio within [3:4, 4:3])", () => {
+    // A square is in range — no letterboxing, the whole box is used.
+    expect(fitAspectClamped(600, 600)).toEqual({
+      width: 600,
+      viewH: 600,
+      editH: 600 * EDIT_HEIGHT_FRACTION,
+    });
+  });
+
+  it("keeps a boundary ratio (exactly 4:3) whole", () => {
+    // 800×600 = 4:3 exactly, the widest in-range ratio — used whole, not clamped.
+    expect(fitAspectClamped(800, 600)).toEqual({ width: 800, viewH: 600, editH: 600 * EDIT_HEIGHT_FRACTION });
+  });
+
+  it("letterboxes a too-wide viewport by narrowing the width to 4:3", () => {
+    // 2000×600 (ratio 3.33 > 4:3): fill the height, width clamps to h × 4:3.
+    const dims = fitAspectClamped(2000, 600);
+    expect(dims).toEqual({ width: 600 * CANVAS_MAX_ASPECT, viewH: 600, editH: 600 * EDIT_HEIGHT_FRACTION });
+  });
+
+  it("letterboxes a too-tall viewport by shortening the height to 3:4", () => {
+    // 600×2000 (ratio 0.3 < 3:4): fill the width, height clamps to w ÷ 3:4.
+    const viewH = 600 / CANVAS_MIN_ASPECT;
+    expect(fitAspectClamped(600, 2000)).toEqual({ width: 600, viewH, editH: viewH * EDIT_HEIGHT_FRACTION });
   });
 });
 

--- a/tests/functional/client/web-graph-selection.test.ts
+++ b/tests/functional/client/web-graph-selection.test.ts
@@ -126,19 +126,20 @@ describe("decorateEdges", () => {
     expect(out[1].style?.stroke).toBeUndefined();
   });
 
-  it("marks every edge clickable when the canvas's edges are clickable", () => {
+  it("marks only your own outgoing edge clickable, matching its value bubble", () => {
     const out = decorateEdges([mk("in", false), mk("out", true)], {
       litEdgeIds: new Set(),
       dimUnlit: false,
       edgesClickable: true,
       hoverEdgeId: null,
     });
-    // Incoming and outgoing alike — every edge selects on click, so both signal it.
-    expect(out[0].className).toBe("cursor-pointer");
+    // An incoming or 2nd-degree link can't be edited, so its line stays inert —
+    // the cursor agrees with the (non-clickable) bubble.
+    expect(out[0].className).toBeUndefined();
     expect(out[1].className).toBe("cursor-pointer");
   });
 
-  it("leaves edges unmarked when the canvas's edges aren't clickable (mini-map)", () => {
+  it("leaves even an outgoing edge unmarked when the canvas's edges aren't clickable (mini-map)", () => {
     const out = decorateEdges([mk("e1", true)], {
       litEdgeIds: new Set(),
       dimUnlit: false,

--- a/tests/functional/client/web-graph-selection.test.ts
+++ b/tests/functional/client/web-graph-selection.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 import {
   decorateEdges,
   decorateNodes,
+  HOVER_EDGE_Z,
+  HOVER_NODE_Z,
   pathToCenter,
   SELECTION_EDGE_Z,
   SELECTION_NODE_Z,
@@ -87,9 +89,14 @@ describe("decorateEdges", () => {
     data: { isOutgoing },
   });
 
-  it("returns edges untouched when nothing is lit or dimmed", () => {
+  it("returns edges untouched when nothing is clickable, lit, dimmed, or hovered", () => {
     const edges = [mk("e1"), mk("e2")];
-    const out = decorateEdges(edges, { litEdgeIds: new Set(), dimUnlit: false, selectedEdgeId: null });
+    const out = decorateEdges(edges, {
+      litEdgeIds: new Set(),
+      dimUnlit: false,
+      edgesClickable: false,
+      hoverEdgeId: null,
+    });
     expect(out[0]).toBe(edges[0]);
     expect(out[1]).toBe(edges[1]);
   });
@@ -98,7 +105,8 @@ describe("decorateEdges", () => {
     const out = decorateEdges([mk("on"), mk("off")], {
       litEdgeIds: new Set(["on"]),
       dimUnlit: true,
-      selectedEdgeId: null,
+      edgesClickable: false,
+      hoverEdgeId: null,
     });
     expect(out[0].style?.stroke).toBe("var(--color-success)");
     expect(out[0].zIndex).toBe(SELECTION_EDGE_Z);
@@ -110,41 +118,89 @@ describe("decorateEdges", () => {
     const out = decorateEdges([mk("on"), mk("off")], {
       litEdgeIds: new Set(["on"]),
       dimUnlit: false,
-      selectedEdgeId: null,
+      edgesClickable: false,
+      hoverEdgeId: null,
     });
     expect(out[0].style?.stroke).toBe("var(--color-success)");
     // The off-path edge is returned untouched — no dim wash.
     expect(out[1].style?.stroke).toBeUndefined();
   });
 
-  it("marks a selected outgoing edge as clickable", () => {
-    const out = decorateEdges([mk("e1", true)], { litEdgeIds: new Set(), dimUnlit: false, selectedEdgeId: "e1" });
-    expect(out[0].className).toBe("cursor-pointer");
-  });
-
-  it("leaves a selected incoming edge unclickable", () => {
-    const out = decorateEdges([mk("e1", false)], {
+  it("marks every edge clickable when the canvas's edges are clickable", () => {
+    const out = decorateEdges([mk("in", false), mk("out", true)], {
       litEdgeIds: new Set(),
       dimUnlit: false,
-      selectedEdgeId: "e1",
+      edgesClickable: true,
+      hoverEdgeId: null,
+    });
+    // Incoming and outgoing alike — every edge selects on click, so both signal it.
+    expect(out[0].className).toBe("cursor-pointer");
+    expect(out[1].className).toBe("cursor-pointer");
+  });
+
+  it("leaves edges unmarked when the canvas's edges aren't clickable (mini-map)", () => {
+    const out = decorateEdges([mk("e1", true)], {
+      litEdgeIds: new Set(),
+      dimUnlit: false,
+      edgesClickable: false,
+      hoverEdgeId: null,
     });
     expect(out[0].className).toBeUndefined();
+  });
+
+  it("lifts a plain hovered edge above the tangle without recoloring it", () => {
+    const out = decorateEdges([mk("h"), mk("rest")], {
+      litEdgeIds: new Set(),
+      dimUnlit: false,
+      edgesClickable: false,
+      hoverEdgeId: "h",
+    });
+    expect(out[0].zIndex).toBe(HOVER_EDGE_Z);
+    expect(out[0].style?.stroke).toBeUndefined(); // hover reveals, never recolors
+    expect(out[1].zIndex).toBeUndefined();
+  });
+
+  it("lifts a hovered lit edge above its lit-path z (pointer focus outranks selection)", () => {
+    const out = decorateEdges([mk("on")], {
+      litEdgeIds: new Set(["on"]),
+      dimUnlit: true,
+      edgesClickable: false,
+      hoverEdgeId: "on",
+    });
+    // Keeps the lit green stroke but rides the hover tier, not SELECTION_EDGE_Z.
+    expect(out[0].style?.stroke).toBe("var(--color-success)");
+    expect(out[0].zIndex).toBe(HOVER_EDGE_Z);
   });
 });
 
 describe("decorateNodes", () => {
   const mk = (id: string): Node => ({ id, position: { x: 0, y: 0 }, data: {} });
 
-  it("returns the same array reference when nothing is lit", () => {
+  it("returns the same array reference when nothing is lifted", () => {
     const nodes = [mk("a"), mk("b")];
-    expect(decorateNodes(nodes, { litNodeIds: new Set() })).toBe(nodes);
+    expect(decorateNodes(nodes, { litNodeIds: new Set(), hoverNodeIds: new Set() })).toBe(nodes);
   });
 
   it("lifts lit nodes and leaves the rest untouched", () => {
     const offPath = mk("b");
-    const out = decorateNodes([mk("a"), offPath], { litNodeIds: new Set(["a"]) });
+    const out = decorateNodes([mk("a"), offPath], { litNodeIds: new Set(["a"]), hoverNodeIds: new Set() });
     expect(out[0].zIndex).toBe(SELECTION_NODE_Z);
     expect(out[1]).toBe(offPath);
     expect(out[1].zIndex).toBeUndefined();
+  });
+
+  it("lifts hovered nodes to the hover tier above the lit path", () => {
+    const out = decorateNodes([mk("h"), mk("lit"), mk("rest")], {
+      litNodeIds: new Set(["lit"]),
+      hoverNodeIds: new Set(["h"]),
+    });
+    expect(out[0].zIndex).toBe(HOVER_NODE_Z);
+    expect(out[1].zIndex).toBe(SELECTION_NODE_Z);
+    expect(out[2].zIndex).toBeUndefined();
+  });
+
+  it("gives hover precedence when a node is both lit and hovered", () => {
+    const out = decorateNodes([mk("a")], { litNodeIds: new Set(["a"]), hoverNodeIds: new Set(["a"]) });
+    expect(out[0].zIndex).toBe(HOVER_NODE_Z);
   });
 });

--- a/tests/functional/client/web-graph-selection.test.ts
+++ b/tests/functional/client/web-graph-selection.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 import {
   decorateEdges,
   decorateNodes,
+  edgeEndpoints,
+  edgeId,
   HOVER_EDGE_Z,
   HOVER_NODE_Z,
   pathToCenter,
@@ -13,6 +15,18 @@ import {
 } from "@/app/myweb/web-graph-selection";
 
 const edge = (relatorId: string, relateeId: string) => ({ relatorId, relateeId });
+
+describe("edgeId / edgeEndpoints", () => {
+  it("stamps direction into the id and splits it back out", () => {
+    expect(edgeId("alice", "bob")).toBe("alice->bob");
+    expect(edgeEndpoints("alice->bob")).toEqual(["alice", "bob"]);
+  });
+
+  it("round-trips a constructed id", () => {
+    const [relator, relatee] = edgeEndpoints(edgeId("u-1", "u-2"));
+    expect([relator, relatee]).toEqual(["u-1", "u-2"]);
+  });
+});
 
 describe("shortestPathTree", () => {
   it("roots the center at null", () => {

--- a/tests/functional/client/web-graph.test.tsx
+++ b/tests/functional/client/web-graph.test.tsx
@@ -49,7 +49,7 @@ vi.mock("@/lib/api", () => ({
   apiClient: { api: { relations: { subgraph: { $get: vi.fn() } } } },
 }));
 
-import { VIEW_STORAGE_KEY } from "@/app/myweb/query-keys";
+import { DEFAULT_SPACING, SPACING_STORAGE_KEY, VIEW_STORAGE_KEY } from "@/app/myweb/query-keys";
 import { WebGraph } from "@/app/myweb/web-graph";
 import { apiClient } from "@/lib/api";
 
@@ -147,6 +147,31 @@ describe("WebGraph — Edit/Done toggle", () => {
     $get.mockResolvedValue(okResponse(populatedWeb));
     renderGraph({ mode: "edit", doneError: true });
     expect(await screen.findByRole("alert")).toHaveTextContent("Couldn't save your update");
+  });
+});
+
+describe("WebGraph — spacing slider", () => {
+  it("persists the default spacing on mount", async () => {
+    $get.mockResolvedValue(okResponse(populatedWeb));
+    renderGraph();
+    await screen.findByRole("slider"); // controls render once data lands
+    await waitFor(() => expect(localStorage.getItem(SPACING_STORAGE_KEY)).toBe(JSON.stringify(DEFAULT_SPACING)));
+  });
+
+  it("restores a stored spacing onto the slider", async () => {
+    localStorage.setItem(SPACING_STORAGE_KEY, JSON.stringify(1.1));
+    $get.mockResolvedValue(okResponse(populatedWeb));
+    renderGraph();
+    expect(await screen.findByRole("slider")).toHaveValue("1.1");
+  });
+
+  it("updates and persists the spacing when dragged", async () => {
+    $get.mockResolvedValue(okResponse(populatedWeb));
+    renderGraph();
+    const slider = await screen.findByRole("slider");
+    fireEvent.change(slider, { target: { value: "0.7" } });
+    expect(slider).toHaveValue("0.7");
+    await waitFor(() => expect(localStorage.getItem(SPACING_STORAGE_KEY)).toBe(JSON.stringify(0.7)));
   });
 });
 

--- a/tests/functional/client/web-graph.test.tsx
+++ b/tests/functional/client/web-graph.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ReactFlow measures its container via ResizeObserver, which jsdom lacks; the
@@ -65,11 +65,21 @@ const populatedWeb = {
   edges: [{ relatorId: "c", relateeId: "a", value: 3 }],
 };
 
-const renderGraph = () => {
+const renderGraph = (props: Partial<ComponentProps<typeof WebGraph>> = {}) => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <WebGraph square={false} onOpenRelating={vi.fn()} onReplayTour={vi.fn()} />
+      <WebGraph
+        expanded={false}
+        onOpenRelating={vi.fn()}
+        onReplayTour={vi.fn()}
+        mode="edit"
+        onEdit={vi.fn()}
+        onDone={vi.fn()}
+        donePending={false}
+        doneError={false}
+        {...props}
+      />
     </QueryClientProvider>,
   );
 };
@@ -111,6 +121,32 @@ describe("WebGraph — view persistence", () => {
     $get.mockResolvedValue(okResponse(emptyWeb));
     renderGraph();
     await waitFor(() => expect($get).toHaveBeenCalledWith({ query: { hops: "1" } }));
+  });
+});
+
+describe("WebGraph — Edit/Done toggle", () => {
+  // The toggle lives in the canvas's lower-left Panel; state stays in MyWeb and
+  // arrives via props, so the canvas just renders the label and reports clicks.
+  it("renders Done in edit mode and reports the click", async () => {
+    $get.mockResolvedValue(okResponse(populatedWeb));
+    const onDone = vi.fn();
+    renderGraph({ mode: "edit", onDone });
+    fireEvent.click(await screen.findByRole("button", { name: "Done" }));
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+
+  it("renders Edit in view mode and reports the click", async () => {
+    $get.mockResolvedValue(okResponse(populatedWeb));
+    const onEdit = vi.fn();
+    renderGraph({ mode: "view", onEdit });
+    fireEvent.click(await screen.findByRole("button", { name: "Edit" }));
+    expect(onEdit).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces the save error alongside the still-enabled Done button", async () => {
+    $get.mockResolvedValue(okResponse(populatedWeb));
+    renderGraph({ mode: "edit", doneError: true });
+    expect(await screen.findByRole("alert")).toHaveTextContent("Couldn't save your update");
   });
 });
 


### PR DESCRIPTION
Summary: Overhaul the My Web canvas — it fills the viewport, reveals names
and relation values on hover/selection, and gains a spacing slider for density.

Why: The fixed square canvas wasted screen space and the graph was hard to
read — nodes were unlabeled and relation values stayed hidden until you
clicked each edge. A density control lets each member tune the layout.

Behavior:
- View mode expands to fill the available space, aspect-clamped to 3:4–4:3
  (only very wide/tall viewports letterbox); edit mode keeps the short strip.
- Hovering or selecting a node/edge reveals member names; a selected node's
  path also shows its relation-value bubbles.
- Hovered nodes, edges, and value pills lift above the rest of the web.
- A spacing slider (persisted to localStorage) scales the neighbor gap;
  density stays invariant to node count via neighbor-distance normalization.
- The root ("you") avatar is now 1.18× a regular node (down from 1.33×).
- Edit/Done moves into the canvas's lower-left corner.

Test Plan:
- npm test — 540 functional + 37 e2e, all green (on a clean dev server).
- npm run lint (Biome) and npx tsc --noEmit both clean.
- New unit tests: fitAspectClamped aspect branches, edgeId/edgeEndpoints,
  computeNeighborNormalization/medianNearestNeighbor, parseStoredSpacing,
  and the spacing slider + Edit/Done toggle.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
