### PR TITLE
chore(149): correct the writeups; alarm silent redemption loss

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,10 @@ on:
 # Serialize e2e across all branches: the suite runs against the shared prod
 # Supabase DB and drives two fixed seeded accounts, resetting their state
 # mid-run. Two overlapping runs clobber each other's accounts and fail (#358).
-# A single global group queues runs instead; cancel-in-progress: false so no
-# deploy loses its e2e result.
+# A single global group queues runs instead; cancel-in-progress: false lets a
+# running suite finish. GitHub keeps one queued run per group, so when deploys
+# stack up the superseded queued runs are cancelled — the newest deploy still
+# gets its result.
 concurrency:
   group: e2e-shared-prod-db
   cancel-in-progress: false

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-07-02 | James | #149 closed — the residual flake was CI concurrency; `prepare: false` did nothing
+
+Retro-analysis of every #149-signature e2e failure: after #173 dropped the reset's `db.transaction`, every remaining failure on a trusted branch coincided with an overlapping e2e run — #358's clobber, fixed by the concurrency group on 2026-06-21, zero recurrences since. `prepare: false` (#296) showed no effect and stays only because it's harmless. The pooler-transaction hazard evidence is scoped to the mid-May probe captures (real, unreproduced since); `strategy-db-transactions.md` corrected, probe teardown filed as #486. The auth callback keeps its transaction by decision, now alarmed on both failure shapes: the existing Sentry capture for loud aborts plus a new post-commit read-back that raises a Sentry error if a redemption silently vanishes.
+
 ## 2026-07-02 | Blake | Required structural gate for the team Skills
 
 A new `functional-skills` Vitest project (`tests/functional/skills/skill-contract.test.ts`) holds `/commit`, `/pr`, and `/ship` to their SKILL.md structure — frontmatter, invocation policy, section order, ≥3 evals each — so a structural break now fails the required `Lint & Functional Tests` check (skill-creator, vendored upstream, is exempt). (#396)

--- a/docs/strategy-db-transactions.md
+++ b/docs/strategy-db-transactions.md
@@ -6,9 +6,14 @@ pooler. **Read this before adding any `db.transaction(...)` call.**
 ## TL;DR — the rule
 
 The default `db` client (`src/server/db.ts`) connects through the Supabase
-**transaction pooler**. A multi-statement `BEGIN…COMMIT` over that pooler can be
-**silently mishandled**: the writes disappear with no error while the
-transaction still reports success, or it aborts part-way through.
+**transaction pooler**. In May 2026 we observed a multi-statement
+`BEGIN…COMMIT` over that pooler being **silently mishandled**: writes
+disappearing with no error while the transaction still reported success, and
+the loud sibling — aborting part-way through with `25P02`. The anomaly has not
+reproduced since and its mechanism was never confirmed, but the failure mode is
+silent data loss and the safe patterns below are cheap — so we treat the
+combination as unsafe **by policy**, not because the bug is known to still
+exist.
 
 So:
 
@@ -29,33 +34,39 @@ transaction pooler — nothing else.*
 ## Background — why this doc exists (the #149 investigation)
 
 `#149` was an intermittent e2e failure: Playwright's `waitForURL('/welcome')`
-timed out after 20s, seemingly at random, for weeks. The investigation ran long
-and took several false starts — RSC streaming, the Next.js router, caching, and
-read replicas were all chased and ruled out.
+timed out, seemingly at random, for weeks. The investigation ran long and took
+several false starts — RSC streaming, the Next.js router, caching, and read
+replicas were all chased and ruled out. It resolved into **two separate bugs
+sharing one symptom** (a welcome-flow read seeing profile state the e2e reset
+had just cleared, so `/` skipped the redirect to `/welcome`):
 
-The actual chain:
+**Bug 1 — the reset's `db.transaction` intermittently lost its writes**
+(May 2026). `resetE2EUsers` wrapped its `DELETE` + `UPDATE` in a
+`db.transaction(...)` over the transaction pooler. A diagnostic probe caught
+the reset returning **HTTP 200 with a stale `bio`** — the UPDATE's `RETURNING`
+reported the row touched, yet the read-back milliseconds later saw the old
+value with an `updated_at` older than the reset. Production logs (Axiom) also
+showed the *loud* variant: `POST /api/_test/reset` returning 500 with a
+Postgres `25P02` ("current transaction is aborted") error. The reset never
+needed atomicity, so #173 replaced the transaction with two plain autocommit
+statements. The probe's anomaly assertion — still armed in
+`tests/e2e/helpers/session.ts` — has been silent across thousands of resets
+since 2026-05-16.
 
-- The e2e suite resets two seeded users between tests via
-  `POST /api/_test/reset` → `resetE2EUsers()`, which wiped `profiles` fields
-  including `bio`.
-- The `/` route redirects to `/welcome` when `bio` is null. Tests rely on the
-  reset having nulled `bio`.
-- `resetE2EUsers` wrapped its `DELETE` + `UPDATE` in a `db.transaction(...)`.
-- Intermittently that transaction **did not persist** — the reset returned HTTP
-  200, but `bio` was never cleared. The next test signed in, `/` saw a stale
-  non-null `bio`, did not redirect, and `waitForURL('/welcome')` hung for 20s.
+**Bug 2 — concurrent e2e runs clobbering each other** (every remaining #149
+failure, May–June 2026). The suite drives two fixed seeded accounts in the
+shared prod DB, and `e2e.yml` had no concurrency control — so two deploys
+minutes apart ran two suites at once, and one run's reset/welcome writes landed
+mid-test in the other. Retro-analysis showed every #149-signature failure on a
+trusted branch after #173 coincided with an overlapping run. This mechanism
+produced the "impossible" traces (a write visible to one read, gone from the
+next) that were chased as pooler stale-read anomalies — the database behaved
+correctly the whole time; the unmodeled writer was the other CI run. Fixed by
+#358: a global concurrency group in `e2e.yml` serializes e2e runs.
 
-A diagnostic probe added to `resetE2EUsers` caught the failure with the reset
-endpoint returning **200 and a stale `bio`** — the transaction reporting success
-while its write was gone. Production logs (Axiom) also showed the *loud*
-variant: `POST /api/_test/reset` returning 500 with a Postgres `25P02`
-("current transaction is aborted") error.
-
-The fix for the reset: it never needed atomicity, so `db.transaction` was
-dropped in favour of two plain autocommit statements. `#149` stopped.
-
-But the same `db.transaction`-over-the-pooler hazard applies to *real*
-application transactions. This doc exists so those are written safely.
+Bug 1 is why this doc exists: the same `db.transaction`-over-the-pooler hazard
+applies to *real* application transactions, so those are written safely by
+construction.
 
 ## The mechanism
 
@@ -80,7 +91,10 @@ watches the wire for `BEGIN` and `COMMIT` to know when to pin and release.
 To run `BEGIN; stmt; stmt; COMMIT` correctly, transaction mode must pin **one**
 backend for the whole sequence. When that pinning desyncs — statements routed to
 different backends, or the `COMMIT` not reaching the backend that holds the
-writes — the transaction is mishandled. Observed results:
+writes — the transaction is mishandled. The desync itself is our working model,
+never confirmed from traces (see
+[What we are and aren't sure of](#what-we-are-and-arent-sure-of)); the two
+result shapes below were observed directly:
 
 - **Silent discard** — the transaction appears to commit (no error; `RETURNING`
   even returns row data), but the writes were never persisted.
@@ -96,11 +110,17 @@ implicit transaction, atomically. Single statements are immune.
 
 - **Sure:** `resetE2EUsers`' `db.transaction` intermittently failed to persist
   (probe-observed: HTTP 200 + stale data) and intermittently aborted with
-  `25P02` (Axiom-observed). Dropping the transaction fixed it.
+  `25P02` (Axiom-observed). Dropping the transaction fixed it: the read-back
+  assertion has stayed silent since 2026-05-16.
+- **Sure:** every `#149`-signature failure *after* the transaction was dropped
+  was cross-run clobbering (#358), fixed by serializing e2e runs — those
+  failures say nothing about the pooler.
 - **Working model, not proven:** the precise trigger — the *first* error that
   aborted the transaction — was never captured in logs. The backend-split
   explanation above is the most coherent fit but is not confirmed from our own
-  traces.
+  traces. The direct evidence is the mid-May 2026 probe captures; the anomaly
+  never reproduced after #173, and Supavisor is a managed component that
+  changes underneath us, so whether the hazard still exists today is unknown.
 - **Related, not identical:** [supabase/supabase#43753](https://github.com/supabase/supabase/issues/43753)
   reports transaction-pooler transactions silently discarding writes. It is
   filed for `SERIALIZABLE` isolation and is untriaged; our transactions run
@@ -220,6 +240,10 @@ lives in a migration rather than TypeScript.
 
 ### 3. The `dbTx` client — session pooler (when logic must stay in TS)
 
+**Status: design, not yet wired.** Nothing in `src/` defines `dbTx` or
+`SESSION_DATABASE_URL` today — implement the client below and add the env var
+(Vercel + `.env.local`) before first use.
+
 When neither of the above fits and the logic must stay in TypeScript with
 `db.transaction(...)`, run it over a **second client pointed at the session
 pooler**, where multi-statement transactions are sound:
@@ -258,8 +282,9 @@ await db.transaction(async (tx) => {
 });
 ```
 
-This is the `#149` bug. A single `await db.insert(...)` is fine; the
-`transaction` wrapper around multiple statements is not.
+This is the bug that hit `resetE2EUsers` (#149, bug 1). A single
+`await db.insert(...)` is fine; the `transaction` wrapper around multiple
+statements is not.
 
 ## Connection options reference
 
@@ -271,14 +296,16 @@ This is the `#149` bug. A single `await db.insert(...)` is fine; the
 | Serverless-safe | ❌ exhausts connections | ⚠️ only with small `max` + `idle_timeout` | ✅ |
 | Multi-statement txns | ✅ sound | ✅ sound | ⚠️ can be mishandled |
 | Prepared statements | ✅ | ✅ | ⚠️ partial (Supavisor-emulated) |
-| In this app | unused | `dbTx` (`SESSION_DATABASE_URL`) | `db` (`DATABASE_URL`) |
+| In this app | unused | pattern 3 (design — not yet wired) | `db` (`DATABASE_URL`) |
 
 postgres-js options worth knowing: `max` (pool size), `idle_timeout` (close idle
 connections — the key to bounding session-mode backends), `prepare` (defaults
 true; harmless on the transaction pooler in practice — Supavisor emulates
-prepared-statement support). The default `db` client nonetheless sets
-`prepare: false` as a #149 variable-reduction measure, kept after the 2026-06
-audit found the redemption path clean under it — see the comment in `db.ts`.
+prepared-statement support). The default `db` client sets `prepare: false`,
+adopted mid-investigation as a #149 isolation experiment (#296). The A/B
+answered "not a factor": the failure signature continued unchanged until #358's
+concurrency fix. It stays because it costs nothing and reverting would
+re-introduce a variable — see the comment in `db.ts`.
 
 ## Recognizing this in the wild
 
@@ -297,11 +324,13 @@ Keep this current as transactions are added or changed.
 |---|---|
 | `resetE2EUsers` (`src/server/test-reset.ts`) | Fixed — `db.transaction` dropped; two autocommit statements (it never needed atomicity). |
 | `createInvite` (`src/server/invites.ts`) | Hardened — pattern 1 (writable CTE): invite + hint rows written in one statement, no transaction. |
-| invited sign-in (`src/app/auth/callback/route.ts`) | Exposed but monitored — multi-statement txn (profile insert + invite redemption + relations). A 2026-06 audit found **zero** occurrences across all 22 prod redemptions (DB integrity check), a normal auth/profile gap, and an empty Sentry `25P02` history; the redirect is now instrumented (`log.warn "invite redemption failed"`, queryable in Axiom). Left as-is under `prepare: false`; pattern 2 (a `redeem_invite` function) is the fix if it ever fires. |
+| invited sign-in (`src/app/auth/callback/route.ts`) | Accepted risk, alarmed (decision 2026-07-02) — multi-statement txn (profile insert + invite redemption + relations) kept as-is. Monitoring covers both failure shapes: loud aborts hit `Sentry_captureException` (tags `feature:auth-callback`) plus an Axiom `invite redemption failed` line with `pgCode`; silent discard is caught by a post-commit read-back of the invite's `redeemed_by`, which raises a Sentry error on mismatch. A 2026-06 audit found zero anomalies across all 22 prod redemptions. Pattern 2 (a `redeem_invite` function) is the harden path if the alarm ever fires. |
 
 ## References
 
-- Issue `#149` — the full investigation trail.
+- Issue `#149` — the full investigation trail (closing comment has the
+  two-bug retro-analysis).
+- Issue `#358` — the cross-run clobber mechanism and the e2e concurrency fix.
 - [supabase/supabase#43753](https://github.com/supabase/supabase/issues/43753)
   — transaction pooler silently discards writes.
 - [Supabase: disabling prepared statements](https://supabase.com/docs/guides/troubleshooting/disabling-prepared-statements-qL8lEL).

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,4 +1,4 @@
-import { captureException as Sentry_captureException } from "@sentry/nextjs";
+import { captureException as Sentry_captureException, captureMessage as Sentry_captureMessage } from "@sentry/nextjs";
 import { and, eq, gt, isNull, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 import { log } from "next-axiom";
@@ -250,6 +250,27 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   if (!result) {
     return NextResponse.redirect(new URL("/signin?error=profile_error", request.url), 303);
+  }
+
+  // #149 read-back alarm — the pooler hazard's silent mode reports
+  // success while the writes vanish, so no catch block can see it. One
+  // post-commit SELECT (its own statement → fresh pooled connection)
+  // verifies the redemption persisted; a mismatch raises a Sentry
+  // error. Alarm only: the member's session is valid either way, and
+  // blocking the redirect wouldn't recover anything.
+  const [readBack] = await db.select({ redeemedBy: invites.redeemedBy }).from(invites).where(eq(invites.code, invite));
+  if (readBack?.redeemedBy !== userId) {
+    Sentry_captureMessage("invite redemption lost after commit (#149-class silent discard)", {
+      level: "error",
+      tags: { feature: "auth-callback", path: "invite-redemption-readback" },
+      extra: { inviteCode: invite, userId, redeemedBy: readBack?.redeemedBy ?? null },
+    });
+    log.error("invite redemption read-back mismatch", {
+      inviteCode: invite,
+      userId,
+      redeemedBy: readBack?.redeemedBy ?? null,
+    });
+    await log.flush();
   }
 
   // Auto-subscribe runs outside the redemption transaction: it is

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -20,14 +20,12 @@ declare global {
   var __pgClient: ReturnType<typeof postgres> | undefined;
 }
 
-// `prepare: false` — kept deliberately. Supavisor's transaction-pooler
-// prepared-statement support is only "partial" (Supabase FAQ +
-// supavisor#239); dropping prepared statements removes a plausible #149
-// aggravator (postgres-js re-preparing against rotating backends) at no
-// measured cost — Supavisor emulates them anyway. A 2026-06 audit of the
-// auth-callback redemption path found zero #149 occurrences in prod under
-// this setting, so we keep it rather than re-introduce the variable.
-// See docs/strategy-db-transactions.md.
+// `prepare: false` — adopted as a #149 isolation experiment (#296). The A/B
+// answered "not a factor": the #149 failure signature continued unchanged
+// until the real fix (#358, e2e run serialization). Kept because it costs
+// nothing — Supavisor emulates prepared statements on the transaction pooler
+// anyway (Supabase FAQ + supavisor#239) — and reverting would re-introduce a
+// variable for no measured gain. See docs/strategy-db-transactions.md.
 const client = globalThis.__pgClient ?? postgres(connectionString, { prepare: false });
 if (process.env.NODE_ENV !== "production") {
   globalThis.__pgClient = client;

--- a/src/server/invites.ts
+++ b/src/server/invites.ts
@@ -113,8 +113,9 @@ export const createInvite = async (params: {
   //
   // The invite and its hint rows are written in a single statement (a
   // writable CTE), not a db.transaction: a multi-statement transaction
-  // over the Supabase transaction pooler can be silently discarded.
-  // See docs/strategy-db-transactions.md.
+  // over the Supabase transaction pooler was observed silently
+  // discarding its writes (May 2026, #149). See
+  // docs/strategy-db-transactions.md.
   for (let attempt = 0; attempt < 3; attempt++) {
     const code = generateInviteCode();
     try {

--- a/src/server/test-reset.ts
+++ b/src/server/test-reset.ts
@@ -63,8 +63,8 @@ export const resetE2EUsers = async (): Promise<{
   // Two separate autocommit statements rather than db.transaction:
   // delete-then-wipe needn't be atomic for a test reset, and a
   // multi-statement BEGIN/COMMIT over the Supabase transaction pooler
-  // can have its writes silently dropped while still reporting success
-  // (cf. supabase/supabase#43753) — the leading suspect for #149.
+  // was observed here (May 2026, #149 bug 1; cf. supabase/supabase#43753)
+  // silently dropping its writes while still reporting success.
   await db.delete(invites).where(inArray(invites.createdBy, ids));
   const updated = await db
     .update(profiles)


### PR DESCRIPTION
Summary: Correct every #149 writeup to the two-bug resolution
(transaction write-loss fixed by #173; the residual flake was #358's
cross-run clobber) and add a post-commit read-back alarm covering the
auth callback's remaining transaction.

Why: The #149 retro-analysis showed every post-#173 failure coincided
with an overlapping e2e run and that `prepare: false` (#296) had no
observable effect — but the strategy doc and code comments stated the
pooler hazard as an established ongoing property and implied the
experiment was validated. The auth callback keeps its multi-statement
transaction by decision (2026-07-02), conditional on monitoring that
alerts on failure; the silent-discard shape had no detector.

Behavior: Docs: strategy-db-transactions.md gets the two-bug
background, working-model framing for the pooler mechanism, pattern 3
marked "design, not yet wired", and an inventory row recording the
accepted-risk decision; comment corrections in db.ts, e2e.yml,
test-reset.ts, invites.ts; new devjournal entry. One runtime change:
after a successful invite-redemption transaction, the auth callback
re-reads the invite's redeemed_by on a fresh pooled connection and
raises a Sentry error + Axiom log.error on mismatch — alarm only, the
member flow is unchanged.

Test Plan:
- ran `npm test` locally (lint clean; 614 functional + 37 e2e, all passing)
- `npx tsc --noEmit` clean

(#149, #358, #486)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtGEsqBuwZyHmjHakVkvWw
