### PR TITLE
feat(buttondown): sync display name into subscriber metadata.name

### DIFF
--- a/docs/design-buttondown.md
+++ b/docs/design-buttondown.md
@@ -18,7 +18,7 @@ The app's sync **replaced** the Apps Script as the writer of program tags; the c
 
 One sentence the whole integration enforces:
 
-> A member who has saved their profile should exist as a Buttondown subscriber, tagged exactly according to their current memberships in programs that have a `buttondownTag` set.
+> A member who has saved their profile should exist as a Buttondown subscriber, tagged exactly according to their current memberships in programs that have a `buttondownTag` set, and whose `metadata.name` equals their current display name.
 
 Every code path below is a route to making that statement true.
 
@@ -50,6 +50,17 @@ We identify "tags we manage" by joining against the `programs` table: the set of
 
 Subscribers are keyed by email. We use `auth.users.email` for the matching member's profile id — the same email Supabase signs them in with. There is no separate "newsletter email" field. Edge case: members who already exist in Buttondown under a different email won't be matched; that's an acknowledged limitation.
 
+### Display name (`metadata.name`)
+
+Buttondown subscribers carry an open `metadata` key-value blob. We mirror the member's display name into `metadata.name`, **verbatim** as they supplied it (`profiles.displayName` — typically "Firstname Lastname", sometimes a first name only; never the slug, never normalized). This restores a detail the pre-cutover Apps Script set, which the app initially dropped when it took over as the writer (#444).
+
+Rules:
+
+- **Only ever write a non-empty name.** An empty or whitespace-only display name never blanks an existing `metadata.name`.
+- **Every write is merge-preserving.** Subscribers carry other metadata keys we don't own, so each name write reads the subscriber first and PATCHes `{ ...existing, name }` — a whole-blob write that keeps the rest. Buttondown **replaces** the whole `metadata` blob on PATCH (it does not merge server-side — confirmed by [Appendix A](#appendix-a-fake-vs-real-comparison-recording-from-a-dedicated-newsletter) probe 20), so sending the full merged blob is exactly what preserves the other keys.
+- **Self-heals like tags.** The daily cron reads `metadata.name` back and repairs drift, so `metadata` is part of the client's subscriber projection.
+- **Hidden / unsubscribed:** same posture as tags — no create for hidden profiles, no write at all for unsubscribed subscribers, but a name reconcile still applies to an already-existing subscriber.
+
 ### Standing tags: `isweb-member`, `new`, `returning`
 
 Three tags carry signup-moment semantics — the app writes them when a subscriber first arrives via IS Web, and the daily cron never modifies them after that:
@@ -79,13 +90,15 @@ When a member saves their profile and `profiles.lastUpdatedProfile IS NULL` *bef
 1. Fetch the member's email from `auth.users`.
 2. Compute the desired program-tag set from their current `profile_programs` rows joined to programs with non-null `buttondownTag`.
 3. GET the Buttondown subscriber by email.
-   - **Missing** → POST to create with tags = `[…program_tags, "isweb-member", "new"]`. Store the returned subscriber id on `profiles.buttondownSubscriberId`.
+   - **Missing** → POST to create with tags = `[…program_tags, "isweb-member", "new"]` and (when the name is non-empty) `metadata: { name }`. Store the returned subscriber id on `profiles.buttondownSubscriberId`.
    - **Unsubscribed** → don't write. Raise an [unsubscribe alert](#unsubscribe-handling) so a human can decide whether this person should be in IS Web at all. Profile save still succeeds.
-   - **Active, existing, already has `isweb-member`** → no-op. The app has authoritatively written this subscriber on a previous run; doing another full-overwrite now risks clobbering tags a human has added in the Buttondown UI since. The cron's diff-only path handles any program-tag drift.
-   - **Active, existing, no `isweb-member`** → PATCH with a **full overwrite** of tags = `[…program_tags, "isweb-member", "returning"]`. This is the one moment we authoritatively reset. Record the subscriber id on `profiles.buttondownSubscriberId`.
+   - **Active, existing, already has `isweb-member`** → no-op. The app has authoritatively written this subscriber on a previous run; doing another full-overwrite now risks clobbering tags a human has added in the Buttondown UI since. The cron's diff-only path handles any program-tag drift — and any `metadata.name` drift.
+   - **Active, existing, no `isweb-member`** → PATCH with a **full overwrite** of tags = `[…program_tags, "isweb-member", "returning"]`, merging `name` into the subscriber's existing metadata. This is the one moment we authoritatively reset. Record the subscriber id on `profiles.buttondownSubscriberId`.
 4. Failure logs to Sentry and is **swallowed** — the profile save succeeds regardless. The cron picks up any miss, and any human tags lost to the overwrite were lost at a discrete known moment that admins can mentally bracket.
 
 This path exists only to shorten the new-member time-to-first-email. It is a latency optimization, not a correctness guarantee. The cron is what we trust.
+
+**Name edits.** A *subsequent* `PUT /me` that changes the display name fires a scoped resync (`runProfileResyncForServer`, reason `update-name`) right after the DB commit — the same merge-preserving name reconcile the cron runs, but inline so the name lands in Buttondown within the request instead of a day later. First saves are excluded: the inline first-save hook above already seeds the name, and firing here too would pre-empt its `new`/`returning` ownership. Like join/leave, it's best-effort, swallows failures, and is gated on `BUTTONDOWN_SYNC_WRITE`.
 
 ### 2. Daily reconciler (Vercel cron)
 
@@ -99,7 +112,7 @@ For each profile where `lastUpdatedProfile IS NOT NULL`:
    - **Unsubscribed**: don't write. Raise an [unsubscribe alert](#unsubscribe-handling).
    - **Found by id but email differs from `auth.users.email`**: PATCH the subscriber's `email` field to the current app email. Then continue with tag diffing.
    - **Found by email** (no stored id yet): record the id on `profiles.buttondownSubscriberId` for next time. Then continue with tag diffing.
