### PR TITLE
perf(avatars): lengthen signed-URL and optimizer cache TTLs to cut Storage egress

### DIFF
--- a/docs/design-profile-pictures.md
+++ b/docs/design-profile-pictures.md
@@ -88,8 +88,9 @@ but it **expires**: a URL that leaks via a `Referer` header, browser
 history, or a pasted link stops working. A public bucket can't offer
 that — a leaked public URL is live until the object is deleted.
 
-TTL: **24 hours**. Long enough that re-signing is rare; short enough
-that a leaked link dies within a day.
+TTL: **5 days**. Long enough that re-signing is rare; short enough that
+a leaked link dies within the week. (Originally 24h; lengthened in
+response to Storage egress — see the optimizer-cache note below and #382.)
 
 Performance — the member directory renders every member's avatar at
 once, so signing must not become N round-trips:
@@ -103,9 +104,15 @@ once, so signing must not become N round-trips:
   `use cache`). Signing then fires roughly once per TTL per warm
   instance — not once per page view. The directory's hot path does
   zero Storage round-trips.
-- The long TTL also keeps `next/image`'s optimizer cache stable: that
-  cache is keyed by source URL, so an hourly-churning URL would force
-  constant re-optimization. A 24h URL does not.
+- The signed URL's `?token=` is part of `next/image`'s optimizer cache
+  key, so each rotation forces a full re-fetch of every avatar's source
+  object from Storage. The original 24h rotation did this daily; combined
+  with the optimizer's 4h default `minimumCacheTTL`, it was the dominant
+  Storage-egress driver (#382). The fix is two-sided: a 5-day sign TTL
+  (rotate ~5× less often) plus a 31-day `images.minimumCacheTTL` in
+  `next.config.ts` so a variant is never re-fetched within a URL's life.
+  A long `minimumCacheTTL` is safe because the object path is immutable
+  (random UUID per upload), so there is nothing to invalidate.
 
 A per-upload random filename means a replaced avatar gets a new path,
 hence a new cache key, so a replace shows immediately rather than

--- a/docs/design-profile-pictures.md
+++ b/docs/design-profile-pictures.md
@@ -74,7 +74,7 @@ downscaling on top.
 
 ## Key decisions
 
-### 1. Private bucket, signed URLs (24h TTL)
+### 1. Private bucket, signed URLs (5-day TTL)
 
 The `avatars` bucket is **private**. Objects are reachable only via a
 **signed URL** — a time-limited, HMAC-signed link minted server-side.
@@ -253,7 +253,7 @@ avatar a new path, so a replace shows immediately.
    used by `getProfileForSelf` / `getProfileForMember` / `listMembers`.
    It batches cache-miss paths into one `createSignedUrls` call and
    caches each signed URL keyed by object path with an expiry near the
-   24h TTL; a null `avatarPath` yields `null`. Single-profile callers
+   5-day TTL; a null `avatarPath` yields `null`. Single-profile callers
    pass a one-element array. One chokepoint keeps a future scheme
    change to a single function.
 4. **Upload endpoint** — `POST /api/me/avatar` in `src/server/api.ts`,

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-22 | James | Cut avatar Storage egress: longer signed-URL TTL + high optimizer cache TTL
+
+Avatar signed URLs rotate a `?token=` that's part of next/image's optimizer cache key, and the optimizer's default `minimumCacheTTL` is 4h — so every avatar's 1024² source was re-fetched from Storage daily (rotation) and again every 4h (expiry), blowing the free-plan egress quota during the Convening. Fix: `SIGN_TTL_SECONDS` 24h → 5 days, and `images.minimumCacheTTL` → 31 days (safe — object paths are immutable). The durable fix (a tokenless proxy route) stays open as #382.
+
 ## 2026-06-20 | James | Buttondown subscribers now carry the member's display name in `metadata.name`
 
 We forgot this earlier: Push `profiles.displayName` into Buttondown's `metadata.name`. Seeded on create, reconciled by the cron via PATCH, and pushed inline on profile displayName edit (`reason: "update-name"`). Adds an `allowReservedTestEmails` client opt-out just for re-recording golds. (#444)

--- a/next.config.ts
+++ b/next.config.ts
@@ -88,6 +88,14 @@ const nextConfig: NextConfig = {
   typedRoutes: true,
   images: {
     remotePatterns,
+    // Hold optimized avatar variants for 31 days instead of the 4h
+    // default. Safe because avatar object paths are immutable — a replace
+    // mints a new random-UUID path (hence a new URL and cache key), so a
+    // stale variant is never served. Without this, each variant expires
+    // every 4h and re-fetches its full 1024² source from Storage; that
+    // intra-day churn was the bulk of our Storage egress (#382). Paired
+    // with the 5-day signed-URL TTL in avatars.ts.
+    minimumCacheTTL: 2_678_400,
     // The local Supabase Storage container lives on 127.0.0.1, which
     // Next 16's optimizer blocks as an SSRF guard. Allow it in dev
     // only — production avatars come from the public *.supabase.co host.

--- a/src/server/avatars.ts
+++ b/src/server/avatars.ts
@@ -14,10 +14,16 @@ import { profiles } from "./schema";
 export const AVATAR_BUCKET = "avatars";
 
 // TTL handed to Supabase when signing, and how long a signed URL is
-// trusted from our cache. The cache window is deliberately shorter
-// than the TTL so a URL is re-signed before it can expire mid-use.
-const SIGN_TTL_SECONDS = 24 * 60 * 60;
-const CACHE_TTL_MS = 23 * 60 * 60 * 1000;
+// trusted from our cache. Re-signing rotates the URL's `?token=`, which
+// is part of next/image's optimizer cache key — so every rotation forces
+// a full re-fetch of each avatar's source object from Storage (the egress
+// driver behind #382). A 5-day TTL keeps rotation rare; pair it with a
+// high `images.minimumCacheTTL` so a variant is never re-fetched within a
+// URL's life. Short enough that a leaked avatar URL still dies within the
+// week. The cache window sits an hour under the TTL so a URL is re-signed
+// before it can expire mid-use.
+const SIGN_TTL_SECONDS = 5 * 24 * 60 * 60;
+const CACHE_TTL_MS = SIGN_TTL_SECONDS * 1000 - 60 * 60 * 1000;
 
 type CacheEntry = { url: string; expiresAt: number };
 


### PR DESCRIPTION
## What

Cut Supabase Storage egress from avatars, which exceeded the free-plan quota during the Quarterly Convening (~1 GB/day, 90% Storage egress).

## Why

Every avatar is a private Storage object served as a signed URL through `next/image`. The signed URL's `?token=` is part of Vercel's image-optimizer cache key, so:

- The token rotated daily (`SIGN_TTL_SECONDS = 24h`), busting the cache key → a full re-fetch of every avatar's 1024² source from Storage once a day.
- The optimizer's default `minimumCacheTTL` is 4h, so each variant also expired and re-fetched the source every ~4h of browsing.

Net: the same unchanged bytes were re-downloaded many times a day. The Convening spiked all three multipliers at once — more avatars viewed, more device widths, sustained all-day traffic.

## Change

- `SIGN_TTL_SECONDS` 24h → 5 days — rotate ~5× less often.
- `images.minimumCacheTTL` → 31 days — a variant is never re-fetched within a URL's life. Safe because avatar object paths are immutable (random UUID per upload), so a stale variant is never served.

Together these take steady-state egress per variant from ~daily rotation + several 4h re-fetches down to ~one fetch per 5 days. The `minimumCacheTTL` half applies to every avatar on deploy (no per-object backfill); benefit ramps in as variants re-cache under the new TTL.

## Scope / follow-up

Mitigation, not the end state — the token still rides in client-visible URLs. The durable fix (a stable tokenless proxy route so the optimizer keys on a stable URL, driving egress to ~zero) stays open as **#382**. Note: that fix trades the design's leaked-URL-expiry property for cache stability and can't enforce per-user auth behind the optimizer, so it needs a privacy re-decision — captured there for when we pick it up.

## Testing

`npm test` green locally — functional 576 passed, e2e 37 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
