### PR TITLE
feat(admin): permanently delete a member's account (#185)

### DIFF
--- a/src/app/admin/members/members-admin-panel.tsx
+++ b/src/app/admin/members/members-admin-panel.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { type UseMutationResult, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ShieldCheck } from "lucide-react";
+import { useState } from "react";
 
 import { Avatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { apiClient } from "@/lib/api";
 import type { AdminMember } from "@/lib/api-types";
 
@@ -13,6 +15,11 @@ const STALE_TIME = 5 * 60 * 1000;
 
 type ToggleVars = { member: AdminMember; isAdmin: boolean };
 type ToggleError = Error & { memberId?: string };
+type ToggleMutation = UseMutationResult<ToggleVars, ToggleError, ToggleVars>;
+
+type DeleteVars = { id: string };
+type DeleteError = Error & { memberId?: string };
+type DeleteMutation = UseMutationResult<DeleteVars, DeleteError, DeleteVars>;
 
 const fetchMembers = async (): Promise<AdminMember[]> => {
   const res = await apiClient.api.admin.members.$get();
@@ -26,7 +33,7 @@ export function MembersAdminPanel({ currentUserId }: { currentUserId: string }) 
 
   const membersQuery = useQuery({ queryKey: QUERY_KEY, queryFn: fetchMembers, staleTime: STALE_TIME });
 
-  const mutation = useMutation<ToggleVars, ToggleError, ToggleVars>({
+  const toggleMutation = useMutation<ToggleVars, ToggleError, ToggleVars>({
     mutationFn: async (vars) => {
       const res = await apiClient.api.admin.members[":id"].admin.$patch({
         param: { id: vars.member.id },
@@ -49,6 +56,26 @@ export function MembersAdminPanel({ currentUserId }: { currentUserId: string }) 
     },
   });
 
+  const deleteMutation = useMutation<DeleteVars, DeleteError, DeleteVars>({
+    mutationFn: async (vars) => {
+      const res = await apiClient.api.admin.members[":id"].$delete({ param: { id: vars.id } } as never);
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        const message =
+          res.status === 403 && body.error === "self_delete"
+            ? "You can't delete your own account here — use deactivate."
+            : res.status === 409 && body.error === "is_admin"
+              ? "Remove this member's admin access before deleting."
+              : `Something went wrong (${res.status}).`;
+        throw Object.assign(new Error(message), { memberId: vars.id });
+      }
+      return vars;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+  });
+
   return (
     <div className="flex flex-col gap-2">
       {membersQuery.isPending ? (
@@ -59,55 +86,140 @@ export function MembersAdminPanel({ currentUserId }: { currentUserId: string }) 
         </p>
       ) : (
         <ul className="flex flex-col gap-2">
-          {membersQuery.data.map((member) => {
-            const isSelf = member.id === currentUserId;
-            const isSaving = mutation.isPending && mutation.variables?.member.id === member.id;
-            const errorMessage =
-              mutation.isError && mutation.error.memberId === member.id ? mutation.error.message : null;
-
-            return (
-              <li key={member.id} className="flex items-center gap-3 rounded border border-border p-3">
-                <Avatar
-                  name={member.displayName}
-                  url={member.avatarUrl}
-                  sizes="32px"
-                  className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-sm font-medium text-muted-foreground"
-                />
-                <div className="flex min-w-0 flex-1 flex-col">
-                  <span className="font-medium">{member.displayName ?? "(unnamed)"}</span>
-                  {member.location && <span className="text-sm text-muted-foreground">{member.location}</span>}
-                </div>
-                {member.isAdmin && <ShieldCheck className="h-4 w-4 shrink-0 text-green-700" aria-label="Admin" />}
-                <div className="flex flex-col items-end gap-1">
-                  {isSelf ? (
-                    <Button size="sm" disabled title="You cannot remove your own admin access">
-                      Admin (you)
-                    </Button>
-                  ) : member.isAdmin ? (
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      disabled={isSaving}
-                      onClick={() => mutation.mutate({ member, isAdmin: false })}
-                    >
-                      {isSaving ? "Saving…" : "Remove admin"}
-                    </Button>
-                  ) : (
-                    <Button size="sm" disabled={isSaving} onClick={() => mutation.mutate({ member, isAdmin: true })}>
-                      {isSaving ? "Saving…" : "Make admin"}
-                    </Button>
-                  )}
-                  {errorMessage && (
-                    <p role="alert" className="text-sm text-destructive">
-                      {errorMessage}
-                    </p>
-                  )}
-                </div>
-              </li>
-            );
-          })}
+          {membersQuery.data.map((member) => (
+            <MemberRow
+              key={member.id}
+              member={member}
+              isSelf={member.id === currentUserId}
+              toggleMutation={toggleMutation}
+              deleteMutation={deleteMutation}
+            />
+          ))}
         </ul>
       )}
     </div>
+  );
+}
+
+function MemberRow({
+  member,
+  isSelf,
+  toggleMutation,
+  deleteMutation,
+}: {
+  member: AdminMember;
+  isSelf: boolean;
+  toggleMutation: ToggleMutation;
+  deleteMutation: DeleteMutation;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+
+  const isSaving = toggleMutation.isPending && toggleMutation.variables?.member.id === member.id;
+  const isDeleting = deleteMutation.isPending && deleteMutation.variables?.id === member.id;
+  const toggleError =
+    toggleMutation.isError && toggleMutation.error.memberId === member.id ? toggleMutation.error.message : null;
+  const deleteError =
+    deleteMutation.isError && deleteMutation.error.memberId === member.id ? deleteMutation.error.message : null;
+
+  // Type-to-confirm phrase: the display name, or "DELETE" for the rare
+  // unnamed (mid-onboarding) member whose name can't be typed.
+  const confirmPhrase = member.displayName?.trim() || "DELETE";
+  const confirmMatches = confirmText.trim() === confirmPhrase;
+
+  const cancelConfirm = () => {
+    setConfirming(false);
+    setConfirmText("");
+  };
+
+  return (
+    <li className="flex flex-col gap-3 rounded border border-border p-3">
+      <div className="flex items-center gap-3">
+        <Avatar
+          name={member.displayName}
+          url={member.avatarUrl}
+          sizes="32px"
+          className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-sm font-medium text-muted-foreground"
+        />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="font-medium">{member.displayName ?? "(unnamed)"}</span>
+          {member.location && <span className="text-sm text-muted-foreground">{member.location}</span>}
+        </div>
+        {member.isAdmin && <ShieldCheck className="h-4 w-4 shrink-0 text-green-700" aria-label="Admin" />}
+        <div className="flex flex-col items-end gap-1">
+          {isSelf ? (
+            <Button size="sm" disabled title="You cannot remove your own admin access">
+              Admin (you)
+            </Button>
+          ) : member.isAdmin ? (
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={isSaving}
+              onClick={() => toggleMutation.mutate({ member, isAdmin: false })}
+            >
+              {isSaving ? "Saving…" : "Remove admin"}
+            </Button>
+          ) : (
+            <div className="flex gap-2">
+              <Button size="sm" disabled={isSaving} onClick={() => toggleMutation.mutate({ member, isAdmin: true })}>
+                {isSaving ? "Saving…" : "Make admin"}
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={confirming || isDeleting}
+                onClick={() => setConfirming(true)}
+              >
+                Delete account
+              </Button>
+            </div>
+          )}
+          {toggleError && (
+            <p role="alert" className="text-sm text-destructive">
+              {toggleError}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {confirming && (
+        <div className="flex flex-col gap-2 rounded border border-destructive/40 bg-destructive/5 p-3">
+          <p className="text-sm">
+            Permanently delete <span className="font-medium">{member.displayName ?? "this member"}</span>? This removes
+            their profile, avatar, all relationships, and program memberships. Invites they sent or redeemed are kept
+            but anonymized. This cannot be undone.
+          </p>
+          <label htmlFor={`confirm-delete-${member.id}`} className="text-sm text-muted-foreground">
+            Type <span className="font-medium text-foreground">{confirmPhrase}</span> to confirm
+          </label>
+          <Input
+            id={`confirm-delete-${member.id}`}
+            value={confirmText}
+            onChange={(e) => setConfirmText(e.target.value)}
+            disabled={isDeleting}
+            autoComplete="off"
+          />
+          <div className="flex gap-2">
+            <Button variant="ghost" size="sm" disabled={isDeleting} onClick={cancelConfirm}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={!confirmMatches || isDeleting}
+              onClick={() => deleteMutation.mutate({ id: member.id })}
+            >
+              {isDeleting ? "Deleting…" : "Delete account"}
+            </Button>
+          </div>
+          {deleteError && (
+            <p role="alert" className="text-sm text-destructive">
+              {deleteError}
+            </p>
+          )}
+        </div>
+      )}
+    </li>
   );
 }

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -27,7 +27,7 @@ import {
   revokeInvite,
   validateNote,
 } from "./invites";
-import { listActiveMemberEmails, listMembersAdmin, setAdminStatus } from "./members-admin";
+import { deleteMemberAccount, listActiveMemberEmails, listMembersAdmin, setAdminStatus } from "./members-admin";
 import {
   deactivateProfile,
   getProfileForMember,
@@ -278,6 +278,18 @@ const adminRoutes = new Hono<{ Variables: ApiVariables }>()
       return c.json({ ok: true });
     },
   )
+  .delete("/members/:id", async (c) => {
+    const id = c.req.param("id");
+    if (!isUuid(id)) return c.json({ error: "id must be a UUID" }, 400);
+    const user = c.get("user");
+    const result = await deleteMemberAccount(id, user.id);
+    if ("error" in result) {
+      if (result.error === "self_delete") return c.json({ error: "self_delete" }, 403);
+      if (result.error === "is_admin") return c.json({ error: "is_admin" }, 409);
+      return c.json({ error: "not_found" }, 404);
+    }
+    return c.json({ ok: true });
+  })
   .get("/invites", async (c) => {
     const invitesList = await listAllInvitesForAdmin();
     return c.json({ invites: invitesList });

--- a/src/server/members-admin.ts
+++ b/src/server/members-admin.ts
@@ -115,9 +115,11 @@ export const deleteMemberAccount = async (
   await db.delete(profiles).where(eq(profiles.id, targetId));
 
   const { error } = await supabaseAdmin.auth.admin.deleteUser(targetId);
-  if (error) {
-    // The profile is already gone; surface the auth-delete failure so an
-    // operator can clean up the orphaned auth.users row.
+  // A 404 means the auth user is already gone — the end state we want — so
+  // treat it as success (keeps the delete idempotent and tolerant of an
+  // auth row that was never fully provisioned by GoTrue). Any other error is
+  // a real failure; surface it, though the profile is already deleted.
+  if (error && error.status !== 404) {
     throw new Error(`deleteMemberAccount: auth deleteUser failed for ${targetId}: ${error.message}`);
   }
 

--- a/src/server/members-admin.ts
+++ b/src/server/members-admin.ts
@@ -1,6 +1,8 @@
 import { asc, count, eq, sql } from "drizzle-orm";
 
-import { attachAvatarUrls } from "./avatars";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+
+import { attachAvatarUrls, clearAvatar } from "./avatars";
 import { db } from "./db";
 import { profiles } from "./schema";
 import { E2E_EMAILS } from "./test-reset";
@@ -78,5 +80,46 @@ export const setAdminStatus = async (
   }
 
   await db.update(profiles).set({ isAdmin }).where(eq(profiles.id, targetId));
+  return { ok: true };
+};
+
+// Permanently delete a member's account. Admin-only (the requireAdmin gate
+// on the route is the authorization). Removes the avatar object, the
+// profiles row — whose FK cascade clears program memberships, relations,
+// and invite hints, and null-sets invite lineage (createdBy/redeemedBy) so
+// the chain survives anonymized — then the auth.users row.
+//
+// Members remove themselves via deactivate, not here: refusing self-delete
+// keeps an admin from stranding the app's admin-only state, and refusing to
+// delete a fellow admin (demote first) guards the same, mirroring
+// setAdminStatus.
+export const deleteMemberAccount = async (
+  targetId: string,
+  requesterId: string,
+): Promise<{ ok: true } | { error: "not_found" | "self_delete" | "is_admin" }> => {
+  if (targetId === requesterId) return { error: "self_delete" };
+
+  const [target] = await db
+    .select({ id: profiles.id, isAdmin: profiles.isAdmin })
+    .from(profiles)
+    .where(eq(profiles.id, targetId));
+  if (!target) return { error: "not_found" };
+  if (target.isAdmin) return { error: "is_admin" };
+
+  // Order matters: clearAvatar reads avatarPath off the profile, and the
+  // profiles → auth.users FK is ON DELETE NO ACTION, so the profile (child)
+  // must go before the auth user (parent). The profile delete is a single
+  // statement, so its cascade runs without a multi-statement transaction
+  // over the pooler (docs/strategy-db-transactions.md).
+  await clearAvatar(targetId);
+  await db.delete(profiles).where(eq(profiles.id, targetId));
+
+  const { error } = await supabaseAdmin.auth.admin.deleteUser(targetId);
+  if (error) {
+    // The profile is already gone; surface the auth-delete failure so an
+    // operator can clean up the orphaned auth.users row.
+    throw new Error(`deleteMemberAccount: auth deleteUser failed for ${targetId}: ${error.message}`);
+  }
+
   return { ok: true };
 };

--- a/tests/functional/server/admin-members-delete.test.ts
+++ b/tests/functional/server/admin-members-delete.test.ts
@@ -1,0 +1,172 @@
+import { randomUUID } from "node:crypto";
+import type { User } from "@supabase/supabase-js";
+import { eq, sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+// deleteMemberAccount calls supabaseAdmin.auth.admin.deleteUser; clearAvatar
+// (also reached) touches supabaseAdmin.storage. Mock the whole admin client.
+vi.mock("@/lib/supabase/admin", () => ({
+  supabaseAdmin: {
+    auth: { admin: { deleteUser: vi.fn() } },
+    storage: {
+      from: () => ({
+        remove: vi.fn().mockResolvedValue({ data: [], error: null }),
+        createSignedUrls: vi.fn().mockResolvedValue({ data: [], error: null }),
+      }),
+    },
+  },
+}));
+
+import { createServerClient } from "@supabase/ssr";
+
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import app from "@/server/api";
+import { db } from "@/server/db";
+import { invites, profilePrograms, profiles, programs, relations } from "@/server/schema";
+
+const mockCreateServerClient = vi.mocked(createServerClient);
+const mockDeleteUser = vi.mocked(supabaseAdmin.auth.admin.deleteUser);
+
+const fakeUser = (id: string): User =>
+  ({
+    id,
+    email: `${id}@testfake.local`,
+    user_metadata: {},
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+  }) as User;
+
+const authAs = (userId: string | null) => {
+  mockCreateServerClient.mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: userId ? fakeUser(userId) : null }, error: null }),
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test mock shape
+  } as any);
+};
+
+const insertMember = async (id: string, opts: { isAdmin?: boolean; displayName?: string } = {}) => {
+  await db.execute(
+    sql`INSERT INTO auth.users (id, email, is_sso_user, is_anonymous) VALUES (${id}::uuid, ${`${id}@testfake.local`}, false, false)`,
+  );
+  await db.insert(profiles).values({ id, isAdmin: opts.isAdmin ?? false, displayName: opts.displayName ?? null });
+};
+
+const removeMember = async (id: string) => {
+  await db.delete(profiles).where(eq(profiles.id, id));
+  await db.execute(sql`DELETE FROM auth.users WHERE id = ${id}::uuid`);
+};
+
+const profileExists = async (id: string): Promise<boolean> => {
+  const [row] = await db.select({ id: profiles.id }).from(profiles).where(eq(profiles.id, id));
+  return Boolean(row);
+};
+
+describe("DELETE /api/admin/members/:id", () => {
+  let admin: string;
+  let target: string;
+
+  beforeEach(async () => {
+    admin = randomUUID();
+    target = randomUUID();
+    mockDeleteUser.mockResolvedValue({ data: { user: null }, error: null } as never);
+    await insertMember(admin, { isAdmin: true, displayName: "Admin" });
+    authAs(admin);
+  });
+
+  afterEach(async () => {
+    mockCreateServerClient.mockReset();
+    mockDeleteUser.mockReset();
+    // Defensive cleanup — a test may have already deleted `target`.
+    await removeMember(target);
+    await removeMember(admin);
+  });
+
+  it("deletes a member: profile + memberships gone, deleteUser called", async () => {
+    await insertMember(target, { displayName: "Target Member" });
+    const programId = randomUUID();
+    await db.insert(programs).values({ id: programId, slug: `p-${programId.slice(0, 8)}`, name: "P" });
+    await db.insert(profilePrograms).values({ profileId: target, programId });
+
+    const res = await app.request(`/api/admin/members/${target}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+
+    expect(await profileExists(target)).toBe(false);
+    const memberships = await db.select().from(profilePrograms).where(eq(profilePrograms.profileId, target));
+    expect(memberships).toHaveLength(0);
+    expect(mockDeleteUser).toHaveBeenCalledWith(target);
+
+    await db.delete(programs).where(eq(programs.id, programId));
+  });
+
+  it("cascades relations and anonymizes invites the member created", async () => {
+    const other = randomUUID();
+    await insertMember(target, { displayName: "Target" });
+    await insertMember(other, { displayName: "Other" });
+    // A rated relation requires a value 1-4 (relations_hint_state check).
+    await db.insert(relations).values({ relatorId: target, relateeId: other, value: 2 });
+    const inviteId = randomUUID();
+    await db.insert(invites).values({
+      id: inviteId,
+      code: `code-${inviteId.slice(0, 8)}`,
+      createdBy: target,
+      note: "come on in",
+      expiresAt: new Date(Date.now() + 86_400_000),
+    });
+
+    const res = await app.request(`/api/admin/members/${target}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+
+    const rels = await db.select().from(relations).where(eq(relations.relatorId, target));
+    expect(rels).toHaveLength(0); // cascade
+    const [invite] = await db.select().from(invites).where(eq(invites.id, inviteId));
+    expect(invite).toBeDefined(); // survives
+    expect(invite.createdBy).toBeNull(); // anonymized
+
+    await db.delete(invites).where(eq(invites.id, inviteId));
+    await removeMember(other);
+  });
+
+  it("refuses self-delete with 403", async () => {
+    const res = await app.request(`/api/admin/members/${admin}`, { method: "DELETE" });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "self_delete" });
+    expect(await profileExists(admin)).toBe(true);
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+  });
+
+  it("refuses deleting another admin with 409", async () => {
+    await insertMember(target, { isAdmin: true, displayName: "Other Admin" });
+    const res = await app.request(`/api/admin/members/${target}`, { method: "DELETE" });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "is_admin" });
+    expect(await profileExists(target)).toBe(true);
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for an unknown member", async () => {
+    const res = await app.request(`/api/admin/members/${randomUUID()}`, { method: "DELETE" });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not_found" });
+  });
+
+  it("returns 400 for a non-UUID id", async () => {
+    const res = await app.request("/api/admin/members/not-a-uuid", { method: "DELETE" });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 (route hidden) when the caller is not an admin", async () => {
+    await insertMember(target, { displayName: "Caller" });
+    authAs(target); // a non-admin signs in and tries to delete the admin
+    const res = await app.request(`/api/admin/members/${admin}`, { method: "DELETE" });
+    // requireAdmin hides admin routes from non-admins behind a 404.
+    expect(res.status).toBe(404);
+    expect(await profileExists(admin)).toBe(true);
+  });
+});

--- a/tests/functional/server/admin-members-delete.test.ts
+++ b/tests/functional/server/admin-members-delete.test.ts
@@ -105,6 +105,20 @@ describe("DELETE /api/admin/members/:id", () => {
     await db.delete(programs).where(eq(programs.id, programId));
   });
 
+  it("treats a 404 from auth deleteUser as success (idempotent)", async () => {
+    await insertMember(target, { displayName: "Ghost" });
+    // The auth user is already gone (e.g. never fully provisioned); the
+    // profile delete still completes and the call succeeds.
+    mockDeleteUser.mockResolvedValueOnce({
+      data: { user: null },
+      error: { status: 404, message: "User not found" },
+    } as never);
+
+    const res = await app.request(`/api/admin/members/${target}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+    expect(await profileExists(target)).toBe(false);
+  });
+
   it("cascades relations and anonymizes invites the member created", async () => {
     const other = randomUUID();
     await insertMember(target, { displayName: "Target" });


### PR DESCRIPTION
## Summary

Implements the **admin-only account deletion** half of #185 (the member-facing **deactivate** half shipped in #301). Per James's 2026-05-27 decision: members self-serve via deactivate; permanent deletion is an admin operation.

An admin deletes a member from `/admin/members`:
- **Server** — `deleteMemberAccount(targetId, requesterId)` (`members-admin.ts`): `clearAvatar` → delete the `profiles` row (FK cascade clears program memberships, relations, and invite hints; null-sets `invites.createdBy`/`redeemedBy` so the chain survives anonymized) → `supabaseAdmin.auth.admin.deleteUser`. Order matters — `profiles → auth.users` is `ON DELETE no action`, so the profile (child) goes first; the single-statement delete avoids a pooler transaction.
- **API** — `DELETE /admin/members/:id` in the `requireAdmin` sub-router → `self_delete`→403, `is_admin`→409, `not_found`→404.
- **UI** — per-row "Delete account" → a **type-to-confirm** panel (type the member's display name to enable), listing what's removed (profile, avatar, relationships, memberships) vs preserved (invites sent/redeemed, anonymized).
- **Guards** (mirror `setAdminStatus`): refuse self-delete (use deactivate), refuse deleting a fellow admin (demote first).

## Test plan

- [x] New `admin-members-delete.test.ts` (7 cases): deletes a member (profile + memberships gone, `deleteUser` called); cascades relations; anonymizes the member's invites (`createdBy` → null); self-delete → 403; admin → 409; unknown → 404; non-UUID → 400; non-admin caller → 404.
- [x] Full functional suite green (583 tests); lint + typecheck clean.
- [ ] Manual: as admin on `/admin/members`, delete a throwaway member via type-to-confirm; verify they vanish from the directory + DB; verify self/admin guards block.
- [ ] CI lint + functional + e2e pass.

## Out of scope (follow-up)
- GDPR "right to be forgotten" as a distinct manual process (James's open question) — this hard delete is v1; a documented manual path can follow.
- No soft-delete/grace period (issue says hard delete is acceptable for v1).

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)