### PR TITLE
feat(programs): copy participant emails on the admin page

### DIFF
--- a/src/app/admin/programs/[id]/program-detail.tsx
+++ b/src/app/admin/programs/[id]/program-detail.tsx
@@ -14,6 +14,8 @@ import { apiClient } from "@/lib/api";
 import type { AdminProgramDetail } from "@/lib/api-types";
 import { formatDate } from "@/lib/format-date";
 
+import { ProgramEmailsPanel } from "./program-emails-panel";
+
 const programQueryKey = (id: string) => ["admin", "programs", id] as const;
 
 const fetchProgram = async (id: string): Promise<AdminProgramDetail> => {
@@ -362,6 +364,12 @@ function ProgramEditor({ program }: { program: AdminProgramDetail }) {
               </li>
             ))}
           </ul>
+        )}
+        {hasParticipants && (
+          <div className="flex flex-col gap-2 border-t border-border pt-3">
+            <h3 className="text-sm font-medium">Email addresses</h3>
+            <ProgramEmailsPanel programId={program.id} />
+          </div>
         )}
       </section>
 

--- a/src/app/admin/programs/[id]/program-emails-panel.tsx
+++ b/src/app/admin/programs/[id]/program-emails-panel.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api";
+
+// Nested under the program-detail key on purpose: invalidating
+// ["admin", "programs", id] after an add/remove also refreshes this list
+// (TanStack invalidation is prefix-matched), so the box stays in sync.
+const queryKey = (programId: string) => ["admin", "programs", programId, "participant-emails"] as const;
+const STALE_TIME = 5 * 60 * 1000;
+
+const fetchEmails = async (programId: string): Promise<string[]> => {
+  const res = await apiClient.api.admin.programs[":id"]["participant-emails"].$get({ param: { id: programId } });
+  if (!res.ok) throw new Error(`admin/programs/${programId}/participant-emails: ${res.status}`);
+  const body = await res.json();
+  return body.emails;
+};
+
+export function ProgramEmailsPanel({ programId }: { programId: string }) {
+  const emailsQuery = useQuery({
+    queryKey: queryKey(programId),
+    queryFn: () => fetchEmails(programId),
+    staleTime: STALE_TIME,
+  });
+  const [copied, setCopied] = useState(false);
+
+  if (emailsQuery.isPending) {
+    return <p className="text-sm text-muted-foreground">Loading…</p>;
+  }
+  if (emailsQuery.isError) {
+    return (
+      <p role="alert" className="text-sm text-destructive">
+        Couldn't load email addresses.
+      </p>
+    );
+  }
+
+  if (emailsQuery.data.length === 0) {
+    // Participants can exist while this is empty — hidden, deactivated,
+    // and e2e accounts are filtered out server-side.
+    return (
+      <p className="text-sm text-muted-foreground">
+        No mailable participants — hidden, deactivated, and e2e test accounts are excluded.
+      </p>
+    );
+  }
+
+  // Comma+space separation so the whole box pastes cleanly into Google
+  // Calendar's guest field.
+  const list = emailsQuery.data.join(", ");
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(list);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API is available in all supported browsers. If a user
+      // manages to hit this, the addresses are still in the box — they
+      // can select and copy by hand.
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <p className="text-sm text-muted-foreground">
+        {emailsQuery.data.length} mailable participant{emailsQuery.data.length === 1 ? "" : "s"} — hidden, deactivated,
+        and e2e test accounts are excluded.
+      </p>
+      <textarea
+        readOnly
+        value={list}
+        rows={5}
+        aria-label="Participant email addresses"
+        onFocus={(e) => e.currentTarget.select()}
+        className="w-full rounded border border-border bg-muted/50 p-3 text-xs"
+      />
+      <Button size="sm" className="self-start" onClick={copy}>
+        {copied ? "Copied" : "Copy all"}
+      </Button>
+    </div>
+  );
+}

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -60,6 +60,7 @@ import {
   joinProgram,
   leaveProgram,
   listAllProgramsForAdmin,
+  listProgramParticipantEmails,
   listPrograms,
   parseProgramCreate,
   parseProgramUpdate,
@@ -179,6 +180,10 @@ const adminRoutes = new Hono<{ Variables: ApiVariables }>()
       write: process.env.BUTTONDOWN_SYNC_WRITE === "1",
     });
     return c.json({ ok: true });
