### PR TITLE
fix(admin): delete a member who redeemed an invite (#185 follow-up)

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-25 | Ola | Admins can delete a member account
+
+Admins permanently delete a member from `/admin/members` (#185, #454): clear avatar → clear the redemption pair on invites the member redeemed → delete the profile (FK cascade drops memberships/relations/hints, null-sets invite `created_by`) → delete the auth user. Profile-first because `profiles → auth.users` is `ON DELETE NO ACTION`; `deleteUser` is idempotent on a 404. The redemption-pair clear is load-bearing: `redeemed_by` is `ON DELETE SET NULL` but `redeemed_at` has no FK, so the cascade alone violates `invites_redemption_pair` and no onboarded member is deletable (caught post-merge on #454). Guards mirror `setAdminStatus` — no self-delete (use deactivate), no deleting a fellow admin.
+
 ## 2026-06-22 | James | Cut avatar Storage egress: longer signed-URL TTL + high optimizer cache TTL
 
 Avatar signed URLs rotate a `?token=` that's part of next/image's optimizer cache key, and the optimizer's default `minimumCacheTTL` is 4h — so every avatar's 1024² source was re-fetched from Storage daily (rotation) and again every 4h (expiry), blowing the free-plan egress quota during the Convening. Fix: `SIGN_TTL_SECONDS` 24h → 5 days, and `images.minimumCacheTTL` → 31 days (safe — object paths are immutable). The durable fix (a tokenless proxy route) stays open as #382.

--- a/src/server/members-admin.ts
+++ b/src/server/members-admin.ts
@@ -4,7 +4,7 @@ import { supabaseAdmin } from "@/lib/supabase/admin";
 
 import { attachAvatarUrls, clearAvatar } from "./avatars";
 import { db } from "./db";
-import { profiles } from "./schema";
+import { invites, profiles } from "./schema";
 import { E2E_EMAILS } from "./test-reset";
 
 export type AdminMember = {
@@ -112,6 +112,16 @@ export const deleteMemberAccount = async (
   // statement, so its cascade runs without a multi-statement transaction
   // over the pooler (docs/strategy-db-transactions.md).
   await clearAvatar(targetId);
+
+  // Clear the redemption pair on any invite this member redeemed before the
+  // profile delete. The redeemed_by FK is ON DELETE SET NULL, but redeemed_at
+  // has no FK, so the cascade alone would null one and leave the other —
+  // violating the invites_redemption_pair check ((redeemed_by IS NULL) =
+  // (redeemed_at IS NULL)) and aborting the whole DELETE. Since most members
+  // join via an invite, without this no normally-onboarded member is
+  // deletable. The invite reverts to unredeemed; its created_by survives.
+  await db.update(invites).set({ redeemedBy: null, redeemedAt: null }).where(eq(invites.redeemedBy, targetId));
+
   await db.delete(profiles).where(eq(profiles.id, targetId));
 
   const { error } = await supabaseAdmin.auth.admin.deleteUser(targetId);

--- a/tests/functional/server/admin-members-delete.test.ts
+++ b/tests/functional/server/admin-members-delete.test.ts
@@ -147,6 +147,39 @@ describe("DELETE /api/admin/members/:id", () => {
     await removeMember(other);
   });
 
+  it("deletes a member who redeemed an invite (redemption-pair check)", async () => {
+    // Regression for the #454 review: redeemed_by FK is ON DELETE SET NULL
+    // but redeemed_at has no FK, so the cascade alone leaves the pair
+    // inconsistent and the invites_redemption_pair check aborts the delete.
+    // Most members onboard by redeeming an invite, so this is the common case.
+    const inviter = randomUUID();
+    await insertMember(inviter, { displayName: "Inviter" });
+    await insertMember(target, { displayName: "Redeemer" });
+    const inviteId = randomUUID();
+    await db.insert(invites).values({
+      id: inviteId,
+      code: `code-${inviteId.slice(0, 8)}`,
+      createdBy: inviter,
+      note: "welcome",
+      expiresAt: new Date(Date.now() + 86_400_000),
+      redeemedBy: target,
+      redeemedAt: new Date(),
+    });
+
+    const res = await app.request(`/api/admin/members/${target}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+    expect(await profileExists(target)).toBe(false);
+    // The invite survives with its redemption cleared (pair stays consistent)
+    // and its creator intact.
+    const [invite] = await db.select().from(invites).where(eq(invites.id, inviteId));
+    expect(invite.redeemedBy).toBeNull();
+    expect(invite.redeemedAt).toBeNull();
+    expect(invite.createdBy).toBe(inviter);
+
+    await db.delete(invites).where(eq(invites.id, inviteId));
+    await removeMember(inviter);
+  });
+
   it("refuses self-delete with 403", async () => {
     const res = await app.request(`/api/admin/members/${admin}`, { method: "DELETE" });
     expect(res.status).toBe(403);


### PR DESCRIPTION
## Summary

Follow-up to #454 (admin account deletion). The claude-review bot flagged a real bug that merged unaddressed: **a member who redeemed an invite could not be deleted.**

`deleteMemberAccount` deleted the profile and leaned on the FK cascade. But `invites.redeemed_by` is `ON DELETE SET NULL` while `redeemed_at` has no FK — so the cascade nulls `redeemed_by`, leaves `redeemed_at`, and the `invites_redemption_pair` check (`(redeemed_by IS NULL) = (redeemed_at IS NULL)`) evaluates `TRUE = FALSE`, aborting the entire DELETE. **Since most members onboard by redeeming an invite, almost no member was actually deletable.**

Fix: clear the redemption pair (`redeemed_by` + `redeemed_at`) on those invites **before** the profile delete. The invite reverts to unredeemed; its `created_by` survives.

Also adds the `docs/devjournal.md` entry the review flagged as missing.

## Test plan

- [x] New regression test (member who redeemed an invite → delete succeeds, invite survives with the pair cleared). **Verified it fails without the fix** — `violates check constraint "invites_redemption_pair"` — and passes with it.
- [x] Full functional suite green (589); lint + typecheck clean.
- [ ] CI lint + functional + e2e pass.

Refs #454, #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)