### PR TITLE
feat: hide hidden accounts from admins on member-facing pages

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-19 | James | Hidden accounts no longer surface to admins on member-facing pages
+
+Dropped the admin `includeHidden` bypass from the directory, profile pages, intentions, and My Web; hidden accounts now show only on the `/admin` pages.
+
 ## 2026-06-18 | James | Rich text: markdown storage, react-markdown render, MDXEditor authoring
 
 Program copy (`description`/`blurb`) and member prose (`bio`/`currentIntention`/`supplementaryInfo`) are now formatted: stored as markdown in the existing `text` columns (no migration), rendered by a shared `<Markdown>` (full + constrained-inline variants, react-markdown + remark-gfm, no rehype-raw → XSS-safe), and authored in a lazy `ssr:false` MDXEditor (full + inline configs). See docs/design-richtext.md. (#432)

--- a/src/app/admin/admin-hidden.tsx
+++ b/src/app/admin/admin-hidden.tsx
@@ -64,8 +64,8 @@ export function AdminHidden() {
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-3 rounded border border-border p-3">
         <p className="text-sm text-muted-foreground">
-          Hide an account so it stops showing up in the directory, the web, and the suggestion feed. Admins still see
-          hidden accounts everywhere; non-admins act as if the account never existed.
+          Hide an account so it stops showing up in the directory, the web, and the suggestion feed — for everyone,
+          admins included. Hidden accounts surface only here and on the admin members page.
         </p>
         <MemberTypeahead
           label="Account to hide"

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -634,23 +634,17 @@ const api = new Hono<{ Variables: ApiVariables }>()
     return c.json({ valid: false, reason: result.reason });
   })
   .get("/members", async (c) => {
-    const user = c.get("user");
-    const includeHidden = await isAdmin(user.id);
-    const members = await listMembers({ includeHidden });
+    const members = await listMembers();
     return c.json({ members });
   })
   .get("/members/:id", async (c) => {
-    const user = c.get("user");
     const memberId = c.req.param("id");
-    const includeHidden = await isAdmin(user.id);
-    const profile = await getProfileForMember(memberId, { includeHidden });
+    const profile = await getProfileForMember(memberId);
     if (!profile) return c.json({ error: "not_found" }, 404);
     return c.json({ profile });
   })
   .get("/intentions", async (c) => {
-    const user = c.get("user");
-    const includeHidden = await isAdmin(user.id);
-    const intentions = await listCurrentIntentions({ includeHidden });
+    const intentions = await listCurrentIntentions();
     return c.json({ intentions });
   })
   .get("/programs", async (c) => {
@@ -704,8 +698,7 @@ const api = new Hono<{ Variables: ApiVariables }>()
   })
   .get("/relations/candidates", async (c) => {
     const user = c.get("user");
-    const includeHidden = await isAdmin(user.id);
-    const feed = await getRelationSuggestions(user.id, { includeHidden });
+    const feed = await getRelationSuggestions(user.id);
     return c.json(feed);
   })
   .get("/relations/subgraph", async (c) => {
@@ -715,26 +708,22 @@ const api = new Hono<{ Variables: ApiVariables }>()
     const includeOutgoing = c.req.query("out") !== "false";
     const includeIncoming = c.req.query("in") === "true";
     const hops = c.req.query("hops") === "1" ? 1 : 2;
-    const includeHidden = await isAdmin(user.id);
 
     const subgraph = await getPersonalWeb({
       centerId: user.id,
       includeIncoming,
       includeOutgoing,
       hops,
-      includeHidden,
     });
     return c.json(subgraph);
   })
   // Read-only mini-map for a member's profile page: the profile member, their
