### PR TITLE
ci(e2e): serialize runs with a concurrency group (#358)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,15 @@ name: E2E Tests
 on:
   deployment_status:
 
+# Serialize e2e across all branches: the suite runs against the shared prod
+# Supabase DB and drives two fixed seeded accounts, resetting their state
+# mid-run. Two overlapping runs clobber each other's accounts and fail (#358).
+# A single global group queues runs instead; cancel-in-progress: false so no
+# deploy loses its e2e result.
+concurrency:
+  group: e2e-shared-prod-db
+  cancel-in-progress: false
+
 # See ci.yml for the rationale. upload-artifact@v4 works with contents:
 # read — it doesn't need write scope on any top-level resource.
 permissions:

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -8,6 +8,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 Avatar signed URLs rotate a `?token=` that's part of next/image's optimizer cache key, and the optimizer's default `minimumCacheTTL` is 4h — so every avatar's 1024² source was re-fetched from Storage daily (rotation) and again every 4h (expiry), blowing the free-plan egress quota during the Convening. Fix: `SIGN_TTL_SECONDS` 24h → 5 days, and `images.minimumCacheTTL` → 31 days (safe — object paths are immutable). The durable fix (a tokenless proxy route) stays open as #382.
 
+## 2026-06-21 | Ola | e2e runs serialize via a CI concurrency group
+
+Two e2e runs overlapping against the shared prod DB clobbered the seeded accounts mid-run and failed. A global `concurrency: { group: e2e-shared-prod-db, cancel-in-progress: false }` in `e2e.yml` now queues runs instead — no deploy loses its e2e. (#358)
+
 ## 2026-06-20 | James | Buttondown subscribers now carry the member's display name in `metadata.name`
 
 We forgot this earlier: Push `profiles.displayName` into Buttondown's `metadata.name`. Seeded on create, reconciled by the cron via PATCH, and pushed inline on profile displayName edit (`reason: "update-name"`). Adds an `allowReservedTestEmails` client opt-out just for re-recording golds. (#444)


### PR DESCRIPTION
## Summary

The Playwright e2e suite runs against the **shared prod Supabase DB** and authenticates as two fixed seeded accounts, whose state `/api/_test/reset` wipes mid-run. Nothing stopped two e2e runs from executing at once, so when two deploys landed within the ~3-min e2e window they clobbered each other's seeded-account state and failed (the recurring `invites.spec.ts` flake we've hit repeatedly).

Adds a global **concurrency group** to `e2e.yml` so runs queue instead of overlapping:

```yaml
concurrency:
  group: e2e-shared-prod-db
  cancel-in-progress: false
```

`cancel-in-progress: false` queues runs rather than cancelling, so no deploy loses its e2e result. This is **Option A** from the issue; per-run isolated accounts (Option B) is deferred until e2e volume makes serialization painful.

## Test plan

- [x] `e2e.yml` parses as valid YAML; `concurrency` is a top-level key.
- [ ] CI lint + functional pass.
- [ ] After merge, overlapping deploys queue their e2e runs instead of running concurrently (observable on the Actions tab).

Note: the concurrency rule takes effect once merged to `main` (deployment_status workflows resolve from the default branch).

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)