### PR TITLE
perf(programs): cap the facepile to 5 before signing avatars (#424)

### DIFF
--- a/src/server/programs.ts
+++ b/src/server/programs.ts
@@ -114,15 +114,26 @@ export const listPrograms = async (userId: string): Promise<ProgramWithMembershi
           .orderBy(desc(profilePrograms.assignedAt))
       : [];
 
-  const withAvatarUrls = await attachAvatarUrls(avatarRows);
+  // Cap to 5 per program *before* signing. avatarRows is ordered by
+  // desc(assignedAt), so the first 5 of each program are exactly the faces
+  // the card renders; signing the rest just signs (and caches) avatars that
+  // never appear in the facepile (#424).
+  const facepileRows = new Map<string, typeof avatarRows>();
+  for (const row of avatarRows) {
+    const existing = facepileRows.get(row.programId) ?? [];
+    if (existing.length < 5) {
+      existing.push(row);
+      facepileRows.set(row.programId, existing);
+    }
+  }
+
+  const withAvatarUrls = await attachAvatarUrls([...facepileRows.values()].flat());
 
   const avatarsByProgram = new Map<string, ProgramMemberAvatar[]>();
   for (const row of withAvatarUrls) {
     const existing = avatarsByProgram.get(row.programId) ?? [];
-    if (existing.length < 5) {
-      existing.push({ id: row.id, displayName: row.displayName, avatarUrl: row.avatarUrl });
-      avatarsByProgram.set(row.programId, existing);
-    }
+    existing.push({ id: row.id, displayName: row.displayName, avatarUrl: row.avatarUrl });
+    avatarsByProgram.set(row.programId, existing);
   }
 
   return rows.map((r) => ({

--- a/tests/functional/server/programs.test.ts
+++ b/tests/functional/server/programs.test.ts
@@ -118,6 +118,34 @@ describe("Programs API", () => {
       const hit = body.programs.find((p: { id: string }) => p.id === programId);
       expect(hit).toBeUndefined();
     });
+
+    it("caps the facepile at 5 even when a program has more members", async () => {
+      // Six current members; the card shows at most 5 faces (and the
+      // server caps before signing so it never signs the other one — #424).
+      const memberIds = Array.from({ length: 6 }, () => randomUUID());
+      for (const id of memberIds) {
+        await db.execute(
+          sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous)
+              VALUES (${id}::uuid, ${`facepile-${id.slice(0, 8)}@testfake.local`}, false, false)`,
+        );
+        await db.insert(profiles).values({ id, displayName: `Member ${id.slice(0, 4)}` });
+        await db.insert(profilePrograms).values({ profileId: id, programId });
+      }
+
+      try {
+        const res = await app.request("/api/programs");
+        const body = await res.json();
+        const program = body.programs.find((p: { id: string }) => p.id === programId);
+        expect(program.memberCount).toBe(6);
+        expect(program.memberAvatars).toHaveLength(5);
+      } finally {
+        await db.delete(profilePrograms).where(eq(profilePrograms.programId, programId));
+        for (const id of memberIds) {
+          await db.delete(profiles).where(eq(profiles.id, id));
+          await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+        }
+      }
+    });
   });
 
   describe("POST /api/programs/:id/join", () => {


### PR DESCRIPTION
## Summary

`listPrograms` fetched **every** current member of every program, signed all their avatars via `attachAvatarUrls`, then sliced to 5-per-program in JS — so it signed (and cached) avatars for members who never appear in the facepile. This was the over-signing finding from the #423 investigation.

Cap to 5 per program **before** signing. `avatarRows` is already ordered by `desc(assignedAt)`, so the rendered faces are unchanged — only the signing scope shrinks (≤5 per program instead of every member).

Not a connection risk (still a single batched `createSignedUrls`), but it signs and caches far fewer objects.

## Test plan

- [x] New regression test: a program with 6 members → `memberAvatars` length 5, `memberCount` 6.
- [x] `programs.test.ts` green (23 tests); lint + typecheck clean.
- [ ] CI lint + functional + e2e pass.

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)