-   - **Subscribed**: compute `(subscriber.tags ∩ managed_universe) Δ desired`. PATCH only if the diff is non-empty. Preserves human-set tags and the `isweb-member` / `new` / `returning` markers because they're outside the managed universe.
+   - **Subscribed**: compute `(subscriber.tags ∩ managed_universe) Δ desired`, and compare `subscriber.metadata?.name` to the member's display name. PATCH only if the tag diff is non-empty, the email drifted, or the name drifted — folding all three into one PATCH per profile. Tags preserve human-set tags and the `isweb-member` / `new` / `returning` markers because they're outside the managed universe; the name write merges `{ ...existing, name }` so other metadata keys survive, and a missing/empty display name is left untouched (never blanked).
 
 Output a structured summary to the dedicated Axiom dataset (see [Logging](#logging)): members scanned, subscribers created, tags added, tags removed, emails updated, unsubscribes flagged, errors.
 
@@ -265,11 +278,13 @@ The manual tests deliberately live outside the `npm test` portfolio. They're run
 
 Record and seed both load `.env.prod` and require `BUTTONDOWN_TEST_API_KEY`. The primary safety is structural — Buttondown's per-newsletter key scoping confines writes (and `listSubscribers` reads) to the key's specific newsletter, so a mis-pasted key cannot reach the wrong audience. The operational sanity check is `assertTestNewsletter` in `tests/manual/_buttondown-probes.ts`: it calls `GET /v1/accounts/me`, which returns the single newsletter the key writes to, and refuses to proceed unless the username matches `intentional-society-api-tests`. That catches both wrong-account and wrong-newsletter-same-account swaps. The key needs `administrivia_access` to call `/accounts/me` (in addition to `subscriber_access` for the destructive ops); the seed-fixtures script's startup error message points at this if the permission is missing.
 
+Both scripts construct their client with `allowReservedTestEmails: true`. The canonical audience is `@fixture.test` addresses, and the client's reserved-TLD wire guard (a prod safety: refuse `.test`/`.local`/etc. so a test user never reaches real Buttondown) would otherwise refuse every probe and seed call *before* any HTTP — which silently broke both scripts from when the guard landed (2026-05-25) until #444. Opting out is safe here precisely because the structural safety above (per-newsletter key scope + `assertTestNewsletter`) is what confines these scripts, not the TLD guard. Every prod path leaves the opt-out off.
+
 ### One probe sequence
 
 There's one ordered sequence of probes covering every public method on `ButtondownClient`, plus targeted error and edge cases. The authoritative list lives in code at `tests/manual/_buttondown-probes.ts` (`buildProbes()`); the recorded outcome for each probe lives at `tests/functional/server/__data__/buttondown/golds/NN-<short-name>.json`. Record and replay both walk the sequence in order.
 
-The last probe deletes the created subscriber, so re-running the sequence is idempotent without needing to re-seed.
+The last probes clean up after themselves — probe 18 deletes the subscriber probe 09 created, and probe 20 (the `metadata` merge-vs-replace check added for #444) creates and deletes its own — so re-running the sequence is idempotent without needing to re-seed.
 
 ### Data layout
 

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-20 | James | Buttondown subscribers now carry the member's display name in `metadata.name`
+
+We forgot this earlier: Push `profiles.displayName` into Buttondown's `metadata.name`. Seeded on create, reconciled by the cron via PATCH, and pushed inline on profile displayName edit (`reason: "update-name"`). Adds an `allowReservedTestEmails` client opt-out just for re-recording golds. (#444)
+
 ## 2026-06-19 | James | Hidden accounts no longer surface to admins on member-facing pages
 
 Dropped the admin `includeHidden` bypass from the directory, profile pages, intentions, and My Web; hidden accounts now show only on the `/admin` pages.

--- a/scripts/buttondown-recording/seed-fixtures.ts
+++ b/scripts/buttondown-recording/seed-fixtures.ts
@@ -70,7 +70,10 @@ const main = async (): Promise<void> => {
   }
   console.log();
 
-  const client = createButtondownClient({ apiKey, write: !isDryRun });
+  // Opt out of the reserved-TLD guard: the seed audience is intentionally
+  // @fixture.test against the dedicated api-tests newsletter (safety is the
+  // per-newsletter key scope + assertTestNewsletter, not that guard).
+  const client = createButtondownClient({ apiKey, write: !isDryRun, allowReservedTestEmails: true });
 
   console.log("Verifying the key resolves to the expected newsletter...");
   await assertTestNewsletter(client);

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -447,6 +447,21 @@ const api = new Hono<{ Variables: ApiVariables }>()
       // DB write commits, so a slug clash (409 above) can't desync the two.
       if (parsed.displayName !== undefined) {
         await syncDisplayNameToAuthMetadata(user.id, parsed.displayName, user.user_metadata ?? {});
+
+        // Mirror the same edit into Buttondown's metadata.name — but only
+        // on a *subsequent* save. On the first save the inline hook below
+        // owns the create and seeds the name; firing here too would
+        // pre-empt that path's new/returning ownership. The scoped resync
+        // does the merge-preserving name reconcile from the cron in one
+        // place. Same write gate and swallow-on-failure posture as the
+        // auth mirror; the cron is the safety net.
+        if (!isFirstSave) {
+          await runProfileResyncForServer({
+            profileId: user.id,
+            reason: "update-name",
+            write: process.env.BUTTONDOWN_SYNC_WRITE === "1",
+          });
+        }
       }
     }
 

--- a/src/server/buttondown-runner.ts
+++ b/src/server/buttondown-runner.ts
@@ -223,7 +223,7 @@ export const runFirstProfileSaveForServer = async (params: {
  * program-join trigger a resync that ends in an error?" without
  * parsing log strings.
  */
-export type ProfileResyncReason = "join-program" | "leave-program" | "admin-remove-participant";
+export type ProfileResyncReason = "join-program" | "leave-program" | "admin-remove-participant" | "update-name";
 
 /**
  * Best-effort inline resync for a single profile. Called from the

--- a/src/server/buttondown-sync.ts
+++ b/src/server/buttondown-sync.ts
@@ -27,6 +27,18 @@ import { db } from "./db";
 import { authUsers, profilePrograms, profiles, programs } from "./schema";
 
 /**
+ * The verbatim display name to mirror into Buttondown's
+ * `metadata.name` (see docs/design-buttondown.md → "The invariant"),
+ * or undefined when the profile has no usable name. We never blank an
+ * existing `metadata.name`, so an empty or whitespace-only display
+ * name yields undefined and every caller simply skips the name write.
+ * The returned value is the stored string untouched — never the slug,
+ * never normalized.
+ */
+const desiredMetadataName = (displayName: string | null | undefined): string | undefined =>
+  displayName && displayName.trim().length > 0 ? displayName : undefined;
+
+/**
  * Inline first-profile-save hook. Called from PUT /me when the
  * profile was being saved for the first time (lastUpdatedProfile was
  * NULL before the save). The "one moment" of full-overwrite tag
@@ -63,8 +75,12 @@ export const runFirstProfileSaveSync = async (params: {
   // Buttondown row spun up on their behalf, even if they exist in
   // the app. (Tag updates for already-existing subscribers still run
   // below.) One row read, fine on the first-save fast path.
-  const [profileRow] = await db.select({ hidden: profiles.hidden }).from(profiles).where(eq(profiles.id, profileId));
+  const [profileRow] = await db
+    .select({ hidden: profiles.hidden, displayName: profiles.displayName })
+    .from(profiles)
+    .where(eq(profiles.id, profileId));
   const hidden = profileRow?.hidden ?? false;
+  const name = desiredMetadataName(profileRow?.displayName);
 
   // This profile's current tagged-program memberships — same shape
   // the daily reconciler computes but for one profile only.
@@ -95,6 +111,7 @@ export const runFirstProfileSaveSync = async (params: {
     const result = await client.createSubscriber({
       email_address: email,
       tags: [...desiredTags, "isweb-member", "new"],
+      ...(name ? { metadata: { name } } : {}),
     });
     if (!isDryRunOutcome(result)) {
       await db.update(profiles).set({ buttondownSubscriberId: result.id }).where(eq(profiles.id, profileId));
@@ -123,8 +140,13 @@ export const runFirstProfileSaveSync = async (params: {
     return;
   }
 
+  // The one authoritative full-overwrite moment also seeds the name,
+  // merged into whatever metadata the subscriber already carries so
+  // other keys survive. The isweb-member no-op branch above leaves
+  // name to the cron, consistent with how it leaves tag drift.
   await client.updateSubscriber(subscriber.id, {
     tags: [...desiredTags, "isweb-member", "returning"],
+    ...(name ? { metadata: { ...subscriber.metadata, name } } : {}),
   });
 };
 
@@ -169,6 +191,16 @@ export type SyncLogEvent =
       to: string;
       dryRun: boolean;
     }
+  | {
+      action: "name-updated";
+      runId: string;
+      profileId: string;
+      subscriberId: string;
+      // null when the subscriber carried no metadata.name before.
+      from: string | null;
+      to: string;
+      dryRun: boolean;
+    }
   | { action: "unsubscribe-alert"; runId: string; profileId: string; email: string; programSlugsHeld: string[] }
   | { action: "skipped-missing-email"; runId: string; profileId: string }
   | { action: "skipped-already-current"; runId: string; profileId: string; subscriberId: string }
@@ -192,6 +224,9 @@ export type SyncRunSummary = {
   created: number;
   tagsUpdated: number;
   emailUpdated: number;
+  // Subscribers whose metadata.name drifted from the member's display
+  // name and was repaired (merge-preserving the rest of metadata).
+  nameUpdated: number;
   unchanged: number;
   unsubscribeAlerts: number;
   missingProfileEmail: number;
@@ -233,6 +268,8 @@ type ProfileRow = {
   // The sync suppresses CREATE for them (no new Buttondown row), but
   // still reconciles tags if a subscriber already exists.
   hidden: boolean;
+  // Mirrored verbatim into Buttondown's metadata.name; null when unset.
+  displayName: string | null;
 };
 
 type ProfileMembership = {
@@ -303,6 +340,7 @@ const loadEligibleProfiles = async (scopeProfileIds?: string[]): Promise<Profile
       email: authUsers.email,
       buttondownSubscriberId: profiles.buttondownSubscriberId,
       hidden: profiles.hidden,
+      displayName: profiles.displayName,
     })
     .from(profiles)
     .innerJoin(authUsers, eq(authUsers.id, profiles.id))
@@ -422,6 +460,7 @@ export const runButtondownSync = async (deps: SyncDeps): Promise<SyncRunSummary>
     created: 0,
     tagsUpdated: 0,
     emailUpdated: 0,
+    nameUpdated: 0,
     unchanged: 0,
     unsubscribeAlerts: 0,
     missingProfileEmail: 0,
@@ -528,6 +567,7 @@ const syncOneProfile = async (args: SyncOneProfileArgs): Promise<void> => {
     return;
   }
   const email = profile.email;
+  const name = desiredMetadataName(profile.displayName);
 
   // Reserved-TLD guard: skip before any client call. The client also
   // refuses these at the wire, so this layer is mainly so the summary
@@ -555,10 +595,11 @@ const syncOneProfile = async (args: SyncOneProfileArgs): Promise<void> => {
     }
     // Catch-up create: this is the path that runs when the inline
     // first-save hook failed (or hasn't shipped yet). Tag with the
-    // managed set + isweb-member + new.
+    // managed set + isweb-member + new, and seed metadata.name.
     const result = await client.createSubscriber({
       email_address: email,
       tags: [...desired.tags, "isweb-member", "new"],
+      ...(name ? { metadata: { name } } : {}),
     });
     summary.created++;
     const subscriberId = isDryRunOutcome(result) ? null : result.id;
@@ -600,7 +641,14 @@ const syncOneProfile = async (args: SyncOneProfileArgs): Promise<void> => {
   const { finalTags, added, removed, changed } = reconcileTags(subscriber.tags, desired.tags, managedUniverse);
   const emailMismatch = subscriber.email_address.toLowerCase() !== email.toLowerCase();
 
-  if (!changed && !emailMismatch) {
+  // Name reconcile: repair a drifted metadata.name, never blank one.
+  // The merge spreads the subscriber's existing metadata so the write
+  // preserves every other key (read-modify-write, whole-blob PATCH).
+  // Building the object inside the guard narrows `name` to a string.
+  const metadataPatch =
+    name !== undefined && subscriber.metadata?.name !== name ? { ...subscriber.metadata, name } : undefined;
+
+  if (!changed && !emailMismatch && !metadataPatch) {
     summary.unchanged++;
     log({ action: "skipped-already-current", runId, profileId, subscriberId: subscriber.id });
     return;
@@ -609,6 +657,7 @@ const syncOneProfile = async (args: SyncOneProfileArgs): Promise<void> => {
   const patch: UpdateSubscriberInput = {};
   if (changed) patch.tags = finalTags;
   if (emailMismatch) patch.email_address = email;
+  if (metadataPatch) patch.metadata = metadataPatch;
 
   const result = await client.updateSubscriber(subscriber.id, patch);
   const dryRun = isDryRunOutcome(result);
@@ -634,6 +683,18 @@ const syncOneProfile = async (args: SyncOneProfileArgs): Promise<void> => {
       subscriberId: subscriber.id,
       from: subscriber.email_address,
       to: email,
+      dryRun,
+    });
+  }
+  if (metadataPatch) {
+    summary.nameUpdated++;
+    log({
+      action: "name-updated",
+      runId,
+      profileId,
+      subscriberId: subscriber.id,
+      from: subscriber.metadata?.name ?? null,
+      to: metadataPatch.name,
       dryRun,
     });
   }

--- a/src/server/buttondown.ts
+++ b/src/server/buttondown.ts
@@ -44,11 +44,17 @@ export type ButtondownSubscriberType = "regular" | "premium" | "unactivated" | "
 
 // Minimal projection of the subscriber object — only the fields the
 // sync reads. The API returns more, all ignored by us.
+//
+// `metadata` is Buttondown's open key-value blob on a subscriber. We
+// read it back so the cron can detect drift in the one key we write
+// (`name`); we never enumerate or depend on the others, but they must
+// survive every write — see the merge note on UpdateSubscriberInput.
 export type ButtondownSubscriber = {
   id: string;
   email_address: string;
   type: ButtondownSubscriberType;
   tags: string[];
+  metadata?: Record<string, string>;
 };
 
 export type CreateSubscriberInput = {
@@ -60,12 +66,19 @@ export type CreateSubscriberInput = {
   // create subscribers (program membership is the consent act). See
   // docs.buttondown.com — "API-driven subscriber creation."
   type?: ButtondownSubscriberType;
+  metadata?: Record<string, string>;
 };
 
 export type UpdateSubscriberInput = {
   tags?: string[];
   email_address?: string;
   type?: ButtondownSubscriberType;
+  // Whole-blob: a PATCH carrying `metadata` sets the entire metadata
+  // object. The sync never sends a partial — every name write reads
+  // the subscriber first and PATCHes `{ ...existing, name }`, so
+  // other keys are preserved regardless of whether Buttondown merges
+  // or replaces server-side. See docs/design-buttondown.md.
+  metadata?: Record<string, string>;
 };
 
 // Identity of the API key's owning newsletter, returned by
@@ -102,17 +115,6 @@ export class ButtondownApiError extends Error {
   }
 }
 
-// Thrown by createSubscriber when the email is already on the audience.
-// The sync interprets this as "fall through to update by email" — the
-// person predates the app's record of them and we need to PATCH, not
-// POST. Per the Buttondown docs, duplicate POSTs are rejected by default.
-export class ButtondownConflictError extends ButtondownApiError {
-  constructor() {
-    super(409, "Subscriber with this email already exists");
-    this.name = "ButtondownConflictError";
-  }
-}
-
 // Shape of one page of the list endpoint's response. `next` is a
 // full URL to the next page or null on the last page.
 type ListSubscribersPage = {
@@ -131,11 +133,17 @@ type ListSubscribersPage = {
 // boundary is what lets the replay deep-equal pass.
 const projectSubscriber = (raw: unknown): ButtondownSubscriber => {
   const obj = raw as Record<string, unknown>;
+  const metadata = obj.metadata as Record<string, string> | null | undefined;
   return {
     id: obj.id as string,
     email_address: obj.email_address as string,
     type: obj.type as ButtondownSubscriberType,
     tags: obj.tags as string[],
+    // Carry `metadata` through only when Buttondown returns a blob; an
+    // absent or null value leaves the field off entirely (it reads
+    // safely as `subscriber.metadata?.name`). The re-recorded golds
+    // (Appendix A) pin the real wire shape for whatever it actually is.
+    ...(metadata ? { metadata } : {}),
   };
 };
 
@@ -168,7 +176,7 @@ export interface ButtondownClient {
    * audience would be wasteful.
    */
   getSubscriber(idOrEmail: string): Promise<ButtondownSubscriber | null>;
-  /** Throws ButtondownConflictError on 409 (duplicate email). */
+  /** A duplicate email surfaces as a 400 ButtondownApiError (Buttondown's `email_already_exists`). */
   createSubscriber(input: CreateSubscriberInput): Promise<ButtondownSubscriber | DryRunOutcome<"create">>;
   updateSubscriber(id: string, patch: UpdateSubscriberInput): Promise<ButtondownSubscriber | DryRunOutcome<"update">>;
   /**
@@ -204,6 +212,12 @@ export type ButtondownClientConfig = {
   // Optional per-request telemetry sink. Constructed by the runner
   // for prod paths; tests typically leave it unset.
   logger?: (event: ButtondownHttpLogEvent) => void;
+  // Lets the manual record/seed scripts reach the api-tests
+  // newsletter's @fixture.test audience past the reserved-email guard
+  // below. Their safety is the per-newsletter key scope +
+  // assertTestNewsletter, not this guard; every prod path leaves it
+  // false. See docs/design-buttondown.md Appendix A.
+  allowReservedTestEmails?: boolean;
 };
 
 export const createButtondownClient = (config: ButtondownClientConfig): ButtondownClient => {
@@ -304,7 +318,7 @@ export const createButtondownClient = (config: ButtondownClientConfig): Buttondo
     },
 
     async getSubscriber(idOrEmail) {
-      if (isReservedTestEmail(idOrEmail)) {
+      if (!config.allowReservedTestEmails && isReservedTestEmail(idOrEmail)) {
         throw new ButtondownApiError(0, `Refusing to query reserved-TLD email: ${idOrEmail}`);
       }
       // The endpoint accepts either id or email at the same slot; we
@@ -320,14 +334,13 @@ export const createButtondownClient = (config: ButtondownClientConfig): Buttondo
     },
 
     async createSubscriber(input) {
-      if (isReservedTestEmail(input.email_address)) {
+      if (!config.allowReservedTestEmails && isReservedTestEmail(input.email_address)) {
         throw new ButtondownApiError(0, `Refusing to create reserved-TLD email: ${input.email_address}`);
       }
       if (!config.write) {
         return { dryRun: true, intent: "create", payload: input };
       }
       const res = await request("POST", "/subscribers", input);
-      if (res.status === 409) throw new ButtondownConflictError();
       if (!res.ok) {
         const detail = await res.text().catch(() => "");
         throw new ButtondownApiError(res.status, `POST subscriber: ${res.status} ${detail}`);
@@ -336,7 +349,11 @@ export const createButtondownClient = (config: ButtondownClientConfig): Buttondo
     },
 
     async updateSubscriber(id, patch) {
-      if (patch.email_address !== undefined && isReservedTestEmail(patch.email_address)) {
+      if (
+        !config.allowReservedTestEmails &&
+        patch.email_address !== undefined &&
+        isReservedTestEmail(patch.email_address)
+      ) {
         throw new ButtondownApiError(0, `Refusing to set reserved-TLD email: ${patch.email_address}`);
       }
       if (!config.write) {

--- a/tests/functional/server/__data__/buttondown/golds/01-list-seeded.json
+++ b/tests/functional/server/__data__/buttondown/golds/01-list-seeded.json
@@ -16,7 +16,8 @@
       "id": "sub_6ng6e0cngh95hra8aa0w7ejydp",
       "email_address": "sandy.60@fixture.test",
       "type": "regular",
-      "tags": []
+      "tags": [],
+      "metadata": {}
     },
     {
       "id": "sub_7e0j9eh3t98y0rz1m2vvjdqsj0",
@@ -24,7 +25,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_4yv1r6fjzf8xar8tcw0n638cec",
@@ -34,7 +36,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_26qfmj2e9w90kbay51kcsa9m9a",
@@ -42,7 +45,8 @@
       "type": "regular",
       "tags": [
         "tactive"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_4vgttejn0y8apa24exes0stq8k",
@@ -54,7 +58,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_60cbg7mayj9myv2p1pz675h043",
@@ -63,13 +68,15 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_0m09zdq64f9j2904d0j6b9yhbx",
       "email_address": "camille.54@fixture.test",
       "type": "regular",
-      "tags": []
+      "tags": [],
+      "metadata": {}
     },
     {
       "id": "sub_6ntkr7vva39g0rvpsdd0g6dxr4",
@@ -80,7 +87,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_397rvagfbf8k4snnd3cx5arrq8",
@@ -90,7 +98,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_27wqvz23ec8j6rqb51g1nd58dz",
@@ -100,7 +109,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_372qyw5y4z9t3reb8mrg8ksepb",
@@ -108,7 +118,8 @@
       "type": "regular",
       "tags": [
         "tactive"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_0trh6dbg858ahrajex6bhrjpkb",
@@ -116,7 +127,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_6gy24t1dk49mq847t9msrkgv7c",
@@ -127,7 +139,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_7rt62xtxdv9c8vgmv06q4zmz5f",
@@ -136,7 +149,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_6pp48s7v5g90etp8t9829bh17h",
@@ -146,13 +160,15 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_1jr9w5n9699yvaa7n9h5qn8197",
       "email_address": "sam.45@fixture.test",
       "type": "regular",
-      "tags": []
+      "tags": [],
+      "metadata": {}
     },
     {
       "id": "sub_7hgfdy5tv4911v0vkh8qjt8q5d",
@@ -162,7 +178,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_0s893p2neq8198aar5fys1sfsz",
@@ -170,7 +187,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_6dy6f7a3my805tbq735nzbkq8g",
@@ -182,7 +200,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_41511dkk919revc8b93taad8e8",
@@ -193,7 +212,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_34r83nn51y82t83kj6m46f6vzx",
@@ -203,7 +223,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_09etdnny7w9169ddns60ktpv8k",
@@ -211,7 +232,8 @@
       "type": "regular",
       "tags": [
         "tactive"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_3ne4hf08aj830vm7s8evv49573",
@@ -222,7 +244,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_7ep0a9rbnn94fsgnnrn6y62q21",
@@ -231,7 +254,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2gamfzex0x9jesjda40c7pjfrq",
@@ -242,7 +266,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2pchfjmzmx9rdb4dvtgdqa752z",
@@ -250,7 +275,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_08a4p81qjh8rjrfwt4p42rhgre",
@@ -260,13 +286,15 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_3ghgezaqcq9m2tp60jzwy7fnra",
       "email_address": "grace.33@fixture.test",
       "type": "regular",
-      "tags": []
+      "tags": [],
+      "metadata": {}
     },
     {
       "id": "sub_1w7xzkd8068z5tarsaftgwwnx4",
@@ -276,7 +304,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2pgynycqwa85av3crvk526mtzy",
@@ -288,7 +317,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_3w1m0b6cf09j9b6ejxrvsdsyzw",
@@ -299,7 +329,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_43v09xmwzw83ab8ndryqz7fx0w",
@@ -308,7 +339,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2rkv413ngy97nbrbs8asnwzn6j",
@@ -316,7 +348,8 @@
       "type": "regular",
       "tags": [
         "tactive"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_4rtpqyhh639jg8cvrq307z8630",
@@ -326,7 +359,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2t2y99wc7q9f5vq3a80tjffvbw",
@@ -337,7 +371,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_1a9r634hb48j7vpy2akjb1hdv2",
@@ -345,7 +380,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_0ww542s4tk9esaet5sm3h3hbkw",
@@ -356,7 +392,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_297s8mqz0z9rj9b4bt9w28p0kr",
@@ -364,7 +401,8 @@
       "type": "regular",
       "tags": [
         "tactive"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_1x68c8jeqa9ppvc5nt4xchv33t",
@@ -374,7 +412,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2vkzmy7w6z9dqr8h20myh8ss0y",
@@ -385,7 +424,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2xrv888cad80jttpzf2jb3h66d",
@@ -394,7 +434,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_1q5qpnhaqc8t39rc3hatbpq1a9",
@@ -406,7 +447,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_1jvjvyjv2r9qg8x684xykpa1c2",
@@ -416,13 +458,15 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_64xw5qnpd990gbx46ynfbasz91",
       "email_address": "quinn.17@fixture.test",
       "type": "regular",
-      "tags": []
+      "tags": [],
+      "metadata": {}
     },
     {
       "id": "sub_1s40rgp3p59ebvha150wsrksd2",
@@ -432,7 +476,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_3nr0ssk2rp8x6tznv5vgbbrxzx",
@@ -441,7 +486,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_0e7xt0wcbb9499mr4xzgss1k1z",
@@ -451,7 +497,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_619tbm3xgr88yt5c5bf3jtnj42",
@@ -462,7 +509,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2bf7esrez98yqskzragv3xcnv1",
@@ -472,7 +520,8 @@
         "tarts-in-is",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_3yxac23tyr8wmr8mkgxvs2hv3x",
@@ -480,7 +529,8 @@
       "type": "regular",
       "tags": [
         "tactive"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_4pkapqcwaj8bbstq10evb7d78k",
@@ -488,7 +538,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_6e0ymqvhme8natbgntbergg6mt",
@@ -498,7 +549,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_34t0e9feej9aatyeq7zkjk9p1e",
@@ -509,7 +561,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_5y5vwt0bp09xp857y43dvrd91j",
@@ -518,7 +571,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_4yvr49xjv892fb33jmwkhqzm0b",
@@ -530,7 +584,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_6x7x44k4xy8kptzmzwv9261p41",
@@ -540,13 +595,15 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_350agfqh1j9gg9k9wk5myw2vnx",
       "email_address": "dave.04@fixture.test",
       "type": "unsubscribed",
-      "tags": []
+      "tags": [],
+      "metadata": {}
     },
     {
       "id": "sub_3tzvveppjh994t7yp4mn8a7mwq",
@@ -554,7 +611,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_0vnn0jm7y99z8rge7fsbc3f5px",
@@ -563,7 +621,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_1psvey6mfj8dza83gkp8hjbktk",
@@ -573,7 +632,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     }
   ]
 }

--- a/tests/functional/server/__data__/buttondown/golds/03-get-by-id.json
+++ b/tests/functional/server/__data__/buttondown/golds/03-get-by-id.json
@@ -19,6 +19,7 @@
       "tcommunity-calls",
       "tisweb-member",
       "tweekly-web-updates"
-    ]
+    ],
+    "metadata": {}
   }
 }

--- a/tests/functional/server/__data__/buttondown/golds/04-get-by-email.json
+++ b/tests/functional/server/__data__/buttondown/golds/04-get-by-email.json
@@ -19,6 +19,7 @@
       "tcommunity-calls",
       "tisweb-member",
       "tweekly-web-updates"
-    ]
+    ],
+    "metadata": {}
   }
 }

--- a/tests/functional/server/__data__/buttondown/golds/07-get-unsubscribed-member.json
+++ b/tests/functional/server/__data__/buttondown/golds/07-get-unsubscribed-member.json
@@ -21,6 +21,7 @@
       "tisweb-member",
       "tpod-program",
       "tweekly-web-updates"
-    ]
+    ],
+    "metadata": {}
   }
 }

--- a/tests/functional/server/__data__/buttondown/golds/08-get-unsubscribed-nonmember.json
+++ b/tests/functional/server/__data__/buttondown/golds/08-get-unsubscribed-nonmember.json
@@ -15,6 +15,7 @@
     "id": "sub_350agfqh1j9gg9k9wk5myw2vnx",
     "email_address": "dave.04@fixture.test",
     "type": "unsubscribed",
-    "tags": []
+    "tags": [],
+    "metadata": {}
   }
 }

--- a/tests/functional/server/__data__/buttondown/golds/09-create-fresh.json
+++ b/tests/functional/server/__data__/buttondown/golds/09-create-fresh.json
@@ -19,11 +19,12 @@
     }
   ],
   "typed_result": {
-    "id": "sub_164q773sbj9agams4jfe6r9m9v",
+    "id": "sub_4yzgme02bk9dq8v70ms78yzpfv",
     "email_address": "probe-created@fixture.test",
     "type": "regular",
     "tags": [
       "probe-fresh"
-    ]
+    ],
+    "metadata": {}
   }
 }

--- a/tests/functional/server/__data__/buttondown/golds/10-create-duplicate.json
+++ b/tests/functional/server/__data__/buttondown/golds/10-create-duplicate.json
@@ -17,9 +17,11 @@
         "status": 400,
         "body": {
           "code": "email_already_exists",
-          "detail": "That email address (probe-created@fixture.test) is already subscribed (id=2625ce71-e572-4aa0-aa64-927b8d84d13b).",
+          "detail": "That email address (probe-created@fixture.test) is already subscribed (id=9efc28e0-0973-4b6e-8d9c-14c9d1efd9fb). To update them instead, retry with the header 'X-Buttondown-Collision-Behavior: overwrite', or PATCH /v1/subscribers/9efc28e0-0973-4b6e-8d9c-14c9d1efd9fb.",
           "metadata": {
-            "subscriber_id": "2625ce71-e572-4aa0-aa64-927b8d84d13b"
+            "subscriber_id": "9efc28e0-0973-4b6e-8d9c-14c9d1efd9fb",
+            "remedy_header": "X-Buttondown-Collision-Behavior: overwrite",
+            "documentation_url": "https://docs.buttondown.com/api-subscribers-create"
           }
         }
       }

--- a/tests/functional/server/__data__/buttondown/golds/11-patch-tags.json
+++ b/tests/functional/server/__data__/buttondown/golds/11-patch-tags.json
@@ -4,7 +4,7 @@
     {
       "request": {
         "method": "PATCH",
-        "url": "https://api.buttondown.com/v1/subscribers/sub_164q773sbj9agams4jfe6r9m9v",
+        "url": "https://api.buttondown.com/v1/subscribers/sub_4yzgme02bk9dq8v70ms78yzpfv",
         "body": {
           "tags": [
             "probe-patched-tags"
@@ -17,11 +17,12 @@
     }
   ],
   "typed_result": {
-    "id": "sub_164q773sbj9agams4jfe6r9m9v",
+    "id": "sub_4yzgme02bk9dq8v70ms78yzpfv",
     "email_address": "probe-created@fixture.test",
     "type": "regular",
     "tags": [
       "probe-patched-tags"
-    ]
+    ],
+    "metadata": {}
   }
 }

--- a/tests/functional/server/__data__/buttondown/golds/12-patch-email.json
+++ b/tests/functional/server/__data__/buttondown/golds/12-patch-email.json
@@ -4,7 +4,7 @@
     {
       "request": {
         "method": "PATCH",
-        "url": "https://api.buttondown.com/v1/subscribers/sub_164q773sbj9agams4jfe6r9m9v",
+        "url": "https://api.buttondown.com/v1/subscribers/sub_4yzgme02bk9dq8v70ms78yzpfv",
         "body": {
           "email_address": "probe-created-renamed@fixture.test"
         }
@@ -15,11 +15,12 @@
     }
   ],
   "typed_result": {
-    "id": "sub_164q773sbj9agams4jfe6r9m9v",
+    "id": "sub_4yzgme02bk9dq8v70ms78yzpfv",
     "email_address": "probe-created-renamed@fixture.test",
     "type": "regular",
     "tags": [
       "probe-patched-tags"
-    ]
+    ],
+    "metadata": {}
   }
 }

--- a/tests/functional/server/__data__/buttondown/golds/13-patch-both-same-email.json
+++ b/tests/functional/server/__data__/buttondown/golds/13-patch-both-same-email.json
@@ -4,7 +4,7 @@
     {
       "request": {
         "method": "PATCH",
-        "url": "https://api.buttondown.com/v1/subscribers/sub_164q773sbj9agams4jfe6r9m9v",
+        "url": "https://api.buttondown.com/v1/subscribers/sub_4yzgme02bk9dq8v70ms78yzpfv",
         "body": {
           "tags": [
             "probe-patched-tags",

--- a/tests/functional/server/__data__/buttondown/golds/14-patch-both-new-email.json
+++ b/tests/functional/server/__data__/buttondown/golds/14-patch-both-new-email.json
@@ -4,7 +4,7 @@
     {
       "request": {
         "method": "PATCH",
-        "url": "https://api.buttondown.com/v1/subscribers/sub_164q773sbj9agams4jfe6r9m9v",
+        "url": "https://api.buttondown.com/v1/subscribers/sub_4yzgme02bk9dq8v70ms78yzpfv",
         "body": {
           "tags": [
             "probe-patched-tags",
@@ -19,12 +19,13 @@
     }
   ],
   "typed_result": {
-    "id": "sub_164q773sbj9agams4jfe6r9m9v",
+    "id": "sub_4yzgme02bk9dq8v70ms78yzpfv",
     "email_address": "probe-created-final@fixture.test",
     "type": "regular",
     "tags": [
       "probe-extra",
       "probe-patched-tags"
-    ]
+    ],
+    "metadata": {}
   }
 }

--- a/tests/functional/server/__data__/buttondown/golds/15-patch-existing-unsubscribe.json
+++ b/tests/functional/server/__data__/buttondown/golds/15-patch-existing-unsubscribe.json
@@ -23,6 +23,7 @@
       "tcommunity-calls",
       "tisweb-member",
       "tweekly-web-updates"
-    ]
+    ],
+    "metadata": {}
   }
 }

--- a/tests/functional/server/__data__/buttondown/golds/16-patch-existing-resubscribe.json
+++ b/tests/functional/server/__data__/buttondown/golds/16-patch-existing-resubscribe.json
@@ -23,6 +23,7 @@
       "tcommunity-calls",
       "tisweb-member",
       "tweekly-web-updates"
-    ]
+    ],
+    "metadata": {}
   }
 }

--- a/tests/functional/server/__data__/buttondown/golds/17-list-after-mutations.json
+++ b/tests/functional/server/__data__/buttondown/golds/17-list-after-mutations.json
@@ -13,19 +13,21 @@
   ],
   "typed_result": [
     {
-      "id": "sub_164q773sbj9agams4jfe6r9m9v",
+      "id": "sub_4yzgme02bk9dq8v70ms78yzpfv",
       "email_address": "probe-created-final@fixture.test",
       "type": "regular",
       "tags": [
         "probe-extra",
         "probe-patched-tags"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_6ng6e0cngh95hra8aa0w7ejydp",
       "email_address": "sandy.60@fixture.test",
       "type": "regular",
-      "tags": []
+      "tags": [],
+      "metadata": {}
     },
     {
       "id": "sub_7e0j9eh3t98y0rz1m2vvjdqsj0",
@@ -33,7 +35,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_4yv1r6fjzf8xar8tcw0n638cec",
@@ -43,7 +46,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_26qfmj2e9w90kbay51kcsa9m9a",
@@ -51,7 +55,8 @@
       "type": "regular",
       "tags": [
         "tactive"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_4vgttejn0y8apa24exes0stq8k",
@@ -63,7 +68,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_60cbg7mayj9myv2p1pz675h043",
@@ -72,13 +78,15 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_0m09zdq64f9j2904d0j6b9yhbx",
       "email_address": "camille.54@fixture.test",
       "type": "regular",
-      "tags": []
+      "tags": [],
+      "metadata": {}
     },
     {
       "id": "sub_6ntkr7vva39g0rvpsdd0g6dxr4",
@@ -89,7 +97,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_397rvagfbf8k4snnd3cx5arrq8",
@@ -99,7 +108,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_27wqvz23ec8j6rqb51g1nd58dz",
@@ -109,7 +119,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_372qyw5y4z9t3reb8mrg8ksepb",
@@ -117,7 +128,8 @@
       "type": "regular",
       "tags": [
         "tactive"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_0trh6dbg858ahrajex6bhrjpkb",
@@ -125,7 +137,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_6gy24t1dk49mq847t9msrkgv7c",
@@ -136,7 +149,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_7rt62xtxdv9c8vgmv06q4zmz5f",
@@ -145,7 +159,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_6pp48s7v5g90etp8t9829bh17h",
@@ -155,13 +170,15 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_1jr9w5n9699yvaa7n9h5qn8197",
       "email_address": "sam.45@fixture.test",
       "type": "regular",
-      "tags": []
+      "tags": [],
+      "metadata": {}
     },
     {
       "id": "sub_7hgfdy5tv4911v0vkh8qjt8q5d",
@@ -171,7 +188,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_0s893p2neq8198aar5fys1sfsz",
@@ -179,7 +197,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_6dy6f7a3my805tbq735nzbkq8g",
@@ -191,7 +210,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_41511dkk919revc8b93taad8e8",
@@ -202,7 +222,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_34r83nn51y82t83kj6m46f6vzx",
@@ -212,7 +233,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_09etdnny7w9169ddns60ktpv8k",
@@ -220,7 +242,8 @@
       "type": "regular",
       "tags": [
         "tactive"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_3ne4hf08aj830vm7s8evv49573",
@@ -231,7 +254,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_7ep0a9rbnn94fsgnnrn6y62q21",
@@ -240,7 +264,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2gamfzex0x9jesjda40c7pjfrq",
@@ -251,7 +276,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2pchfjmzmx9rdb4dvtgdqa752z",
@@ -259,7 +285,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_08a4p81qjh8rjrfwt4p42rhgre",
@@ -269,13 +296,15 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_3ghgezaqcq9m2tp60jzwy7fnra",
       "email_address": "grace.33@fixture.test",
       "type": "regular",
-      "tags": []
+      "tags": [],
+      "metadata": {}
     },
     {
       "id": "sub_1w7xzkd8068z5tarsaftgwwnx4",
@@ -285,7 +314,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2pgynycqwa85av3crvk526mtzy",
@@ -297,7 +327,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_3w1m0b6cf09j9b6ejxrvsdsyzw",
@@ -308,7 +339,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_43v09xmwzw83ab8ndryqz7fx0w",
@@ -317,7 +349,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2rkv413ngy97nbrbs8asnwzn6j",
@@ -325,7 +358,8 @@
       "type": "regular",
       "tags": [
         "tactive"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_4rtpqyhh639jg8cvrq307z8630",
@@ -335,7 +369,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2t2y99wc7q9f5vq3a80tjffvbw",
@@ -346,7 +381,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_1a9r634hb48j7vpy2akjb1hdv2",
@@ -354,7 +390,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_0ww542s4tk9esaet5sm3h3hbkw",
@@ -365,7 +402,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_297s8mqz0z9rj9b4bt9w28p0kr",
@@ -373,7 +411,8 @@
       "type": "regular",
       "tags": [
         "tactive"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_1x68c8jeqa9ppvc5nt4xchv33t",
@@ -383,7 +422,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2vkzmy7w6z9dqr8h20myh8ss0y",
@@ -394,7 +434,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2xrv888cad80jttpzf2jb3h66d",
@@ -403,7 +444,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_1q5qpnhaqc8t39rc3hatbpq1a9",
@@ -415,7 +457,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_1jvjvyjv2r9qg8x684xykpa1c2",
@@ -425,13 +468,15 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_64xw5qnpd990gbx46ynfbasz91",
       "email_address": "quinn.17@fixture.test",
       "type": "regular",
-      "tags": []
+      "tags": [],
+      "metadata": {}
     },
     {
       "id": "sub_1s40rgp3p59ebvha150wsrksd2",
@@ -441,7 +486,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_3nr0ssk2rp8x6tznv5vgbbrxzx",
@@ -450,7 +496,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_0e7xt0wcbb9499mr4xzgss1k1z",
@@ -460,7 +507,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_619tbm3xgr88yt5c5bf3jtnj42",
@@ -471,7 +519,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_2bf7esrez98yqskzragv3xcnv1",
@@ -481,7 +530,8 @@
         "tarts-in-is",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_3yxac23tyr8wmr8mkgxvs2hv3x",
@@ -489,7 +539,8 @@
       "type": "regular",
       "tags": [
         "tactive"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_4pkapqcwaj8bbstq10evb7d78k",
@@ -497,7 +548,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_6e0ymqvhme8natbgntbergg6mt",
@@ -507,7 +559,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_34t0e9feej9aatyeq7zkjk9p1e",
@@ -518,7 +571,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_5y5vwt0bp09xp857y43dvrd91j",
@@ -527,7 +581,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_4yvr49xjv892fb33jmwkhqzm0b",
@@ -539,7 +594,8 @@
         "tisweb-member",
         "tpod-program",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_6x7x44k4xy8kptzmzwv9261p41",
@@ -549,13 +605,15 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_350agfqh1j9gg9k9wk5myw2vnx",
       "email_address": "dave.04@fixture.test",
       "type": "unsubscribed",
-      "tags": []
+      "tags": [],
+      "metadata": {}
     },
     {
       "id": "sub_3tzvveppjh994t7yp4mn8a7mwq",
@@ -563,7 +621,8 @@
       "type": "regular",
       "tags": [
         "tisweb-member"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_0vnn0jm7y99z8rge7fsbc3f5px",
@@ -572,7 +631,8 @@
       "tags": [
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     },
     {
       "id": "sub_1psvey6mfj8dza83gkp8hjbktk",
@@ -582,7 +642,8 @@
         "tcommunity-calls",
         "tisweb-member",
         "tweekly-web-updates"
-      ]
+      ],
+      "metadata": {}
     }
   ]
 }

--- a/tests/functional/server/__data__/buttondown/golds/18-delete-probe-created.json
+++ b/tests/functional/server/__data__/buttondown/golds/18-delete-probe-created.json
@@ -4,7 +4,7 @@
     {
       "request": {
         "method": "DELETE",
-        "url": "https://api.buttondown.com/v1/subscribers/sub_164q773sbj9agams4jfe6r9m9v"
+        "url": "https://api.buttondown.com/v1/subscribers/sub_4yzgme02bk9dq8v70ms78yzpfv"
       },
       "response": {
         "status": 204,

--- a/tests/functional/server/__data__/buttondown/golds/20-patch-metadata-partial.json
+++ b/tests/functional/server/__data__/buttondown/golds/20-patch-metadata-partial.json
@@ -1,0 +1,69 @@
+{
+  "probe": "20-patch-metadata-partial",
+  "http_calls": [
+    {
+      "request": {
+        "method": "POST",
+        "url": "https://api.buttondown.com/v1/subscribers",
+        "body": {
+          "email_address": "probe-metadata@fixture.test",
+          "tags": [
+            "probe-metadata"
+          ],
+          "type": "regular",
+          "metadata": {
+            "name": "Probe Original",
+            "external_id": "ext-444"
+          }
+        }
+      },
+      "response": {
+        "status": 201
+      }
+    },
+    {
+      "request": {
+        "method": "PATCH",
+        "url": "https://api.buttondown.com/v1/subscribers/sub_4tq1rzjzyf9qk9n3d9k089czcs",
+        "body": {
+          "metadata": {
+            "name": "Probe Renamed"
+          }
+        }
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "https://api.buttondown.com/v1/subscribers/sub_4tq1rzjzyf9qk9n3d9k089czcs"
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    {
+      "request": {
+        "method": "DELETE",
+        "url": "https://api.buttondown.com/v1/subscribers/sub_4tq1rzjzyf9qk9n3d9k089czcs"
+      },
+      "response": {
+        "status": 204,
+        "body": null
+      }
+    }
+  ],
+  "typed_result": {
+    "id": "sub_4tq1rzjzyf9qk9n3d9k089czcs",
+    "email_address": "probe-metadata@fixture.test",
+    "type": "regular",
+    "tags": [
+      "probe-metadata"
+    ],
+    "metadata": {
+      "name": "Probe Renamed"
+    }
+  }
+}

--- a/tests/functional/server/__data__/buttondown/golds/meta.json
+++ b/tests/functional/server/__data__/buttondown/golds/meta.json
@@ -1,6 +1,6 @@
 {
   "api_version": "2026-04-01",
   "key_fingerprint": "b84...965",
-  "recorded_at": "2026-05-24T17:20:21.749Z",
+  "recorded_at": "2026-06-21T02:53:39.076Z",
   "recorded_by": "james-baker@users.noreply.github.com"
 }

--- a/tests/functional/server/api-me.test.ts
+++ b/tests/functional/server/api-me.test.ts
@@ -23,18 +23,31 @@ vi.mock("@sentry/nextjs", () => ({
   captureMessage: vi.fn(),
 }));
 
+// Stub the Buttondown runner so the inline hooks PUT /me fires are
+// observable without a live key (the real fns soft-skip when
+// BUTTONDOWN_API_KEY is unset, so these no-op spies are behaviorally
+// equivalent for every other test in the file).
+vi.mock("@/server/buttondown-runner", () => ({
+  runButtondownSyncForServer: vi.fn().mockResolvedValue({ status: "skipped", reason: "api_key_missing" }),
+  runFirstProfileSaveForServer: vi.fn().mockResolvedValue(undefined),
+  runProfileResyncForServer: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { captureException as Sentry_captureException } from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 
 import { toSlug } from "@/lib/slug";
 import { supabaseAdmin } from "@/lib/supabase/admin";
 import app from "@/server/api";
+import { runFirstProfileSaveForServer, runProfileResyncForServer } from "@/server/buttondown-runner";
 import { db } from "@/server/db";
 import { profiles } from "@/server/schema";
 
 const mockCreateServerClient = vi.mocked(createServerClient);
 const mockUpdateUserById = vi.mocked(supabaseAdmin.auth.admin.updateUserById);
 const mockCaptureException = vi.mocked(Sentry_captureException);
+const mockResync = vi.mocked(runProfileResyncForServer);
+const mockFirstSave = vi.mocked(runFirstProfileSaveForServer);
 
 // Unique per run: upsertProfile derives the profile slug via toSlug,
 // which hits a global unique constraint, and parallel test files share
@@ -61,6 +74,8 @@ describe("GET /api/me", () => {
     testUserId = randomUUID();
     mockUpdateUserById.mockClear();
     mockCaptureException.mockClear();
+    mockResync.mockClear();
+    mockFirstSave.mockClear();
     await db.execute(
       sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${testUserId}::uuid, 'me-test@testfake.local', false, false)`,
     );
@@ -345,6 +360,49 @@ describe("GET /api/me", () => {
     expect(res.status).toBe(200);
     expect((await res.json()).profile.displayName).toBe("Resilient Name");
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("PUT /me pushes a Buttondown name resync on a subsequent name edit", async () => {
+    // A profile that has already been saved once → not a first save.
+    // An explicit slug keeps the rename from triggering slug-backfill
+    // (and its unique-constraint collision with parallel test files).
+    await db.insert(profiles).values({
+      id: testUserId,
+      displayName: "Old Name",
+      slug: `sub-edit-${testUserId.slice(0, 8)}`,
+      lastUpdatedProfile: new Date(),
+    });
+
+    const res = await putMe({ displayName: "Renamed Member" });
+    expect(res.status).toBe(200);
+
+    expect(mockResync).toHaveBeenCalledTimes(1);
+    expect(mockResync).toHaveBeenCalledWith(expect.objectContaining({ profileId: testUserId, reason: "update-name" }));
+    // First-save hook is the other branch — it must not also fire.
+    expect(mockFirstSave).not.toHaveBeenCalled();
+  });
+
+  it("PUT /me does not push a name resync on the first save (the first-save hook owns it)", async () => {
+    // No prior save: lastUpdatedProfile is null, so this is a first save.
+    const res = await putMe({ displayName: "First Name" });
+    expect(res.status).toBe(200);
+
+    expect(mockResync).not.toHaveBeenCalled();
+    expect(mockFirstSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("PUT /me does not push a name resync when displayName is absent", async () => {
+    await db.insert(profiles).values({
+      id: testUserId,
+      displayName: "Steady Name",
+      slug: `steady-${testUserId.slice(0, 8)}`,
+      lastUpdatedProfile: new Date(),
+    });
+
+    const res = await putMe({ bio: "Edited my bio, not my name." });
+    expect(res.status).toBe(200);
+
+    expect(mockResync).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/functional/server/buttondown-fake.ts
+++ b/tests/functional/server/buttondown-fake.ts
@@ -65,7 +65,11 @@ const sortTags = (tags: string[]): string[] => [...tags].sort();
 export const createFakeButtondownClient = (config: FakeButtondownConfig = { write: true }): FakeButtondownClient => {
   const subscribers = new Map<string, ButtondownSubscriber>();
   for (const s of config.initialSubscribers ?? []) {
-    subscribers.set(s.id, { ...s, tags: sortTags(s.tags) });
+    // Real Buttondown always returns `metadata` as an object — a
+    // metadata-less subscriber comes back as `{}`, not absent (confirmed
+    // by the re-recorded golds, Appendix A). Normalize seeds to match so
+    // the fake's reads deep-equal the real ones.
+    subscribers.set(s.id, { ...s, tags: sortTags(s.tags), metadata: { ...(s.metadata ?? {}) } });
   }
   const account: ButtondownAccount = { ...(config.account ?? DEFAULT_FAKE_ACCOUNT) };
   const effects: FakeButtondownEffect[] = [];
@@ -85,7 +89,11 @@ export const createFakeButtondownClient = (config: FakeButtondownConfig = { writ
     async listSubscribers() {
       // Snapshot — callers shouldn't see in-flight mutations during a
       // single iteration, so we return a copy of the values.
-      return Array.from(subscribers.values()).map((s) => ({ ...s, tags: [...s.tags] }));
+      return Array.from(subscribers.values()).map((s) => ({
+        ...s,
+        tags: [...s.tags],
+        metadata: { ...(s.metadata ?? {}) },
+      }));
     },
 
     async getAccount() {
@@ -104,9 +112,9 @@ export const createFakeButtondownClient = (config: FakeButtondownConfig = { writ
         return { dryRun: true, intent: "create", payload: input };
       }
       if (findByEmail(input.email_address)) {
-        // Real Buttondown returns 400 (not 409) for duplicate
-        // creates — see probe 10's gold. Match the status; the
-        // message text is whatever, since replay compares {name,
+        // Real Buttondown returns 400 email_already_exists for a
+        // duplicate create — see probe 10's gold. Match the status;
+        // the message text is whatever, since replay compares {name,
         // status} only.
         throw new ButtondownApiError(400, "fake: duplicate email");
       }
@@ -115,9 +123,12 @@ export const createFakeButtondownClient = (config: FakeButtondownConfig = { writ
         email_address: input.email_address,
         type: "regular",
         tags: sortTags(input.tags),
+        // Absent input metadata materializes as `{}`, mirroring real
+        // Buttondown's create response (Appendix A golds).
+        metadata: { ...(input.metadata ?? {}) },
       };
       subscribers.set(sub.id, sub);
-      return sub;
+      return { ...sub, metadata: { ...sub.metadata } };
     },
 
     async updateSubscriber(
@@ -143,9 +154,15 @@ export const createFakeButtondownClient = (config: FakeButtondownConfig = { writ
         ...(patch.email_address !== undefined ? { email_address: patch.email_address } : {}),
         ...(patch.tags !== undefined ? { tags: sortTags(patch.tags) } : {}),
         ...(patch.type !== undefined ? { type: patch.type } : {}),
+        // Whole-blob replace: a PATCH carrying `metadata` sets the
+        // entire object, dropping any key not in the new blob — probe 20
+        // confirms Buttondown replaces rather than server-side merges.
+        // The sync only ever sends a full merged blob (`{ ...existing,
+        // name }`), so other keys survive every production write.
+        ...(patch.metadata !== undefined ? { metadata: { ...patch.metadata } } : {}),
       };
       subscribers.set(id, updated);
-      return updated;
+      return { ...updated, metadata: { ...(updated.metadata ?? {}) } };
     },
 
     async deleteSubscriber(id: string): Promise<undefined | DryRunOutcome<"delete">> {

--- a/tests/functional/server/buttondown-first-save.test.ts
+++ b/tests/functional/server/buttondown-first-save.test.ts
@@ -11,7 +11,13 @@ import { createFakeButtondownClient } from "./buttondown-fake";
 
 const insertUserAndProfile = async (
   id: string,
-  opts: { email?: string; buttondownSubscriberId?: string | null; saved?: boolean; hidden?: boolean } = {},
+  opts: {
+    email?: string;
+    buttondownSubscriberId?: string | null;
+    saved?: boolean;
+    hidden?: boolean;
+    displayName?: string | null;
+  } = {},
 ) => {
   const email = opts.email ?? `${id}@testfake.local`;
   await db.execute(
@@ -19,6 +25,7 @@ const insertUserAndProfile = async (
   );
   await db.insert(profiles).values({
     id,
+    displayName: opts.displayName ?? null,
     lastUpdatedProfile: opts.saved === false ? null : new Date(),
     buttondownSubscriberId: opts.buttondownSubscriberId ?? null,
     hidden: opts.hidden ?? false,
@@ -90,6 +97,57 @@ describe("runFirstProfileSaveSync (inline hook)", () => {
       .from(profiles)
       .where(eq(profiles.id, profileId));
     expect(row.buttondownSubscriberId).not.toBeNull();
+  });
+
+  it("seeds metadata.name on create from the profile's display name", async () => {
+    const profileId = await makeProfile({ email: "fs-name@example.com", displayName: "Ada Lovelace" });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await db.insert(profilePrograms).values({ profileId, programId });
+
+    const client = createFakeButtondownClient({ write: true });
+    await runFirstProfileSaveSync({ profileId, email: "fs-name@example.com", client });
+
+    expect(client.effects[0]).toMatchObject({
+      kind: "create",
+      input: { email_address: "fs-name@example.com", metadata: { name: "Ada Lovelace" } },
+    });
+    const after = await client.getSubscriber("fs-name@example.com");
+    expect(after?.metadata).toEqual({ name: "Ada Lovelace" });
+  });
+
+  it("merges name into the full-overwrite PATCH, preserving other metadata", async () => {
+    const profileId = await makeProfile({ email: "fs-merge@example.com", displayName: "Grace Hopper" });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await db.insert(profilePrograms).values({ profileId, programId });
+
+    const initial: ButtondownSubscriber = {
+      id: "sub_merge",
+      email_address: "fs-merge@example.com",
+      type: "regular",
+      tags: ["legacy-active"],
+      metadata: { external_id: "crm-42" },
+    };
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+    await runFirstProfileSaveSync({ profileId, email: "fs-merge@example.com", client });
+
+    const after = await client.getSubscriber("sub_merge");
+    expect(after?.tags).toEqual(["isweb-member", "returning", "weekly"]);
+    // external_id survives the overwrite; name is added alongside it.
+    expect(after?.metadata).toEqual({ external_id: "crm-42", name: "Grace Hopper" });
+  });
+
+  it("writes no metadata.name when the display name is blank", async () => {
+    const profileId = await makeProfile({ email: "fs-blank@example.com", displayName: "   " });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await db.insert(profilePrograms).values({ profileId, programId });
+
+    const client = createFakeButtondownClient({ write: true });
+    await runFirstProfileSaveSync({ profileId, email: "fs-blank@example.com", client });
+
+    const created = client.effects[0];
+    expect(created.kind).toBe("create");
+    // Never seed an empty/whitespace name onto a fresh subscriber.
+    if (created.kind === "create") expect(created.input.metadata).toBeUndefined();
   });
 
   it("does a full-overwrite PATCH with isweb-member + returning when subscriber exists and lacks isweb-member", async () => {

--- a/tests/functional/server/buttondown-sync.test.ts
+++ b/tests/functional/server/buttondown-sync.test.ts
@@ -24,7 +24,7 @@ import { createFakeButtondownClient, type FakeButtondownEffect } from "./buttond
 const insertUserAndProfile = async (
   id: string,
   opts: {
-    displayName?: string;
+    displayName?: string | null;
     saved?: boolean;
     buttondownSubscriberId?: string | null;
     email?: string;
@@ -423,6 +423,152 @@ describe("runButtondownSync (daily reconciler)", () => {
     expect(updated?.tags.sort()).toEqual(["isweb-member", "weekly"]);
     expect(summary.tagsUpdated).toBe(1);
     expect(summary.skippedHiddenCreate).toBe(0);
+  });
+
+  it("backfills a missing metadata.name without rewriting tags", async () => {
+    const profileId = await makeProfile({
+      email: "name-a@example.com",
+      displayName: "Alan Turing",
+      buttondownSubscriberId: "sub_name_a",
+    });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    // Tags already current → the only diff is the absent metadata.name.
+    const initial = sampleSubscriber({
+      id: "sub_name_a",
+      email_address: "name-a@example.com",
+      tags: ["weekly", "isweb-member"],
+    });
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+    const { log, events } = collectingLogger();
+
+    const summary = await runButtondownSync({ client, runId: "rn1", write: true, log, scopeProfileIds: [profileId] });
+
+    const myEffects = effectsForSubscriberId(client.effects, "sub_name_a");
+    expect(myEffects).toHaveLength(1);
+    const eff = myEffects[0];
+    expect(eff.kind).toBe("update");
+    if (eff.kind === "update") {
+      expect(eff.patch.metadata).toEqual({ name: "Alan Turing" });
+      // Metadata-only PATCH: tags weren't part of the diff.
+      expect(eff.patch.tags).toBeUndefined();
+    }
+    expect(summary.nameUpdated).toBe(1);
+    expect(summary.tagsUpdated).toBe(0);
+    expect(events.find((e) => e.action === "name-updated" && e.profileId === profileId)).toMatchObject({
+      from: null,
+      to: "Alan Turing",
+    });
+    expect((await client.getSubscriber("sub_name_a"))?.metadata).toEqual({ name: "Alan Turing" });
+  });
+
+  it("repairs a drifted metadata.name and preserves a second metadata key", async () => {
+    const profileId = await makeProfile({
+      email: "name-b@example.com",
+      displayName: "Katherine Johnson",
+      buttondownSubscriberId: "sub_name_b",
+    });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    const initial = sampleSubscriber({
+      id: "sub_name_b",
+      email_address: "name-b@example.com",
+      tags: ["weekly", "isweb-member"],
+      metadata: { name: "Old Name", external_id: "crm-7" },
+    });
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    const summary = await runButtondownSync({ client, runId: "rn2", write: true, scopeProfileIds: [profileId] });
+
+    expect(summary.nameUpdated).toBe(1);
+    // name repaired; external_id untouched (merge-preserving write).
+    expect((await client.getSubscriber("sub_name_b"))?.metadata).toEqual({
+      name: "Katherine Johnson",
+      external_id: "crm-7",
+    });
+  });
+
+  it("never blanks an existing metadata.name when the display name is empty", async () => {
+    const profileId = await makeProfile({
+      email: "name-c@example.com",
+      displayName: null,
+      buttondownSubscriberId: "sub_name_c",
+    });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    const initial = sampleSubscriber({
+      id: "sub_name_c",
+      email_address: "name-c@example.com",
+      tags: ["weekly", "isweb-member"],
+      metadata: { name: "Keep Me" },
+    });
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    const summary = await runButtondownSync({ client, runId: "rn3", write: true, scopeProfileIds: [profileId] });
+
+    expect(effectsForSubscriberId(client.effects, "sub_name_c")).toHaveLength(0);
+    expect(summary.nameUpdated).toBe(0);
+    expect(summary.unchanged).toBe(1);
+    expect((await client.getSubscriber("sub_name_c"))?.metadata).toEqual({ name: "Keep Me" });
+  });
+
+  it("leaves metadata.name alone when it already matches the display name", async () => {
+    const profileId = await makeProfile({
+      email: "name-d@example.com",
+      displayName: "Exact Match",
+      buttondownSubscriberId: "sub_name_d",
+    });
+    const programId = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, programId);
+
+    const initial = sampleSubscriber({
+      id: "sub_name_d",
+      email_address: "name-d@example.com",
+      tags: ["weekly", "isweb-member"],
+      metadata: { name: "Exact Match" },
+    });
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    const summary = await runButtondownSync({ client, runId: "rn4", write: true, scopeProfileIds: [profileId] });
+
+    expect(effectsForSubscriberId(client.effects, "sub_name_d")).toHaveLength(0);
+    expect(summary.nameUpdated).toBe(0);
+  });
+
+  it("folds a name repair and a tag change into a single PATCH", async () => {
+    const profileId = await makeProfile({
+      email: "name-e@example.com",
+      displayName: "Combined Edit",
+      buttondownSubscriberId: "sub_name_e",
+    });
+    const weekly = await makeProgram({ buttondownTag: "weekly" });
+    await join(profileId, weekly);
+    // "monthly" is in the managed universe but not desired → a tag drop.
+    await makeProgram({ buttondownTag: "monthly" });
+
+    const initial = sampleSubscriber({
+      id: "sub_name_e",
+      email_address: "name-e@example.com",
+      tags: ["monthly", "isweb-member"],
+      metadata: { name: "Stale Name" },
+    });
+    const client = createFakeButtondownClient({ write: true, initialSubscribers: [initial] });
+
+    const summary = await runButtondownSync({ client, runId: "rn5", write: true, scopeProfileIds: [profileId] });
+
+    const myEffects = effectsForSubscriberId(client.effects, "sub_name_e");
+    expect(myEffects).toHaveLength(1); // one PATCH carrying both changes
+    const eff = myEffects[0];
+    if (eff.kind === "update") {
+      expect(eff.patch.metadata).toEqual({ name: "Combined Edit" });
+      expect(eff.patch.tags?.sort()).toEqual(["isweb-member", "weekly"]);
+    }
+    expect(summary.tagsUpdated).toBe(1);
+    expect(summary.nameUpdated).toBe(1);
+    expect((await client.getSubscriber("sub_name_e"))?.metadata).toEqual({ name: "Combined Edit" });
   });
 });
 

--- a/tests/functional/server/buttondown.test.ts
+++ b/tests/functional/server/buttondown.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type ButtondownAccount,
   ButtondownApiError,
-  ButtondownConflictError,
   type ButtondownSubscriber,
   createButtondownClient,
   isDryRunOutcome,
@@ -143,7 +142,7 @@ describe("createButtondownClient", () => {
       expect(url).toBe("https://api.buttondown.com/v1/subscribers/a%2Bb%40example.com");
     });
 
-    it("projects the response to the declared four fields, dropping anything else", async () => {
+    it("projects the response to the declared fields, dropping anything else", async () => {
       const withExtras = {
         ...sampleSubscriber,
         creation_date: "2024-01-01T00:00:00Z",
@@ -155,7 +154,17 @@ describe("createButtondownClient", () => {
       const client = createButtondownClient({ apiKey: "k", write: true, fetcher });
 
       const got = await client.getSubscriber("alice@example.com");
-      expect(got).toEqual(sampleSubscriber);
+      // metadata is a declared field and rides through; creation_date,
+      // secondary_id, and notes are still dropped.
+      expect(got).toEqual({ ...sampleSubscriber, metadata: { foo: "bar" } });
+      expect(Object.keys(got ?? {}).sort()).toEqual(["email_address", "id", "metadata", "tags", "type"]);
+    });
+
+    it("omits the metadata field when the response carries none", async () => {
+      const fetcher = mockFetch(200, sampleSubscriber);
+      const client = createButtondownClient({ apiKey: "k", write: true, fetcher });
+
+      const got = await client.getSubscriber("alice@example.com");
       expect(Object.keys(got ?? {}).sort()).toEqual(["email_address", "id", "tags", "type"]);
     });
 
@@ -203,13 +212,20 @@ describe("createButtondownClient", () => {
       expect(fetcher).not.toHaveBeenCalled();
     });
 
-    it("throws ButtondownConflictError on 409 (duplicate email)", async () => {
-      const fetcher = mockFetch(409, { detail: "Subscriber already exists." });
+    it("surfaces a duplicate email as a 400 ButtondownApiError (Buttondown's email_already_exists)", async () => {
+      // Buttondown rejects a duplicate create with 400 email_already_exists,
+      // not 409 — see Appendix A probe 10's gold. The sync's get-before-create
+      // makes this a rare race; when it happens it throws like any other
+      // non-2xx and the next cron's lookup finds the existing subscriber.
+      const fetcher = mockFetch(400, { code: "email_already_exists" });
       const client = createButtondownClient({ apiKey: "k", write: true, fetcher });
 
-      await expect(client.createSubscriber({ email_address: "alice@example.com", tags: [] })).rejects.toBeInstanceOf(
-        ButtondownConflictError,
-      );
+      const err = await client
+        .createSubscriber({ email_address: "alice@example.com", tags: [] })
+        .then(() => null)
+        .catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(ButtondownApiError);
+      expect((err as ButtondownApiError).status).toBe(400);
     });
 
     it("passes `type` through in the POST body when provided", async () => {
@@ -393,6 +409,33 @@ describe("createButtondownClient", () => {
       await client.getSubscriber("sub_abc123");
       expect(fetcher).toHaveBeenCalledTimes(1);
     });
+
+    // The manual record/seed scripts opt out of the guard so they can
+    // operate on the api-tests newsletter's @fixture.test audience.
+    // Without this, both scripts break (and seed-fixtures empties the
+    // newsletter, then can't recreate anyone). See docs Appendix A.
+    describe("allowReservedTestEmails opt-out", () => {
+      it("getSubscriber reaches the wire for a .test email when opted out", async () => {
+        const fetcher = mockFetch(200, sampleSubscriber);
+        const client = createButtondownClient({ apiKey: "k", write: true, fetcher, allowReservedTestEmails: true });
+        await client.getSubscriber("alice.01@fixture.test");
+        expect(fetcher).toHaveBeenCalledTimes(1);
+      });
+
+      it("createSubscriber reaches the wire for a .test email when opted out", async () => {
+        const fetcher = mockFetch(201, sampleSubscriber);
+        const client = createButtondownClient({ apiKey: "k", write: true, fetcher, allowReservedTestEmails: true });
+        await client.createSubscriber({ email_address: "probe-created@fixture.test", tags: ["probe-fresh"] });
+        expect(fetcher).toHaveBeenCalledTimes(1);
+      });
+
+      it("updateSubscriber reaches the wire for a .test email patch when opted out", async () => {
+        const fetcher = mockFetch(200, sampleSubscriber);
+        const client = createButtondownClient({ apiKey: "k", write: true, fetcher, allowReservedTestEmails: true });
+        await client.updateSubscriber("sub_abc123", { email_address: "probe-renamed@fixture.test" });
+        expect(fetcher).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });
 
@@ -442,6 +485,9 @@ describe("createFakeButtondownClient", () => {
       email_address: "preexisting@example.com",
       type: "regular",
       tags: ["old-tag"],
+      // Real Buttondown (and the fake) always return a metadata object;
+      // an unset blob is `{}`, not absent. See Appendix A golds.
+      metadata: {},
     };
   });
 

--- a/tests/manual/_buttondown-probes.ts
+++ b/tests/manual/_buttondown-probes.ts
@@ -64,6 +64,7 @@ export const SEED_EMAILS = {
 export const PROBE_CREATED_EMAIL = "probe-created@fixture.test";
 export const PROBE_CREATED_EMAIL_RENAMED = "probe-created-renamed@fixture.test";
 export const PROBE_CREATED_EMAIL_FINAL = "probe-created-final@fixture.test";
+export const PROBE_METADATA_EMAIL = "probe-metadata@fixture.test";
 export const PROBE_MISSING_ID = "missing-subscriber-for-probe-04";
 export const PROBE_MISSING_EMAIL = "nobody-here@fixture.test";
 
@@ -205,6 +206,32 @@ export const buildProbes = (): Probe[] => [
   {
     name: "19-delete-missing",
     run: async (client) => client.deleteSubscriber(PROBE_MISSING_ID),
+  },
+  {
+    // The definitive merge-vs-replace answer for #444. Create a
+    // subscriber holding a SECOND metadata key, then PATCH metadata
+    // with ONLY `name`. The recorded GET shows whether `external_id`
+    // survives — i.e. whether Buttondown merges server-side or
+    // replaces the whole blob. We record reality rather than assert it:
+    // the sync always sends a full merged blob (`{ ...existing, name }`),
+    // so other keys survive under either semantics; this probe just
+    // pins Buttondown's native behavior so the fake reproduces it.
+    // Self-contained (creates and deletes its own subscriber) so the
+    // sequence stays idempotent like probe 18.
+    name: "20-patch-metadata-partial",
+    run: async (client) => {
+      const created = await client.createSubscriber({
+        email_address: PROBE_METADATA_EMAIL,
+        tags: ["probe-metadata"],
+        type: "regular",
+        metadata: { name: "Probe Original", external_id: "ext-444" },
+      });
+      if ("dryRun" in created) throw new Error("probe 20: unexpected dry-run");
+      await client.updateSubscriber(created.id, { metadata: { name: "Probe Renamed" } });
+      const after = await client.getSubscriber(created.id);
+      await client.deleteSubscriber(created.id);
+      return after;
+    },
   },
 ];
 

--- a/tests/manual/buttondown-api-golds.test.ts
+++ b/tests/manual/buttondown-api-golds.test.ts
@@ -116,7 +116,16 @@ describe.skipIf(!process.env.BUTTONDOWN_TEST_API_KEY)("buttondown api golds (rec
 
   beforeAll(async () => {
     const recorder = createRecordingFetcher();
-    const client = createButtondownClient({ apiKey, write: true, fetcher: recorder.fetch });
+    // The probe fixtures are @fixture.test addresses (RFC-reserved), the
+    // intended audience of the api-tests newsletter — so opt out of the
+    // client's reserved-TLD refusal here. Safety is the per-newsletter
+    // key scope + assertTestNewsletter below, not that guard.
+    const client = createButtondownClient({
+      apiKey,
+      write: true,
+      fetcher: recorder.fetch,
+      allowReservedTestEmails: true,
+    });
 
     // Refuse to record if the key points at anything other than the
     // api-tests newsletter. The recorder also writes (creates and


### PR DESCRIPTION
Summary: Mirror each member's display name into their Buttondown subscriber's `metadata.name`, kept true going forward.

Why: Earlier iterations (manual, then the Apps Script) populated `metadata.name`; when the app took over as the writer (#280) that detail was dropped. This restores it, extending the integration's invariant to the display name, not just tags.

Behavior: `metadata.name` (verbatim `profiles.displayName`) is seeded on both create paths, reconciled by the daily cron via a merge-preserving `{ ...existing, name }` PATCH (new `name-updated` action), and pushed inline on a non-first-save `PUT /me` name edit (resync reason `update-name`). An empty/whitespace name never blanks an existing value. The re-recorded golds + new probe 20 pin that Buttondown returns `metadata` as `{}` when unset and replaces the whole blob on PATCH. Two adjacent items rode along: the manual record/seed scripts gain an `allowReservedTestEmails` client opt-out (the reserved-TLD guard had silently broken them against the `@fixture.test` audience), and the dead `409 ButtondownConflictError` branch is removed (duplicates really return `400 email_already_exists`).

Test Plan:
- ran `npm test` locally — functional 565 + 37 e2e green
- re-recorded the Buttondown API golds against the api-tests newsletter; `npm run test:manual:buttondown-api-replay` green

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)
