### PR TITLE
feat(programs): allow program descriptions of any length

### DIFF
--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -351,7 +351,6 @@ export type ProgramDetail = AdminProgram & { participants: ProgramParticipant[] 
 const MAX_PROGRAM_NAME = 120;
 const MAX_PROGRAM_SLUG = 80;
 const MAX_PROGRAM_BLURB = 200;
-const MAX_PROGRAM_DESCRIPTION = 2000;
 // Buttondown tag names are short by convention; the cap is well above
 // anything Buttondown surfaces in its UI and keeps the column index-friendly.
 const MAX_BUTTONDOWN_TAG = 100;
@@ -398,9 +397,6 @@ export const parseProgramCreate = (
   }
 
   const description = trimmedString(obj.description);
-  if (description && description.length > MAX_PROGRAM_DESCRIPTION) {
-    return { error: "description is too long" };
-  }
 
   const buttondownTag = trimmedString(obj.buttondownTag);
   if (buttondownTag && buttondownTag.length > MAX_BUTTONDOWN_TAG) {
@@ -462,9 +458,6 @@ export const parseProgramUpdate = (body: unknown): ProgramUpdate | { error: stri
   }
   if ("description" in obj) {
     const description = trimmedString(obj.description);
-    if (description && description.length > MAX_PROGRAM_DESCRIPTION) {
-      return { error: "description is too long" };
-    }
     result.description = description || null;
   }
   if ("archived" in obj) {


### PR DESCRIPTION
Summary: Drop the 2000-character validation cap on program descriptions.

Why: Descriptions render as markdown long-form content; the cap was validation-only (the DB column is already unbounded `text`) and blocked longer write-ups.

Behavior: The admin create/edit program APIs no longer reject descriptions over 2000 characters. Blank/whitespace still normalizes to `null`. Name (120), slug (80), blurb (200), and Buttondown tag (100) caps are unchanged.

Test Plan:
- ran `npm test` locally — functional + 37 e2e green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
