### PR TITLE
chore(observability): log theme selections from the nav toggle, tag source (#414)

### DIFF
--- a/src/app/me/theme-selector.tsx
+++ b/src/app/me/theme-selector.tsx
@@ -30,7 +30,7 @@ export function ThemeSelector() {
     setPref(next);
     // userId is the pseudonymous auth UUID (same field as the api
     // request log), so adoption is countable per-person, not per-click.
-    log.info("theme-selected", { theme: next, userId: user?.id ?? null });
+    log.info("theme-selected", { theme: next, userId: user?.id ?? null, source: "settings" });
   };
 
   return (

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -3,6 +3,7 @@
 import { House, Menu, Moon, Settings, ShieldCheck, Sun, XIcon } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useLogger } from "next-axiom";
 import { useEffect, useState } from "react";
 
 import { useAuth } from "@/components/auth-provider";
@@ -57,6 +58,8 @@ function HomeLink() {
 
 // The top-right corner: the hamburger trigger and the nav sheet it opens.
 function MenuSheet({ displayName, isAdmin }: { displayName: string | null; isAdmin: boolean }) {
+  const { user } = useAuth();
+  const log = useLogger();
   const [isDark, setIsDark] = useState(false);
   const [mounted, setMounted] = useState(false);
 
@@ -80,6 +83,9 @@ function MenuSheet({ displayName, isAdmin }: { displayName: string | null; isAdm
     const next: ThemePreference = isDark ? "light" : "dark";
     applyThemePreference(next);
     setIsDark(!isDark);
+    // Mirror the settings-page selector's log so theme adoption is
+    // countable per-person; `source` distinguishes which affordance.
+    log.info("theme-selected", { theme: next, userId: user?.id ?? null, source: "nav" });
   };
 
   return (


### PR DESCRIPTION
## Summary

The nav-menu theme toggle changed the theme **silently** — no log. It now emits the same `theme-selected` event as the settings-page selector. Both call sites gain a `source: "nav" | "settings"` field so theme adoption can be attributed to the affordance used, alongside the existing `theme` and pseudonymous `userId` (consistent with the `api request` log).

- `src/components/site-header.tsx` — `MenuSheet` now uses `useAuth` + `useLogger`; `toggleTheme` logs `theme-selected` with `source: "nav"`.
- `src/app/me/theme-selector.tsx` — existing log gains `source: "settings"`.

## Test plan

- [x] Verified locally: toggling theme from the nav menu emits `theme-selected { theme, userId, source: "nav" }` to the dev console (next-axiom prettyprints client logs in dev); the toggle previously logged nothing.
- [ ] Settings selector emits the same event with `source: "settings"`.
- [ ] CI lint + functional + e2e pass.

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)