### PR TITLE
THROWAWAY: gate-test fixture — DO NOT MERGE (except as part of the merge-gate test)

### DIFF
--- a/docs/THROWAWAY-gate-test.md
+++ b/docs/THROWAWAY-gate-test.md
@@ -1,0 +1,12 @@
+# THROWAWAY — merge-confirmation gate test fixture
+
+This file is a disposable test fixture. It exists only to give a human a harmless
+PR to use when testing whether the `/ship` merge-confirmation gate
+(`"ask": ["Bash(gh pr merge *)", "PowerShell(gh pr merge *)"]` in
+`.claude/settings.json`) actually prompts a human on the FIRST `gh pr merge`
+of a brand-new Claude Code session.
+
+It touches no application, server, or schema code. If it is ever accidentally
+merged, delete this file — that is the entire revert.
+
+Do not build anything on top of this file. Throwaway.


### PR DESCRIPTION
## THROWAWAY — do not merge

This PR exists **only** as a low-stakes fixture for testing the `/ship`
merge-confirmation gate. **Do not merge it** except deliberately, as the final
step of that gate test.

### What it changes
Adds one harmless file: `docs/THROWAWAY-gate-test.md`. No app/server/schema
code, no `.claude/settings*.json`, no `SKILL.md`. If it ever merges by accident,
deleting that one file is the entire revert.

### Why it exists
We found the merge-confirmation gate is unreliable: the `ask` rule
`Bash(gh pr merge *)` in `.claude/settings.json` is supposed to prompt a human
before **every** merge, but within one long session a later merge (PR #460)
went through **silently** after an earlier merge had been approved.

Working hypothesis: approving a plain "Yes" on a `gh pr merge` prompt grants a
**session-scoped, in-memory allow** for that command pattern, so subsequent
merges in the **same session** are not re-prompted.

### How to use this fixture
1. Open a **brand-new** Claude Code session (fresh process — the in-memory
   session allow must be empty).
2. Run `/ship` against this PR.
3. Watch whether the harness shows the `Allow … gh pr merge …?` prompt on this
   fresh session's **first** merge.
4. When the prompt appears, click **Deny**. Do not actually merge.

Expected if the gate works: the prompt appears on the first merge of the fresh
session. The earlier silent #460 merge is explained by it being a *second*
merge in a session where an earlier "Yes" had already granted the in-memory
allow.