### PR TITLE
chore: merge-gate test fixture A — add throwaway file (#463)

### DIFF
--- a/docs/gate-merge-test.md
+++ b/docs/gate-merge-test.md
@@ -1,0 +1,5 @@
+# Throwaway — /ship merge-gate test (#463)
+
+PR A adds this file; PR B deletes it. It exists only to test whether the harness `gh pr merge`
+confirmation prompt fires on a **2nd same-session merge**. Net change to `main` is zero. Safe to
+remove.


### PR DESCRIPTION
PR **A** of 2 for the #463 merge-gate test. Adds a throwaway `docs/gate-merge-test.md`.

The test (two `/ship` merges in one session): approve **this** merge, then attempt PR B (which deletes the file) in the **same** session and watch whether the harness `gh pr merge` prompt fires. Net change to `main` is zero. Do not merge except as part of that test.

Refs #463.