-  // strong connections, and the caller's shortest path back to them. Mirrors
-  // /relations/subgraph's admin → includeHidden rule.
+  // strong connections, and the caller's shortest path back to them.
   .get("/relations/mini-map/:profileId", async (c) => {
     const user = c.get("user");
     const profileId = c.req.param("profileId");
     if (!isUuid(profileId)) return c.json({ error: "profileId must be a UUID" }, 400);
-    const includeHidden = await isAdmin(user.id);
-    const miniMap = await getProfileMiniMap({ viewerId: user.id, profileId, includeHidden });
+    const miniMap = await getProfileMiniMap({ viewerId: user.id, profileId });
     return c.json(miniMap);
   })
   .get("/relations/value/:relateeId", async (c) => {

--- a/src/server/profiles.ts
+++ b/src/server/profiles.ts
@@ -355,16 +355,14 @@ export type ProfileForMember = {
 // Accepts either a UUID or a slug so /members/aria-chen and
 // /members/<uuid> both work. UUID-shaped strings go straight to the id
 // column; anything else is treated as a slug lookup.
-// includeHidden=true bypasses the profiles.hidden filter so admins can
-// view hidden test accounts; the API handler decides which to pass.
-export const getProfileForMember = async (
-  idOrSlug: string,
-  options: { includeHidden?: boolean } = {},
-): Promise<ProfileForMember | null> => {
+// Hidden and deactivated profiles are never returned — the profile page is
+// member-facing, so admins see the same as anyone. Admins manage hidden
+// accounts from the /admin pages, which run their own queries.
+export const getProfileForMember = async (idOrSlug: string): Promise<ProfileForMember | null> => {
   const match = isUuid(idOrSlug)
     ? or(eq(profiles.id, idOrSlug), eq(profiles.slug, idOrSlug))
     : eq(profiles.slug, idOrSlug);
-  const where = options.includeHidden ? match : and(match, eq(profiles.hidden, false), isNull(profiles.deactivatedAt));
+  const where = and(match, eq(profiles.hidden, false), isNull(profiles.deactivatedAt));
 
   const [row] = await db
     .select({
@@ -409,11 +407,16 @@ export type MemberSummary = {
 // gates on content, not on lastUpdatedProfile.
 const hasSetUpProfile = sql`btrim(coalesce(${profiles.bio}, '')) <> ''`;
 
-// includeHidden=true returns hidden profiles too — admins only.
-export const listMembers = async (options: { includeHidden?: boolean } = {}): Promise<MemberSummary[]> => {
-  const where = options.includeHidden
-    ? isNotNull(profiles.displayName)
-    : and(isNotNull(profiles.displayName), hasSetUpProfile, eq(profiles.hidden, false), isNull(profiles.deactivatedAt));
+// The directory everyone sees: members who finished onboarding and aren't
+// hidden or deactivated. Admins see the same list — hidden and mid-onboarding
+// accounts surface on the /admin members page instead.
+export const listMembers = async (): Promise<MemberSummary[]> => {
+  const where = and(
+    isNotNull(profiles.displayName),
+    hasSetUpProfile,
+    eq(profiles.hidden, false),
+    isNull(profiles.deactivatedAt),
+  );
   const rows = await db
     .select({
       id: profiles.id,
@@ -442,15 +445,15 @@ export type IntentionSummary = {
 // first — the /intentions browse cloud renders the most recently
 // updated on top (highest z-index) and largest. `nulls last` parks the
 // rare row whose intentionUpdatedAt was never stamped at the back.
-// Hidden profiles are excluded unless an admin caller opts in, matching
-// listMembers.
-export const listCurrentIntentions = async (options: { includeHidden?: boolean } = {}): Promise<IntentionSummary[]> => {
+// Hidden profiles are always excluded, matching listMembers — the intentions
+// cloud is member-facing, so admins see the same as anyone.
+export const listCurrentIntentions = async (): Promise<IntentionSummary[]> => {
   const present = and(
     isNotNull(profiles.displayName),
     isNotNull(profiles.currentIntention),
     sql`btrim(${profiles.currentIntention}) <> ''`,
   );
-  const where = options.includeHidden ? present : and(present, eq(profiles.hidden, false));
+  const where = and(present, eq(profiles.hidden, false));
   const rows = await db
     .select({
       id: profiles.id,

--- a/src/server/relations-mini-map.ts
+++ b/src/server/relations-mini-map.ts
@@ -34,18 +34,16 @@ export type ProfileMiniMap = {
 //      first).
 // The lit path is the shortest bridge among those rendered (a direct edge wins,
 // then a mutual, then a two-hop), ties broken by the strongest average. Hidden/
-// deactivated endpoints are pruned for non-admins; them and you are exempt since
-// they anchor the map.
+// deactivated endpoints are pruned for everyone, admins included; them and you
+// are exempt since they anchor the map.
 // At MVP scale (≤100 members) loading the whole confirmed-edge set and doing the
 // bridge enumeration in JS is trivial; revisit if the network grows large.
 export const getProfileMiniMap = async (params: {
   viewerId: string;
   profileId: string;
-  includeHidden?: boolean;
   maxNodes?: number;
 }): Promise<ProfileMiniMap> => {
   const { viewerId, profileId } = params;
-  const includeHidden = params.includeHidden ?? false;
   const maxNodes = params.maxNodes ?? 10;
 
   const allRelations = await db
@@ -58,16 +56,14 @@ export const getProfileMiniMap = async (params: {
     .from(relations)
     .where(isNotNull(relations.value));
 
-  // Drop hidden/deactivated endpoints for non-admins (deactivated always); them
-  // and you anchor the map, so they're exempt.
+  // Drop hidden/deactivated endpoints; them and you anchor the map, so
+  // they're exempt.
   const endpointIds = new Set<string>([viewerId, profileId]);
   for (const e of allRelations) {
     endpointIds.add(e.relatorId);
     endpointIds.add(e.relateeId);
   }
-  const dropFilter = includeHidden
-    ? isNotNull(profiles.deactivatedAt)
-    : or(eq(profiles.hidden, true), isNotNull(profiles.deactivatedAt));
+  const dropFilter = or(eq(profiles.hidden, true), isNotNull(profiles.deactivatedAt));
   const droppedIds = new Set<string>();
   const dropRows = await db
     .select({ id: profiles.id })

--- a/src/server/relations-personal.ts
+++ b/src/server/relations-personal.ts
@@ -38,24 +38,20 @@ export const nodeColumns = {
 const edgeKey = (e: { relatorId: string; relateeId: string }): string => `${e.relatorId}:${e.relateeId}`;
 
 // Hints (value IS NULL) are filtered out — they live in the suggestion
-// feed, not the rendered web. includeHidden=true keeps hidden profiles in
-// the graph — admins see everything. When false, hidden profiles are
-// excluded as nodes AND edges touching them are dropped, so the rendered
-// web never shows a dangling edge to a vanished node.
+// feed, not the rendered web. Hidden profiles are excluded as nodes AND
+// edges touching them are dropped, so the rendered web never shows a
+// dangling edge to a vanished node; admins see the same web as anyone.
 export const getPersonalWeb = async (params: {
   centerId: string;
   includeIncoming: boolean;
   includeOutgoing: boolean;
   hops: 1 | 2;
-  includeHidden?: boolean;
 }): Promise<Subgraph> => {
   const { centerId, includeIncoming, includeOutgoing, hops } = params;
-  const includeHidden = params.includeHidden ?? false;
 
-  // First hop — direct relations involving centerId. If the viewer is
-  // not an admin, the join to profiles on both endpoints is what filters
-  // an edge whose other end is hidden; we do that pruning in JS rather
-  // than two subquery joins.
+  // First hop — direct relations involving centerId. Pruning an edge whose
+  // other end is hidden is done in JS over the endpoint set rather than two
+  // subquery joins.
   const firstHopWhere = (() => {
     if (includeIncoming && includeOutgoing) {
       return or(eq(relations.relatorId, centerId), eq(relations.relateeId, centerId));
@@ -75,16 +71,13 @@ export const getPersonalWeb = async (params: {
     .where(and(firstHopWhere, isNotNull(relations.value)));
 
   // Determine which ids to drop as nodes and as edge endpoints before
-  // rendering. Deactivated profiles are always dropped; hidden ones only
-  // for non-admins (admins pass includeHidden=true and keep seeing them).
+  // rendering: any hidden or deactivated profile.
   const candidateIds = new Set<string>([centerId]);
   for (const e of firstHop) {
     candidateIds.add(e.relatorId);
     candidateIds.add(e.relateeId);
   }
-  const dropFilter = includeHidden
-    ? isNotNull(profiles.deactivatedAt)
-    : or(eq(profiles.hidden, true), isNotNull(profiles.deactivatedAt));
+  const dropFilter = or(eq(profiles.hidden, true), isNotNull(profiles.deactivatedAt));
   const hiddenIds = new Set<string>();
   if (candidateIds.size > 0) {
     const rows = await db
@@ -130,8 +123,7 @@ export const getPersonalWeb = async (params: {
           and(isNotNull(relations.value), inArray(relations.relatorId, firstHopIds), ne(relations.relateeId, centerId)),
         );
       // Second-hop relatees can introduce new ids; mark any to-drop ones
-      // (always deactivated, plus hidden for non-admins) so the filter
-      // below catches them too.
+      // (hidden or deactivated) so the filter below catches them too.
       const newIds = secondHop.map((e) => e.relateeId).filter((id) => !candidateIds.has(id));
       if (newIds.length > 0) {
         const rows = await db

--- a/src/server/relations.ts
+++ b/src/server/relations.ts
@@ -92,15 +92,10 @@ const collectInto = <T extends { id: string }>(
 // IDs via `seen`. Sources 1–4 land in `suggestions` (signal-bearing);
 // source 5 lands in `otherMembers` (catch-all of the rest of the
 // directory) so the feed never goes empty while a member remains.
-// includeHidden=true skips profiles.hidden filtering across all five
-// sources so admins still see hidden test accounts in suggestions.
-export const getRelationSuggestions = async (
-  userId: string,
-  options: { includeHidden?: boolean } = {},
-): Promise<RelationSuggestionFeed> => {
-  const notHidden = options.includeHidden
-    ? sql`true`
-    : sql`${profiles.hidden} = false AND ${profiles.deactivatedAt} IS NULL`;
+// Hidden and deactivated profiles are filtered from all five sources for
+// every caller, admins included — the suggestion feed is member-facing.
+export const getRelationSuggestions = async (userId: string): Promise<RelationSuggestionFeed> => {
+  const notHidden = sql`${profiles.hidden} = false AND ${profiles.deactivatedAt} IS NULL`;
   const seen = new Set<string>([userId]);
   const suggestions: SuggestionCardRow[] = [];
   const otherMembers: SuggestionCardRow[] = [];

--- a/tests/e2e/me.spec.ts
+++ b/tests/e2e/me.spec.ts
@@ -42,12 +42,13 @@ test("tabs switch between profile and settings, and a theme choice persists", as
   await expect(page.locator("html")).not.toHaveClass(/dark/);
 });
 
-// Runs as the admin user: the seeded accounts are hidden in the prod
-// DB that previews share, and /members/[id] resolves hidden profiles
-// only for admin viewers — a regular seeded user would get "Member
-// not found" on their own page in CI.
+// We don't visit the public /members/[slug] page to confirm the change: the
+// seeded accounts are hidden on the prod DB that previews share, and a hidden
+// profile 404s from /members/:id for everyone (admins included), so that page
+// is unviewable in CI. Instead, a full reload proves the slug persisted —
+// the settings form re-hydrates from the saved value.
 test("a member can change their profile URL from settings", async ({ page }) => {
-  await signInAs(page, "admin");
+  await signInAs(page, "regular");
   // Distinct bio per completeWelcome caller — see the #149 probe.
   await completeWelcome(page, { displayName: "Slug Tester", bio: "e2e bio · me.spec · slug" });
 
@@ -60,8 +61,9 @@ test("a member can change their profile URL from settings", async ({ page }) => 
   await page.getByRole("button", { name: "Update URL" }).click();
   await expect(page.getByText("Profile URL updated")).toBeVisible();
 
-  // The new slug resolves in the member directory.
-  await page.goto("/members/e2e-slug-tester");
-  await page.waitForURL((u) => u.pathname === "/members/e2e-slug-tester", { timeout: TIMEOUT_MS });
-  await expect(page.getByRole("heading", { name: "Slug Tester" })).toBeVisible();
+  // A full reload re-fetches the profile, so the form re-hydrates with the
+  // saved slug — the field and the live preview both reflect it.
+  await page.reload();
+  await expect(page.getByLabel("Profile URL")).toHaveValue("e2e-slug-tester");
+  await expect(page.getByText("/members/e2e-slug-tester")).toBeVisible();
 });

--- a/tests/functional/server/profiles.test.ts
+++ b/tests/functional/server/profiles.test.ts
@@ -312,19 +312,14 @@ describe("profiles.hidden", () => {
     expect(profile?.hidden).toBe(true);
   });
 
-  it("listMembers excludes hidden by default and includes when includeHidden=true", async () => {
+  it("listMembers excludes hidden accounts", async () => {
     const visible = await listMembers();
     expect(visible.find((m) => m.id === hiddenId)).toBeUndefined();
     expect(visible.find((m) => m.id === visibleId)).toBeDefined();
-
-    const all = await listMembers({ includeHidden: true });
-    expect(all.find((m) => m.id === hiddenId)).toBeDefined();
   });
 
-  it("getProfileForMember returns null for hidden by default; returns the row when includeHidden=true", async () => {
+  it("getProfileForMember returns null for hidden accounts", async () => {
     expect(await getProfileForMember(hiddenId)).toBeNull();
-    const admin = await getProfileForMember(hiddenId, { includeHidden: true });
-    expect(admin?.id).toBe(hiddenId);
   });
 
   it("listHiddenMembers returns only hidden profiles", async () => {
@@ -363,11 +358,6 @@ describe("directory onboarding gate", () => {
   it("listMembers omits a member who has not set up their profile yet", async () => {
     const visible = await listMembers();
     expect(visible.find((m) => m.id === pendingId)).toBeUndefined();
-  });
-
-  it("admins still see mid-onboarding members via includeHidden", async () => {
-    const all = await listMembers({ includeHidden: true });
-    expect(all.find((m) => m.id === pendingId)).toBeDefined();
   });
 
   it("a saved bio makes the member visible (whitespace alone does not)", async () => {

--- a/tests/functional/server/relations-mini-map.test.ts
+++ b/tests/functional/server/relations-mini-map.test.ts
@@ -183,19 +183,15 @@ describe("getProfileMiniMap", () => {
     expect(set.has(a)).toBe(true);
   });
 
-  it("prunes a hidden mutual for a non-admin viewer, keeps it for an admin", async () => {
+  it("prunes a hidden mutual from the map", async () => {
     const hidden = await mk("Hidden");
     await relate(viewer, hidden, 4);
     await relate(hidden, them, 4);
     await db.update(profiles).set({ hidden: true }).where(eq(profiles.id, hidden));
 
-    const nonAdmin = await getProfileMiniMap({ viewerId: viewer, profileId: them });
-    expect(ids(nonAdmin).has(hidden)).toBe(false);
-    expect(nonAdmin.pathToViewer).toEqual([]); // the only bridge ran through the hidden node
-
-    const admin = await getProfileMiniMap({ viewerId: viewer, profileId: them, includeHidden: true });
-    expect(ids(admin)).toEqual(new Set([them, viewer, hidden]));
-    expect(admin.pathToViewer).toEqual([them, hidden, viewer]);
+    const map = await getProfileMiniMap({ viewerId: viewer, profileId: them });
+    expect(ids(map).has(hidden)).toBe(false);
+    expect(map.pathToViewer).toEqual([]); // the only bridge ran through the hidden node
   });
 
   it("returns every confirmed edge among the final node set", async () => {
@@ -252,7 +248,7 @@ describe("GET /api/relations/mini-map/:profileId", () => {
     expect(res.status).toBe(400);
   });
 
-  it("prunes a hidden node for a non-admin but keeps it for an admin", async () => {
+  it("prunes a hidden node for non-admins and admins alike", async () => {
     await updateRelationValue({ relatorId: them, relateeId: hidden, value: 4 });
     await db.update(profiles).set({ hidden: true }).where(eq(profiles.id, hidden));
 
@@ -262,6 +258,6 @@ describe("GET /api/relations/mini-map/:profileId", () => {
 
     authAs(admin);
     const adminBody = await (await app.request(`/api/relations/mini-map/${them}`)).json();
-    expect(adminBody.nodes.map((n: { id: string }) => n.id)).toContain(hidden);
+    expect(adminBody.nodes.map((n: { id: string }) => n.id)).not.toContain(hidden);
   });
 });

--- a/tests/functional/server/relations-personal.test.ts
+++ b/tests/functional/server/relations-personal.test.ts
@@ -116,22 +116,6 @@ describe("getPersonalWeb", () => {
     expect(sub.edges[0]).toMatchObject({ relatorId: center, relateeId: a });
   });
 
-  it("includeHidden=true keeps hidden nodes and their edges (admin viewer)", async () => {
-    await updateRelationValue({ relatorId: center, relateeId: a, value: 3 });
-    await updateRelationValue({ relatorId: center, relateeId: b, value: 2 });
-    await db.update(profiles).set({ hidden: true }).where(eq(profiles.id, b));
-
-    const sub = await getPersonalWeb({
-      centerId: center,
-      includeIncoming: false,
-      includeOutgoing: true,
-      hops: 1,
-      includeHidden: true,
-    });
-    expect(new Set(sub.nodes.map((n) => n.id))).toEqual(new Set([center, a, b]));
-    expect(sub.edges).toHaveLength(2);
-  });
-
   it("hops=2 drops a hidden second-degree neighbor and the edge that reaches it", async () => {
     const c = randomUUID();
     await insertUserAndProfile(c, { displayName: "C" });
@@ -167,20 +151,6 @@ describe("getPersonalWeb", () => {
     expect(sub.nodes.map((n) => n.id).includes(b)).toBe(false);
     expect(sub.edges.some((e) => e.relateeId === b)).toBe(false);
     expect(sub.nodes.map((n) => n.id).includes(a)).toBe(true);
-  });
-
-  it("includeHidden=true still drops deactivated neighbors (admin viewer)", async () => {
-    await updateRelationValue({ relatorId: center, relateeId: a, value: 3 });
-    await db.update(profiles).set({ deactivatedAt: new Date() }).where(eq(profiles.id, a));
-
-    const sub = await getPersonalWeb({
-      centerId: center,
-      includeIncoming: false,
-      includeOutgoing: true,
-      hops: 1,
-      includeHidden: true,
-    });
-    expect(sub.nodes.map((n) => n.id).includes(a)).toBe(false);
   });
 });
 

--- a/tests/functional/server/relations.test.ts
+++ b/tests/functional/server/relations.test.ts
@@ -388,12 +388,6 @@ describe("getRelationSuggestions — hidden filter", () => {
     expect(allIds).toContain(visibleOther);
     expect(allIds).not.toContain(hiddenOther);
   });
-
-  it("includeHidden=true keeps hidden profiles in the feed", async () => {
-    const feed = await getRelationSuggestions(me, { includeHidden: true });
-    const allIds = [...feed.suggestions, ...feed.otherMembers].map((c) => c.id);
-    expect(allIds).toContain(hiddenOther);
-  });
 });
 
 describe("materializeInviteRelations", () => {


### PR DESCRIPTION
Summary: Member-facing pages now show admins the same view as any member; hidden accounts are confined to the /admin pages.

Why: Admins were seeing hidden (and mid-onboarding) accounts in the Member Directory, profile pages, the intentions cloud, and My Web. That visibility belongs only on the special-admin pages, so admins see what the average member sees everywhere else.

Behavior:
- The Member Directory, /members/:id profile pages, the intentions cloud, and the My Web graph + suggestion feed + mini-map no longer surface hidden or deactivated accounts to admins — they match the regular-member view.
- A hidden profile now 404s from /members/:id for everyone, admins included.
- The /admin members page and the Hidden panel still list every account, so admins keep full visibility there.
- Side effect: the admin "Account to hide" and hint typeaheads share the /members endpoint, so they now exclude hidden/mid-onboarding accounts too.

Test Plan:
- ran the functional + e2e suites locally (550 functional + 37 e2e passing); biome clean
- functional suites assert hidden/deactivated accounts are excluded from each feed for every caller
- reworked the me.spec profile-URL e2e test to verify persistence via reload instead of viewing a hidden directory page (the prior version leaned on the removed admin bypass and would have failed in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