+  })
+  .get("/programs/:id/participant-emails", async (c) => {
+    const emails = await listProgramParticipantEmails(c.req.param("id"));
+    return c.json({ emails });
   })
   .get("/profiles/hidden", async (c) => {
     const members = await listHiddenMembers();

--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -5,6 +5,7 @@ import { isUuid } from "./auth-middleware";
 import { attachAvatarUrls } from "./avatars";
 import { db } from "./db";
 import { profilePrograms, profiles, programs } from "./schema";
+import { E2E_EMAILS } from "./test-reset";
 
 // Slugs of programs every new member is enrolled in automatically on
 // first sign-in. The welcome flow's "We added one for you" copy on
@@ -645,6 +646,33 @@ export const getProgramDetail = async (
       participants,
     },
   };
+};
+
+// Recipient list for one program's admin drill-down: every current
+// participant who should receive mail — same exclusions as
+// listActiveMemberEmails (hidden profiles, deactivated profiles, and the
+// seeded e2e accounts), scoped to this program's active memberships
+// (left_at IS NULL). Email lives on auth.users, which schema.ts maps only
+// partially, so the query is raw SQL — same approach as members-admin.ts.
+export const listProgramParticipantEmails = async (programId: string): Promise<string[]> => {
+  if (!isUuid(programId)) return [];
+  const e2eList = sql.join(
+    E2E_EMAILS.map((e) => sql`${e}`),
+    sql`, `,
+  );
+  const rows = (await db.execute(sql`
+    SELECT u.email
+    FROM auth.users u
+    JOIN public.profiles p ON p.id = u.id
+    JOIN public.profile_programs pp ON pp.profile_id = p.id
+    WHERE pp.program_id = ${programId}::uuid
+      AND pp.left_at IS NULL
+      AND p.hidden = false
+      AND p.deactivated_at IS NULL
+      AND u.email NOT IN (${e2eList})
+    ORDER BY lower(u.email), u.email
+  `)) as unknown as { email: string }[];
+  return rows.map((r) => r.email);
 };
 
 export const addParticipant = async (

--- a/tests/functional/server/admin-program-participant-emails.test.ts
+++ b/tests/functional/server/admin-program-participant-emails.test.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+import type { User } from "@supabase/supabase-js";
+import { eq, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+import { createServerClient } from "@supabase/ssr";
+
+import app from "@/server/api";
+import { db } from "@/server/db";
+import { profilePrograms, profiles, programs } from "@/server/schema";
+import { E2E_EMAILS } from "@/server/test-reset";
+
+const mockCreateServerClient = vi.mocked(createServerClient);
+
+const fakeUser = (id: string): User =>
+  ({
+    id,
+    email: `${id}@testfake.local`,
+    user_metadata: {},
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+  }) as User;
+
+const authAs = (userId: string | null) => {
+  mockCreateServerClient.mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? fakeUser(userId) : null },
+        error: null,
+      }),
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test mock shape
+  } as any);
+};
+
+const insertUserAndProfile = async (id: string, opts: { isAdmin?: boolean; email?: string } = {}) => {
+  await db.execute(
+    sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${id}::uuid, ${opts.email ?? `${id}@testfake.local`}, false, false)`,
+  );
+  await db.insert(profiles).values({ id, isAdmin: opts.isAdmin ?? false });
+};
+
+const deleteUserAndProfile = async (id: string) => {
+  await db.delete(profiles).where(eq(profiles.id, id));
+  await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+};
+
+const createProgram = async (): Promise<string> => {
+  const slug = `test-prog-${randomUUID()}`;
+  const [row] = await db.insert(programs).values({ slug, name: slug }).returning({ id: programs.id });
+  return row.id;
+};
+
+const join = async (profileId: string, programId: string, opts: { leftAt?: Date } = {}) => {
+  await db.insert(profilePrograms).values({ profileId, programId, leftAt: opts.leftAt });
+};
+
+describe("GET /api/admin/programs/:id/participant-emails", () => {
+  let admin: string;
+  let active: string;
+  let hiddenMember: string;
+  let deactivated: string;
+  let leftMember: string;
+  let otherProgramMember: string;
+  let programId: string;
+  let otherProgramId: string;
+  // The seeded e2e account may already exist (dev DBs run the e2e seed
+  // script; fresh CI DBs don't), so create it only when absent and clean
+  // up only what this run created.
+  const E2E_EMAIL = E2E_EMAILS[0];
+  let e2eId: string;
+  let e2eUserCreated = false;
+  let e2eProfileCreated = false;
+
+  beforeEach(async () => {
+    admin = randomUUID();
+    active = randomUUID();
+    hiddenMember = randomUUID();
+    deactivated = randomUUID();
+    leftMember = randomUUID();
+    otherProgramMember = randomUUID();
+    await insertUserAndProfile(admin, { isAdmin: true });
+    await insertUserAndProfile(active);
+    await insertUserAndProfile(hiddenMember);
+    await insertUserAndProfile(deactivated);
+    await insertUserAndProfile(leftMember);
+    await insertUserAndProfile(otherProgramMember);
+    await db.update(profiles).set({ hidden: true }).where(eq(profiles.id, hiddenMember));
+    await db.update(profiles).set({ deactivatedAt: new Date() }).where(eq(profiles.id, deactivated));
+
+    const existing = (await db.execute(sql`SELECT id FROM auth.users WHERE email = ${E2E_EMAIL}`)) as unknown as {
+      id: string;
+    }[];
+    if (existing.length > 0) {
+      e2eId = existing[0].id;
+    } else {
+      e2eId = randomUUID();
+      await db.execute(
+        sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${e2eId}::uuid, ${E2E_EMAIL}, false, false)`,
+      );
+      e2eUserCreated = true;
+    }
+    const existingProfile = await db.select({ id: profiles.id }).from(profiles).where(eq(profiles.id, e2eId));
+    if (existingProfile.length === 0) {
+      await db.insert(profiles).values({ id: e2eId });
+      e2eProfileCreated = true;
+    }
+
+    programId = await createProgram();
+    otherProgramId = await createProgram();
+    // Active, non-excluded participant — the only one that should appear.
+    await join(active, programId);
+    // Excluded by profile state.
+    await join(hiddenMember, programId);
+    await join(deactivated, programId);
+    await join(e2eId, programId);
+    // Past member of this program (left_at set) — excluded.
+    await join(leftMember, programId, { leftAt: new Date() });
+    // Active member of a different program — excluded from this one.
+    await join(otherProgramMember, otherProgramId);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    // Deleting programs cascades their profile_programs rows (incl. the
+    // shared e2e account's membership), so memberships need no explicit
+    // cleanup.
+    await db.delete(programs).where(eq(programs.id, programId));
+    await db.delete(programs).where(eq(programs.id, otherProgramId));
+    await deleteUserAndProfile(admin);
+    await deleteUserAndProfile(active);
+    await deleteUserAndProfile(hiddenMember);
+    await deleteUserAndProfile(deactivated);
+    await deleteUserAndProfile(leftMember);
+    await deleteUserAndProfile(otherProgramMember);
+    if (e2eProfileCreated) await db.delete(profiles).where(eq(profiles.id, e2eId));
+    if (e2eUserCreated) await db.execute(sql`DELETE FROM auth.users WHERE id = ${e2eId}::uuid`);
+    e2eUserCreated = false;
+    e2eProfileCreated = false;
+  });
+
+  it("returns only this program's active, mailable participants", async () => {
+    authAs(admin);
+    const res = await app.request(`/api/admin/programs/${programId}/participant-emails`);
+    expect(res.status).toBe(200);
+    const { emails } = (await res.json()) as { emails: string[] };
+
+    // Program-scoped fixtures are unique to this run, so the list is exact.
+    expect(emails).toEqual([`${active}@testfake.local`]);
+    expect(emails).not.toContain(`${hiddenMember}@testfake.local`);
+    expect(emails).not.toContain(`${deactivated}@testfake.local`);
+    expect(emails).not.toContain(`${leftMember}@testfake.local`);
+    expect(emails).not.toContain(`${otherProgramMember}@testfake.local`);
+    for (const e2eEmail of E2E_EMAILS) {
+      expect(emails).not.toContain(e2eEmail);
+    }
+  });
+
+  it("returns an empty list for an unknown program id", async () => {
+    authAs(admin);
+    const res = await app.request(`/api/admin/programs/${randomUUID()}/participant-emails`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ emails: [] });
+  });
+
+  it("returns 404 for an authenticated non-admin", async () => {
+    authAs(active);
+    const res = await app.request(`/api/admin/programs/${programId}/participant-emails`);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not_found" });
+  });
+
+  it("returns 401 when no session is present", async () => {
+    authAs(null);
+    const res = await app.request(`/api/admin/programs/${programId}/participant-emails`);
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
Summary: Add a "copy all" box of participant email addresses to the admin
program detail page.

Why: Programs — Community Calls especially — are supported by calendar
events, and admins need a fast way to pull every joined member's email
into a calendar guest list. /admin/members already has an "everyone"
version of this; this brings the same affordance to a single program.

Behavior: /admin/programs/[id] gains an "Email addresses" box under the
participant list (shown once a program has participants). It fetches a new
admin endpoint GET /api/admin/programs/:id/participant-emails, which
returns the program's current participants' emails — comma-joined in a
read-only textarea with a "Copy all" button. Same exclusions as the
members box: hidden, deactivated, and e2e test accounts are filtered
server-side, so the "mailable participants" count can be lower than the
Participants (N) header. The box refreshes when a participant is added or
removed.

Test Plan:
- ran `npm test` locally — functional 569 + 37 e2e green
- new functional test covers endpoint scoping (this program's active
participants only), the hidden/deactivated/left/other-program/e2e
exclusions, and the 404 (non-admin) / 401 (no session) guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
