### PR TITLE
test(e2e): mock /_next/image except the avatar canary

### DIFF
--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-30 | James | e2e stubs avatar image-optimizer fetches
+
+e2e mocks `/_next/image` except the avatar canary, to stop CI driving prod Storage egress.
+
 ## 2026-06-27 | Blake | Local preflight catches stale node_modules
 
 `scripts/ensure-deps.mjs` now checks npm's installed lockfile (`node_modules/.package-lock.json`) against the repo `package-lock.json` before local dev/test entry points invoke dependency binaries. `npm run dev` catches stale installs through `dev:db`; `npm test` catches them before Biome through `lint`. If a dependency changed since the last install, the fix is `npm install`. (#288)

--- a/tests/e2e/about.spec.ts
+++ b/tests/e2e/about.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from "@playwright/test";
-
+import { expect, test } from "./helpers/fixtures";
 import { completeWelcome, resetSeededUsers, signInAs, TIMEOUT_MS } from "./helpers/session";
 
 // Smoke coverage of the /about page: the sidebar link reaches it, and

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1,5 +1,4 @@
-import { expect, type Page, test } from "@playwright/test";
-
+import { expect, type Page, test } from "./helpers/fixtures";
 import { resetSeededUsers, signInAs } from "./helpers/session";
 
 // Smoke test for the admin surface: the seeded admin user can reach the

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./helpers/fixtures";
 
 test("unauthenticated visit to / shows logged-out home page", async ({ page }) => {
   await page.goto("/");

--- a/tests/e2e/avatar.spec.ts
+++ b/tests/e2e/avatar.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "@playwright/test";
 import sharp from "sharp";
 
+import { expect, test } from "./helpers/fixtures";
 import { completeWelcome, resetSeededUsers, signInAs } from "./helpers/session";
 
 // Profile-picture upload (#131): a member picks a photo, confirms the
@@ -8,6 +8,12 @@ import { completeWelcome, resetSeededUsers, signInAs } from "./helpers/session";
 // seeded user starting clean, so reset per-test.
 
 test.describe.configure({ mode: "serial" });
+
+// The canary: opt out of the suite-wide /_next/image stub so this spec
+// drives the real optimizer → Storage → render path end to end. The
+// naturalWidth assertion below would catch the optimizer rejecting the
+// upstream image (e.g. #469). See tests/e2e/helpers/fixtures.ts.
+test.use({ mockImages: false });
 
 test.beforeEach(async ({ baseURL }) => {
   if (!baseURL) throw new Error("avatar.spec.ts: baseURL is not configured");

--- a/tests/e2e/breadcrumb.spec.ts
+++ b/tests/e2e/breadcrumb.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from "@playwright/test";
-
+import { expect, test } from "./helpers/fixtures";
 import { completeWelcome, resetSeededUsers, signInAs, TIMEOUT_MS } from "./helpers/session";
 
 // Exercises the history-aware breadcrumb back link from #274. /me

--- a/tests/e2e/helpers/fixtures.ts
+++ b/tests/e2e/helpers/fixtures.ts
@@ -1,0 +1,37 @@
+// Shared e2e `test`: re-exports `expect`/`Page` unchanged, so a spec adopts the
+// suite-wide fixtures by importing from here instead of "@playwright/test" with
+// no other edit. The one fixture stubs `/_next/image` — see below.
+import { test as base } from "@playwright/test";
+
+export type { Page } from "@playwright/test";
+export { expect } from "@playwright/test";
+
+// 1×1 transparent GIF — the ubiquitous tracking-pixel bytes. Returned for
+// every `/_next/image` request the browser makes (see the `page` override).
+const PIXEL_GIF = Buffer.from("R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7", "base64");
+
+// Avatars are the app's only `<Image>`. Rendering one through `next/image`
+// makes the browser hit `/_next/image`, which invokes Vercel's optimizer,
+// which fetches the avatar's full master from Supabase Storage. CI shares the
+// preview→prod Supabase, every preview deploy starts with a cold optimizer
+// cache, and e2e then loads the directory/web-graph on every run — so the
+// suite re-fetches every avatar's master from prod Storage on each run. That
+// was ~60% of avatar Storage egress (docs/design-profile-pictures.md, #382).
+//
+// Fulfilling `/_next/image` in the browser short-circuits that whole chain:
+// the optimizer is never invoked, so Storage is never hit. It's a harness-only
+// stub — the app builds and runs byte-identical; we've only told the browser
+// under test to use a pixel. The real optimizer→Storage→render path is still
+// covered for real by the opt-out canary (avatar.spec.ts sets
+// `test.use({ mockImages: false })`), which asserts naturalWidth > 0.
+export const test = base.extend<{ mockImages: boolean }>({
+  mockImages: [true, { option: true }],
+  page: async ({ page, mockImages }, use) => {
+    if (mockImages) {
+      await page.route(/\/_next\/image/, (route) =>
+        route.fulfill({ status: 200, contentType: "image/gif", body: PIXEL_GIF }),
+      );
+    }
+    await use(page);
+  },
+});

--- a/tests/e2e/invites.spec.ts
+++ b/tests/e2e/invites.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from "@playwright/test";
-
+import { expect, test } from "./helpers/fixtures";
 import { completeWelcome, resetSeededUsers, signInAs, TIMEOUT_MS } from "./helpers/session";
 
 // These tests exercise the authed invite UI end-to-end against the

--- a/tests/e2e/me.spec.ts
+++ b/tests/e2e/me.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from "@playwright/test";
-
+import { expect, test } from "./helpers/fixtures";
 import { completeWelcome, resetSeededUsers, signInAs, TIMEOUT_MS } from "./helpers/session";
 
 // The /me page (#376): anchor-linked Profile/Settings tabs, the

--- a/tests/e2e/myweb.spec.ts
+++ b/tests/e2e/myweb.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from "@playwright/test";
-
+import { expect, test } from "./helpers/fixtures";
 import { completeWelcome, resetSeededUsers, signInAs, TIMEOUT_MS } from "./helpers/session";
 
 // Smoke coverage of /myweb's wiring: page loads, the WebBuilder

--- a/tests/e2e/page-titles.spec.ts
+++ b/tests/e2e/page-titles.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from "@playwright/test";
-
+import { expect, test } from "./helpers/fixtures";
 import { completeWelcome, resetSeededUsers, signInAs } from "./helpers/session";
 
 // Every page sets a distinct <title> ("IS Web: <page>") so the browser

--- a/tests/e2e/password-reset.spec.ts
+++ b/tests/e2e/password-reset.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from "@playwright/test";
-
+import { expect, test } from "./helpers/fixtures";
 import { signInAs } from "./helpers/session";
 
 // Password-reset flow. Like the other auth specs, Supabase's auth

--- a/tests/e2e/session-helper.spec.ts
+++ b/tests/e2e/session-helper.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from "@playwright/test";
-
+import { expect, test } from "./helpers/fixtures";
 import { expectAuthed, signInAs } from "./helpers/session";
 
 // Sanity test for the session helper itself. Signed-in specs build on

--- a/tests/e2e/signin-password.spec.ts
+++ b/tests/e2e/signin-password.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./helpers/fixtures";
 
 // /signin is public, so these tests run without a session. The Supabase
 // auth endpoints are intercepted at the Playwright level, which lets us

--- a/tests/e2e/signout.spec.ts
+++ b/tests/e2e/signout.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from "@playwright/test";
-
+import { expect, test } from "./helpers/fixtures";
 import { completeWelcome, signInAs, TIMEOUT_MS } from "./helpers/session";
 
 test("sign-out button signs the user out and lands on /signin", async ({ page }) => {

--- a/tests/e2e/version-update.spec.ts
+++ b/tests/e2e/version-update.spec.ts
@@ -1,5 +1,4 @@
-import { expect, type Page, test } from "@playwright/test";
-
+import { expect, type Page, test } from "./helpers/fixtures";
 import { completeWelcome, resetSeededUsers, signInAs, TIMEOUT_MS } from "./helpers/session";
 
 // The live-deploy update UX (docs/strategy-deployment.md): the bottom

--- a/tests/e2e/welcome.spec.ts
+++ b/tests/e2e/welcome.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from "@playwright/test";
-
+import { expect, test } from "./helpers/fixtures";
 import { resetSeededUsers, signInAs, TIMEOUT_MS } from "./helpers/session";
 
 // The multi-step welcome flow (#166): a fresh user is routed through


### PR DESCRIPTION
Summary: Stub /_next/image in the e2e harness so specs render without
invoking Vercel's image optimizer, which fetches avatars from prod
Storage on every CI run.

Why: CI is a large share of traffic and a driver of avatar Storage
egress — preview shares prod Supabase, each preview deploy starts with a
cold optimizer cache, and the suite loads avatar-heavy pages every run.
Part of #382.

Behavior: A shared tests/e2e/helpers/fixtures.ts `test` fulfills browser
/_next/image requests with a stub image; specs import it instead of
@playwright/test. avatar.spec.ts opts out (test.use({ mockImages:
false })) to keep the real optimizer→Storage→render path covered.
Harness only.

Test Plan:
- ran `npm test` locally (37 e2e passed)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
