### PR TITLE
feat(programs): add a "Learn more" link to program cards (#434)

### DIFF
--- a/src/app/programs/programs-list.tsx
+++ b/src/app/programs/programs-list.tsx
@@ -97,6 +97,15 @@ function ProgramCard({
           </div>
         )}
 
+        {/* Explicit affordance for the detail page — the title is also a
+            link, but it doesn't read as one at a glance (#434). */}
+        <Link
+          href={{ pathname: `/programs/${program.slug}` } satisfies UrlObject}
+          className="text-sm font-medium text-foreground hover:underline focus-visible:underline"
+        >
+          Learn more <span aria-hidden="true">→</span>
+        </Link>
+
         {program.joined ? (
           <Button
             type="button"


### PR DESCRIPTION
## Summary

The program title links to the detail page, but it doesn't read as clickable at a glance. This adds an explicit **"Learn more →"** link to each program card's bottom group, so the path to the detail page is obvious.

UI-only; one file (`programs-list.tsx`).

## Test plan

- [ ] `/programs` — each card shows a "Learn more →" link; clicking it opens the program detail page
- [ ] It bottom-pins with the action button, staying aligned across cards
- [ ] CI lint + functional + e2e pass

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)