### PR TITLE
fix(setup): install Playwright Chromium in local setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Intentional Society web application — an authenticated app for a small, global
 
 ## Commands
 
-- `npm run setup` — one-time: generate `.env.local` with local Supabase defaults (idempotent)
+- `npm run setup` — one-time: generate `.env.local`, install Playwright Chromium, and apply local workflow setup (idempotent)
 - `npm run make_lane_inside_worktree` — one-time: turn the current git worktree into an isolated parallel "lane" (own Supabase stack + ports); see `docs/strategy-worktree-lanes.md`
 - `npm run dev` — start local Supabase (if needed) + dev server (http://localhost:3000)
 - `npm run build` — production build

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install
 npm run setup
 ```
 
-Generates `.env.local` with the deterministic local Supabase defaults. Safe to re-run.
+Generates `.env.local` with the deterministic local Supabase defaults, installs the Playwright Chromium browser for e2e tests, and applies local workflow setup. Safe to re-run.
 
 ### 4. Run
 

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-27 | Blake | Local setup installs Playwright Chromium
+
+`npm run setup` now installs the Playwright Chromium browser binary that local e2e tests require, so a fresh checkout that has run `npm install` and setup can run `npm test` without a separate browser-install step. The setup script remains the home for required local setup gaps plus selected defense-in-depth checks such as lefthook.
+
 ## 2026-06-25 | Ola | Admins can delete a member account
 
 Admins permanently delete a member from `/admin/members` (#185, #454): clear avatar → clear the redemption pair on invites the member redeemed → delete the profile (FK cascade drops memberships/relations/hints, null-sets invite `created_by`) → delete the auth user. Profile-first because `profiles → auth.users` is `ON DELETE NO ACTION`; `deleteUser` is idempotent on a 404. The redemption-pair clear is load-bearing: `redeemed_by` is `ON DELETE SET NULL` but `redeemed_at` has no FK, so the cascade alone violates `invites_redemption_pair` and no onboarded member is deletable (caught post-merge on #454). Guards mirror `setAdminStatus` — no self-delete (use deactivate), no deleting a fellow admin.

--- a/docs/doc-local-setup.md
+++ b/docs/doc-local-setup.md
@@ -32,13 +32,13 @@ npm install
 
 ---
 
-## Generate the local environment file
+## Run local setup
 
 ```bash
 npm run setup
 ```
 
-This creates `.env.local` with the deterministic defaults that the local Supabase stack uses. Safe to re-run — it skips the file if it already exists. The generated values:
+This creates `.env.local` with the deterministic defaults that the local Supabase stack uses, installs the Playwright Chromium browser binary for e2e tests, wires local git hooks, and applies small local git config. Safe to re-run — it skips the env file if it already exists and Playwright only downloads browsers when missing or outdated. The generated values:
 
 ```
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
@@ -132,6 +132,9 @@ Stopping is optional — the containers are lightweight and persist safely betwe
 
 **`.env.local` has wrong values**
 : Delete it and re-run `npm run setup` to regenerate from the known-good defaults.
+
+**Playwright says the browser executable does not exist**
+: Re-run `npm run setup`, or repair just the browser binary with `npx playwright install chromium`.
 
 ---
 

--- a/docs/setup-dev-machine.md
+++ b/docs/setup-dev-machine.md
@@ -109,4 +109,10 @@ We use [Claude Code](https://claude.ai/code) as our AI coding assistant, configu
 
 ---
 
-Once the prerequisites above are installed, clone the repo and run `npm install` followed by `npm run setup` to generate your local `.env.local` with the deterministic local Supabase defaults. Then `npm run dev`. See the [README](../README.md) for the full walkthrough.
+Once the prerequisites above are installed, clone the repo and run `npm install` followed by `npm run setup` to prepare the local checkout. Then `npm run dev`. See the [README](../README.md) for the full walkthrough.
+
+`npm run setup` creates `.env.local` with deterministic local Supabase defaults and installs the Playwright Chromium browser binary used by `npm test` and `npm run test:e2e`. That install is safe to re-run; Playwright only downloads when the expected browser is missing or outdated. If the browser install ever fails independently, repair it with:
+
+```bash
+npx playwright install chromium
+```

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 // One-time setup for new developers. Safe to re-run — every step is idempotent.
 // Extend by adding more step functions below and calling them from main().
+// This script is the canonical place for required local setup gaps that
+// `npm install` does not cover, plus selected defense-in-depth checks that keep
+// local workflow tooling reliable.
 
 import { spawnSync } from "node:child_process";
 import { copyFileSync, existsSync, readFileSync } from "node:fs";
@@ -11,9 +14,8 @@ const repoRoot = resolve(import.meta.dirname, "..");
 function ensureLefthookInstalled() {
   // Wires lefthook's binary into .git/hooks. Re-running is a no-op.
   // Note: lefthook's own postinstall already does this during `npm install`
-  // (skipped only when CI=true). Calling it here too is defense-in-depth +
-  // explicit documentation of intent — see PR #307 discussion and #285 for
-  // the broader "extra setup steps beyond npm install" policy question.
+  // (skipped only when CI=true). Calling it here too is deliberate
+  // defense-in-depth: missing hooks are a silent local quality failure.
   const result = spawnSync("npx", ["lefthook", "install"], {
     cwd: repoRoot,
     stdio: "inherit",
@@ -23,6 +25,22 @@ function ensureLefthookInstalled() {
     console.error("  lefthook install failed — pre-commit formatting will not run");
     process.exit(1);
   }
+}
+
+function ensurePlaywrightBrowsersInstalled() {
+  // Playwright's npm package does not install browser binaries. The e2e suite
+  // uses Chromium only, so keep setup lean by installing just that browser.
+  const result = spawnSync("npx", ["--no-install", "playwright", "install", "chromium"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    shell: true,
+  });
+  if (result.status !== 0) {
+    console.error("  playwright browser install failed — e2e tests will not run");
+    console.error("  Fix: run `npx playwright install chromium` and retry `npm run setup`.");
+    process.exit(1);
+  }
+  console.log("  Playwright Chromium browser installed/current");
 }
 
 function ensureGitBlameIgnoreConfig() {
@@ -131,14 +149,17 @@ function main() {
   console.log("1. Environment file");
   ensureLocalEnv();
 
-  console.log("\n2. Git hooks (lefthook)");
+  console.log("\n2. Playwright browser binaries");
+  ensurePlaywrightBrowsersInstalled();
+
+  console.log("\n3. Git hooks (lefthook)");
   ensureLefthookInstalled();
 
-  console.log("\n3. Git blame ignore-revs config");
+  console.log("\n4. Git blame ignore-revs config");
   ensureGitBlameIgnoreConfig();
 
   if (process.platform === "win32") {
-    console.log("\n4. Windows Supabase port reservation (advisory)");
+    console.log("\n5. Windows Supabase port reservation (advisory)");
     if (isBaseWorktree()) {
       checkWindowsSupabasePortReservation();
     } else {


### PR DESCRIPTION
Summary: Make local setup install the Playwright Chromium browser binary and document the updated setup behavior.

Why: New or refreshed developer machines can run `npm install` successfully but still fail `npm test` or `npm run test:e2e` because Playwright browser binaries are installed separately.

Behavior: `npm run setup` now installs the project Playwright Chromium browser with an explicit success/failure path, and setup docs describe the browser install plus the manual repair command.

Ticket alignment / deviations:
- Matches #285 Option A: setup docs explicitly cover Playwright browser installation.
- Matches #285 Option B: `npm run setup` installs Chromium, matching `playwright.config.ts`.
- Uses `spawnSync` instead of the ticket sample's `execSync` to stay consistent with existing `scripts/setup.mjs` style.
- Fails setup instead of warning and continuing, so a successful setup means the local e2e browser dependency is present.
- Uses `npx --no-install` so the project-installed Playwright version is used.

Test Plan:
- ran `npm test` locally

Closes #285

Note: AI co-author identity provided by human; auto-detection failed.

Co-Authored-By: GPT-5 Codex <noreply@unspecified>