### PR TITLE
fix(programs): align facepiles across program cards

### DIFF
--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -70,30 +70,33 @@ function ProgramCard({
         <MarkdownInline className="font-serif text-sm text-muted-foreground leading-relaxed">{cardText}</MarkdownInline>
       )}
 
-      {program.memberAvatars.length > 0 && (
-        <div className="flex items-center">
-          {program.memberAvatars.map((member, i) => (
-            <div
-              key={member.id}
-              className="relative h-7 w-7 shrink-0 rounded-full border-2 border-card bg-muted"
-              style={{ marginLeft: i === 0 ? 0 : "-8px", zIndex: program.memberAvatars.length - i }}
-              title={member.displayName ?? undefined}
-            >
-              <Avatar
-                name={member.displayName}
-                url={member.avatarUrl}
-                sizes="28px"
-                className="flex h-full w-full items-center justify-center overflow-hidden rounded-full text-[10px] font-semibold text-muted-foreground"
-              />
-            </div>
-          ))}
-          {program.memberCount > 5 && (
-            <span className="ml-1 text-xs text-muted-foreground">+{program.memberCount - 5}</span>
-          )}
-        </div>
-      )}
+      {/* Facepile and action button are bottom-pinned together so the
+          avatar row lands on the same baseline across cards regardless of
+          how long each card's blurb runs. */}
+      <div className="mt-auto flex flex-col gap-3 pt-2">
+        {program.memberAvatars.length > 0 && (
+          <div className="flex items-center">
+            {program.memberAvatars.map((member, i) => (
+              <div
+                key={member.id}
+                className="relative h-7 w-7 shrink-0 rounded-full border-2 border-card bg-muted"
+                style={{ marginLeft: i === 0 ? 0 : "-8px", zIndex: program.memberAvatars.length - i }}
+                title={member.displayName ?? undefined}
+              >
+                <Avatar
+                  name={member.displayName}
+                  url={member.avatarUrl}
+                  sizes="28px"
+                  className="flex h-full w-full items-center justify-center overflow-hidden rounded-full text-[10px] font-semibold text-muted-foreground"
+                />
+              </div>
+            ))}
+            {program.memberCount > 5 && (
+              <span className="ml-1 text-xs text-muted-foreground">+{program.memberCount - 5}</span>
+            )}
+          </div>
+        )}
 
-      <div className="mt-auto pt-2">
         {program.joined ? (
           <Button
             type="button"


### PR DESCRIPTION
## Summary

Program cards bottom-pinned only the action button (`mt-auto`), so the member facepile floated directly beneath each card's blurb. With variable-length blurbs, the avatar rows landed on different heights card-to-card (e.g. a short blurb pushed its facepile well above its neighbours').

This groups the facepile **and** the button into one bottom-pinned container, so the avatar row sits on the same baseline on every card. The variable whitespace now falls between the blurb and the facepile instead. UI-only; no backend, schema, or API changes.

## Test plan

- [ ] `/programs` — across cards with short and long blurbs, the avatar facepiles line up on the same baseline
- [ ] Cards with no avatars still bottom-pin the button as before
- [ ] CI lint + functional + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)