### PR TITLE
feat(signup): hide the invite-code field when prefilled from the link (#419)

### DIFF
--- a/src/app/signup/signup-form.tsx
+++ b/src/app/signup/signup-form.tsx
@@ -30,6 +30,9 @@ export function SignupForm({ initialCode, intro }: { initialCode: string; intro:
   const [email, setEmail] = useState("");
   const [displayName, setDisplayName] = useState("");
 
+  // Whether the code arrived prefilled from the invite link.
+  const prefilled = initialCode.trim().length > 0;
+
   const checkCode = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const normalized = codeInput.trim().toUpperCase();
@@ -142,27 +145,37 @@ export function SignupForm({ initialCode, intro }: { initialCode: string; intro:
   } else {
     const checking = step.kind === "code-checking";
     const ready = codeInput.trim().length === INVITE_CODE_LENGTH;
+    const codeError = step.kind === "enter-code" ? step.error : undefined;
+    // Hide the code field when it arrived prefilled from the invite link and
+    // is a complete code that hasn't errored — the user doesn't need to see
+    // or touch it (#419). A malformed or rejected prefilled code reveals the
+    // field so they can fix it; an empty (no-code) arrival shows it as normal.
+    const showCodeField = !prefilled || !ready || Boolean(codeError);
     content = (
       <form onSubmit={checkCode} className="flex w-full flex-col gap-3">
-        <Label htmlFor="code">Invite code</Label>
-        <Input
-          id="code"
-          type="text"
-          required
-          autoComplete="off"
-          autoCapitalize="characters"
-          spellCheck={false}
-          value={codeInput}
-          onChange={(event) => setCodeInput(event.target.value)}
-          disabled={checking}
-          className="font-mono uppercase"
-        />
+        {showCodeField && (
+          <>
+            <Label htmlFor="code">Invite code</Label>
+            <Input
+              id="code"
+              type="text"
+              required
+              autoComplete="off"
+              autoCapitalize="characters"
+              spellCheck={false}
+              value={codeInput}
+              onChange={(event) => setCodeInput(event.target.value)}
+              disabled={checking}
+              className="font-mono uppercase"
+            />
+          </>
+        )}
         <Button type="submit" disabled={checking || !ready}>
           {checking ? "Checking…" : ready ? "Sign up!" : "Enter invite code…"}
         </Button>
-        {step.kind === "enter-code" && step.error && (
+        {codeError && (
           <p role="alert" className="text-base text-destructive">
-            {step.error}
+            {codeError}
           </p>
         )}
       </form>

--- a/tests/functional/client/signup-form.test.tsx
+++ b/tests/functional/client/signup-form.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  apiClient: { api: { invites: { ":code": { check: { $get: vi.fn() } } } } },
+}));
+vi.mock("@/lib/supabase/client", () => ({ createClient: vi.fn() }));
+
+import { SignupForm } from "@/app/signup/signup-form";
+
+describe("SignupForm — prefilled invite code (#419)", () => {
+  it("hides the code field when a complete code is prefilled from the link", () => {
+    render(<SignupForm initialCode="ABCDE12345" intro="welcome" />);
+    expect(screen.queryByLabelText("Invite code")).toBeNull();
+    expect(screen.getByRole("button", { name: "Sign up!" })).toBeVisible();
+  });
+
+  it("shows the code field when no code is supplied", () => {
+    render(<SignupForm initialCode="" intro="welcome" />);
+    expect(screen.getByLabelText("Invite code")).toBeVisible();
+  });
+
+  it("shows the code field when a prefilled code is incomplete", () => {
+    render(<SignupForm initialCode="ABC" intro="welcome" />);
+    expect(screen.getByLabelText("Invite code")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

When a member arrives via an invite link, the code is already in the URL (`/signup?code=…`), but the signup form still showed the code input — redundant friction (Kevin's feedback). Now the field is **hidden when the code is prefilled and complete**; the member just clicks "Sign up!".

Reveals the field again if the prefilled code is malformed/incomplete or the server rejects it (so they can fix it), and shows it as normal when someone reaches `/signup` with no code.

## Test plan

- [x] New `signup-form.test.tsx`: field hidden for a complete prefilled code; shown for no code; shown for an incomplete prefilled code.
- [x] Existing e2e signup flow unaffected (both tests use `/signup` with no code param and fill the field).
- [ ] CI lint + functional + e2e pass.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)