### PR TITLE
feat(myweb): show the member's photo in the relating dialog (#420)

### DIFF
--- a/src/app/myweb/relating-dialog.tsx
+++ b/src/app/myweb/relating-dialog.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import { useEffect, useState } from "react";
 
+import { Avatar } from "@/components/avatar";
 import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api";
 import type { RelationCandidatesFeed } from "@/lib/api-types";
@@ -22,6 +23,7 @@ import { RELATION_CANDIDATES_QUERY_KEY, RELATION_SUBGRAPH_QUERY_KEY, relationVal
 export type RelatingTarget = {
   id: string;
   displayName: string | null;
+  avatarUrl?: string | null;
   hintAttribution?: string | null;
   currentValue?: RelationValue | null;
 };
@@ -201,9 +203,16 @@ export function RelatingDialog({ target, onClose, onRelated, deferGraphCommit }:
           >
             <X className="h-4 w-4" />
           </Dialog.Close>
-          <Dialog.Title className="pr-8 font-heading text-base font-medium">
-            Who is <span className="font-semibold">{target?.displayName ?? "this member"}</span> to you?
-          </Dialog.Title>
+          <div className="flex items-center gap-2 pr-8">
+            <Avatar
+              name={target?.displayName ?? null}
+              url={target?.avatarUrl ?? null}
+              className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-sm font-semibold text-muted-foreground"
+            />
+            <Dialog.Title className="font-heading text-base font-medium">
+              Who is <span className="font-semibold">{target?.displayName ?? "this member"}</span> to you?
+            </Dialog.Title>
+          </div>
           {target?.hintAttribution && (
             <p id="relating-attribution" className="mt-1 text-sm text-muted-foreground">
               ({target.hintAttribution})

--- a/src/app/myweb/web-builder.tsx
+++ b/src/app/myweb/web-builder.tsx
@@ -39,6 +39,7 @@ const buildHintAttribution = (candidate: RelationCandidate): string | null => {
 const targetFromCandidate = (candidate: RelationCandidate): RelatingTarget => ({
   id: candidate.id,
   displayName: candidate.displayName,
+  avatarUrl: candidate.avatarUrl,
   hintAttribution: buildHintAttribution(candidate),
 });
 

--- a/tests/functional/client/relating-dialog.test.tsx
+++ b/tests/functional/client/relating-dialog.test.tsx
@@ -47,6 +47,13 @@ describe("RelatingDialog — No Relationship option", () => {
     expect(screen.queryByRole("button", { name: /No Relationship/ })).toBeNull();
   });
 
+  it("shows the member's avatar in the header (#420)", () => {
+    // No photo set → the Avatar falls back to initials, distinct from the
+    // "Who is Bao Tran to you?" title text.
+    renderDialog({ id: "m1", displayName: "Bao Tran" });
+    expect(screen.getByText("BT")).toBeVisible();
+  });
+
   it("removes via DELETE and closes the dialog on success", async () => {
     $delete.mockResolvedValue({ ok: true, json: async () => ({ ok: true }) } as never);
     const { onClose } = renderDialog({ id: "m1", displayName: "Ada", currentValue: 3 });


### PR DESCRIPTION
## Summary

Kevin's feedback: when selecting a member to relate to, only the name showed. The member *pickers* (the suggestion-card grid, the typeahead) already render avatars — the remaining name-only surface is the **relating dialog** itself ("Who is *X* to you?"). This adds the member's avatar there, so it's easy to confirm you're relating to the right person.

- `RelatingTarget` gains `avatarUrl`; the dialog header renders an `<Avatar>` (initials fallback when no photo).
- The candidate path (`web-builder`) passes `candidate.avatarUrl`. The graph-edge re-edit path has no avatar in its edge data, so it falls back to initials (graceful, per the issue).

## Test plan

- [x] `relating-dialog.test.tsx`: header renders the member's avatar (initials fallback).
- [x] Verified locally: My Web → click a suggestion card → the relating dialog shows the member's avatar next to the title.
- [x] Existing relating-dialog tests still pass; lint + typecheck clean.
- [ ] CI lint + functional + e2e pass.

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)