### PR TITLE
chore: merge-gate test fixture B — remove throwaway file (#463)

### DIFF
--- a/docs/gate-merge-test.md
+++ b/docs/gate-merge-test.md
@@ -1,5 +1,0 @@
-# Throwaway — /ship merge-gate test (#463)
-
-PR A adds this file; PR B deletes it. It exists only to test whether the harness `gh pr merge`
-confirmation prompt fires on a **2nd same-session merge**. Net change to `main` is zero. Safe to
-remove.


### PR DESCRIPTION
PR **B** of 2 for the #463 merge-gate test. Deletes the `docs/gate-merge-test.md` that PR A (#465) added — net change to `main` is zero.

**This is the observation merge.** With PR A already approved in the same session, running `/ship` here tests whether the harness `gh pr merge` prompt is suppressed:
- **No prompt (silent merge) → confirms** the once-per-session suppression.
- **Prompt → disproves** it (and the gate is fine).

Refs #463.