### PR TITLE
ci: quarantine sharp from the dependabot minor-and-patch batch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,13 @@ updates:
       # PR per transitively-related package. Majors still land as their
       # own PRs so the breaking-change review happens in isolation.
       minor-and-patch:
+        # sharp is quarantined into its own PR, not ignored: 0.35.x corrupts
+        # uploaded avatars on Vercel (#469) and fails e2e every week. Isolating
+        # it keeps the rest of the batch mergeable while leaving a standalone
+        # sharp PR whose e2e status tells us the moment the corruption is fixed
+        # upstream — then drop this exclude and merge the bump.
+        exclude-patterns:
+          - "sharp"
         update-types:
           - patch
           - minor

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-06-30 | James | Dependabot quarantines `sharp` into its own weekly PR
+
+`sharp` now opens as a standalone Dependabot PR (excluded from the `minor-and-patch` group) instead of reddening the whole weekly batch, because 0.35.x corrupts uploaded avatars on Vercel (#469); it's a quarantine, not an `ignore`, so the isolated PR's e2e status still signals when the bump is safe to adopt.
+
 ## 2026-06-30 | James | e2e stubs avatar image-optimizer fetches
 
 e2e mocks `/_next/image` except the avatar canary, to stop CI driving prod Storage egress.


### PR DESCRIPTION
Summary: Exclude sharp from the minor-and-patch Dependabot group so it
opens as its own weekly PR instead of failing the whole batch.

Why: sharp 0.35.x corrupts uploaded avatars on Vercel (#469) and fails
the avatar e2e every week; it's held at 0.34.5. With no isolation, that
one broken dep reddens the entire minor-and-patch batch and blocks the
other safe bumps. An outright ignore would hide the bump indefinitely,
so we'd lose the signal for when it's fixed upstream.

Behavior: Dependabot opens a standalone sharp PR each week (deps excluded
from all groups get individual PRs); the rest of the batch stays green
and mergeable. The sharp PR's e2e status flags when 0.35.x is safe to
adopt — then drop the exclude and merge the bump.

Rollout: once this merges, `@dependabot recreate` on #478 rebuilds the
current batch without sharp (green, mergeable) and Dependabot opens the
standalone sharp PR.

Test Plan:
- ran `npm test` locally — lint, typecheck, vitest, and all 37 Playwright
  e2e passed (2.5m)

(#469)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
