### PR TITLE
ci(skills): monthly drift check for vendored skill-creator

### DIFF
--- a/.github/workflows/skill-creator-drift.yml
+++ b/.github/workflows/skill-creator-drift.yml
@@ -1,0 +1,91 @@
+name: skill-creator drift check
+
+# Monthly freshness check for the vendored `.claude/skills/skill-creator/` copy.
+# Dependabot can't watch a vendored directory, so this runs the repo's own
+# `update-skill-creator.mjs --check` (pinned SHA in UPSTREAM.md vs upstream) and
+# opens ONE tracking issue when upstream has moved ahead — labeled
+# `dependencies` + `skill-creator-drift`, mirroring Dependabot's
+# dependencies+qualifier labeling; the qualifier label is also the dedup key.
+# Read-only toward the repo: it never edits files or opens a PR — refreshing
+# stays the deliberate, human-run `update-skill-creator.mjs` + reviewed /commit.
+# See docs/plan-skill-creator-vendoring.md (PR 3) and docs/doc-skill-creator.md.
+
+on:
+  schedule:
+    - cron: "7 5 1 * *" # 05:07 UTC on the 1st of each month (:07 dodges the :00 scheduling rush)
+  workflow_dispatch: {} # manual: gh workflow run skill-creator-drift.yml
+
+permissions:
+  contents: read
+  issues: write
+
+# One run at a time; never cancel a mid-flight check (they're seconds long).
+concurrency:
+  group: skill-creator-drift
+  cancel-in-progress: false
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Check vendored skill-creator against upstream
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          out="$(node scripts/update-skill-creator.mjs --check 2>&1)"
+          code=$?
+          set -e
+          printf '%s\n' "$out"
+
+          if [ "$code" -eq 0 ]; then
+            echo "Vendored skill-creator is current — nothing to do."
+            exit 0
+          fi
+          if [ "$code" -ne 2 ]; then
+            echo "::error::update-skill-creator.mjs --check failed (exit $code) — fix the check before trusting drift results"
+            exit 1
+          fi
+
+          # Behind upstream. Ensure the qualifier label exists (idempotent: if it
+          # already exists this fails and we move on; if creation genuinely failed,
+          # `gh issue create --label` below fails loudly).
+          gh label create skill-creator-drift \
+            --description "Vendored skill-creator copy is behind upstream" \
+            --color 0366d6 2>/dev/null || true
+
+          # Dedup by label, FAIL-CLOSED: if the query itself errors we abort red
+          # rather than risk opening a duplicate issue.
+          open_count="$(gh issue list --state open --label skill-creator-drift --json number --jq 'length')" || {
+            echo "::error::dedup query failed — aborting instead of risking a duplicate issue"
+            exit 1
+          }
+          if [ "$open_count" -gt 0 ]; then
+            echo "A skill-creator-drift issue is already open — not duplicating."
+            exit 0
+          fi
+
+          cat > issue-body.md <<'STATIC'
+          The vendored `.claude/skills/skill-creator/` copy has fallen behind upstream.
+
+          Refresh with `node scripts/update-skill-creator.mjs`, review the diff, run the
+          acceptance evals (`evals/skill-creator.evals.json`), and ship via /commit.
+          See docs/doc-skill-creator.md.
+
+          STATIC
+          {
+            echo '```'
+            printf '%s\n' "$out"
+            echo '```'
+            echo
+            echo "_Opened automatically by \`.github/workflows/skill-creator-drift.yml\` (monthly)._"
+          } >> issue-body.md
+
+          gh issue create \
+            --title "skill-creator vendored copy is behind upstream" \
+            --label dependencies --label skill-creator-drift \
+            --body-file issue-body.md

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,13 +4,13 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
-## 2026-07-02 | James | #149 closed — the residual flake was CI concurrency; `prepare: false` did nothing
-
-Retro-analysis of every #149-signature e2e failure: after #173 dropped the reset's `db.transaction`, every remaining failure on a trusted branch coincided with an overlapping e2e run — #358's clobber, fixed by the concurrency group on 2026-06-21, zero recurrences since. `prepare: false` (#296) showed no effect and stays only because it's harmless. The pooler-transaction hazard evidence is scoped to the mid-May probe captures (real, unreproduced since); `strategy-db-transactions.md` corrected, probe teardown filed as #486. The auth callback keeps its transaction by decision, now alarmed on both failure shapes: the existing Sentry capture for loud aborts plus a new post-commit read-back that raises a Sentry error if a redemption silently vanishes.
-
 ## 2026-07-02 | Blake | Monthly drift check for the vendored skill-creator
 
 A new `skill-creator drift check` workflow (`.github/workflows/skill-creator-drift.yml`, monthly + manual dispatch) compares the vendored `.claude/skills/skill-creator/` pin against upstream and opens a single tracking issue (labels `dependencies` + `skill-creator-drift`) when it falls behind; refreshing stays the human-run `update-skill-creator.mjs` + reviewed `/commit`. Replaces the previously planned `/commit` Step 14 reminder, which only fired on refresh commits and couldn't detect upstream movement. (#396)
+
+## 2026-07-02 | James | #149 closed — the residual flake was CI concurrency; `prepare: false` did nothing
+
+Retro-analysis of every #149-signature e2e failure: after #173 dropped the reset's `db.transaction`, every remaining failure on a trusted branch coincided with an overlapping e2e run — #358's clobber, fixed by the concurrency group on 2026-06-21, zero recurrences since. `prepare: false` (#296) showed no effect and stays only because it's harmless. The pooler-transaction hazard evidence is scoped to the mid-May probe captures (real, unreproduced since); `strategy-db-transactions.md` corrected, probe teardown filed as #486. The auth callback keeps its transaction by decision, now alarmed on both failure shapes: the existing Sentry capture for loud aborts plus a new post-commit read-back that raises a Sentry error if a redemption silently vanishes.
 
 ## 2026-07-02 | Blake | Required structural gate for the team Skills
 

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -8,6 +8,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 Retro-analysis of every #149-signature e2e failure: after #173 dropped the reset's `db.transaction`, every remaining failure on a trusted branch coincided with an overlapping e2e run — #358's clobber, fixed by the concurrency group on 2026-06-21, zero recurrences since. `prepare: false` (#296) showed no effect and stays only because it's harmless. The pooler-transaction hazard evidence is scoped to the mid-May probe captures (real, unreproduced since); `strategy-db-transactions.md` corrected, probe teardown filed as #486. The auth callback keeps its transaction by decision, now alarmed on both failure shapes: the existing Sentry capture for loud aborts plus a new post-commit read-back that raises a Sentry error if a redemption silently vanishes.
 
+## 2026-07-02 | Blake | Monthly drift check for the vendored skill-creator
+
+A new `skill-creator drift check` workflow (`.github/workflows/skill-creator-drift.yml`, monthly + manual dispatch) compares the vendored `.claude/skills/skill-creator/` pin against upstream and opens a single tracking issue (labels `dependencies` + `skill-creator-drift`) when it falls behind; refreshing stays the human-run `update-skill-creator.mjs` + reviewed `/commit`. Replaces the previously planned `/commit` Step 14 reminder, which only fired on refresh commits and couldn't detect upstream movement. (#396)
+
 ## 2026-07-02 | Blake | Required structural gate for the team Skills
 
 A new `functional-skills` Vitest project (`tests/functional/skills/skill-contract.test.ts`) holds `/commit`, `/pr`, and `/ship` to their SKILL.md structure — frontmatter, invocation policy, section order, ≥3 evals each — so a structural break now fails the required `Lint & Functional Tests` check (skill-creator, vendored upstream, is exempt). (#396)

--- a/docs/doc-skill-creator.md
+++ b/docs/doc-skill-creator.md
@@ -29,6 +29,13 @@ commits. After a refresh: review the diff, run the acceptance evals in
 `evals/skill-creator.evals.json` and capture results in the commit's Test Plan, then ship via
 `/commit`.
 
+You don't have to remember to run `--check`: a monthly workflow
+(`.github/workflows/skill-creator-drift.yml`, 05:07 UTC on the 1st; manual via
+`gh workflow run skill-creator-drift.yml`) runs it and opens a tracking issue — labeled
+`dependencies` + `skill-creator-drift`, one open at a time (deduped by the qualifier label) —
+when the pin falls behind upstream. It never syncs files or opens PRs; refreshing stays the
+human-run procedure above.
+
 ## Running its scripts (authoring time only)
 
 The bundled `scripts/*.py` and `eval-viewer/` need **Python 3 with PyYAML**

--- a/docs/plan-skill-creator-vendoring.md
+++ b/docs/plan-skill-creator-vendoring.md
@@ -1,7 +1,8 @@
 # Plan: Vendor `skill-creator` + Drift Management + Skill Eval Gates
 
-**Status:** PR 1 shipped (#395, 2026-06-14). NL-invocation prereq shipped (#353/#433/#459/#460,
-2026-06-24). PRs 2–3 ready to implement; PRs 4–5 deferred. See #396.
+**Status:** PRs 1–3 shipped (PR 1 #395 2026-06-14; PR 2 #485 2026-07-02; PR 3
+`skill-creator-drift` 2026-07-03). NL-invocation prereq shipped (#353/#433/#459/#460,
+2026-06-24). #396 complete; PRs 4–5 deferred.
 **Relevant files:** `.claude/skills/`, `evals/`, `scripts/`, `.github/workflows/`,
 `docs/spec-portable-ai-procedures.md`
 
@@ -23,8 +24,8 @@ the normal repo CI plus human review.
 
 **Vendor the `skills/skill-creator/` subdirectory into `.claude/skills/skill-creator/`, pinned to
 an upstream commit SHA, refreshed by a small Node script.** Five PRs, sequenced below: vendor
-(1), deterministic structural gate (2), light drift detection + local eval surfacing (3), then two
-deferred upgrades (4, 5).
+(1), deterministic structural gate (2), scheduled drift detection (3), then two deferred
+upgrades (4, 5).
 
 Why vendoring wins: skill-creator is a *subdirectory of a monorepo*, and Claude Code auto-loads
 project skills only from `.claude/skills/<name>/`. Vendoring puts it exactly there — zero setup
@@ -48,7 +49,8 @@ without silent drift.
   needs Python in CI. Our gate asserts *our* spec instead; `quick_validate.py` remains a local
   authoring aid.
 - **Behavioral LLM evals as a blocking CI gate** — nondeterministic; a flaky required check is
-  how `main` stalls. Behavioral evals are local (PR 3) and later advisory-only (PR 5).
+  how `main` stalls. Behavioral evals stay local at authoring/refresh time and later
+  advisory-only (PR 5).
 - **Auto-PR drift automation first** — needs a PAT/App token so the bot PR triggers required
   checks. A tracking issue (PR 3) gets the same signal with the default `GITHUB_TOKEN`; the
   auto-PR upgrade (PR 4) is deferred until the cadence proves annoying.
@@ -84,10 +86,9 @@ the post-NL repo state, which is now live. **Verified post-NL state (don't re-de
   ≥3); it touches `/ship` SKILL.md too, but body-only (delegation narration) — the
   `disable-model-invocation: true` frontmatter is unchanged, so the expectation table holds. It
   also edits spec §2, so re-deriving the citations matters more.
-- **PR 3:** `/commit` has Step 0 at lines 28–43 and the approval block at Step 14 (line 105 on
-  `main`; ~109 after PR #484, a +4 shift entirely above Step 14). Place the skill-creator
-  surfacing inside **Step 14** (approval block), not near Step 0. Current line count is 198;
-  ample headroom to 500.
+- **PR 3:** *(Superseded 2026-07-02 — PR 3 was redesigned to the scheduled drift workflow and
+  the `/commit` Step 14 surfacing was dropped; see the PR 3 section and the decision log. The
+  original Step 14 placement notes are retired with it.)*
 - Both: `.claude/settings.json` is tracked (explicit `!.claude/settings.json` gitignore negation
   added by #353) — expected state, not a surprise to "fix".
 - **Resolved issue (know it):** Thread 15 (`.scratch/skill-nl-invocation-review-roundtable.md`;
@@ -160,20 +161,37 @@ skill contract. Assertions, each traceable to `docs/spec-portable-ai-procedures.
 Deliberately *not* asserted (judgment/LLM territory, per spec L115): description quality,
 `## Depends on` accuracy, "passes its eval set", self-hosting, eval realism.
 
-## PR 3 — Local eval surfacing in `/commit`
+## PR 3 — Scheduled drift check → tracking issue
 
-> Tracked in #396. Reference that issue in the PR body.
-> **Scope decision (2026-06-26):** The drift-detection workflow (`.github/workflows/skill-creator-drift.yml`)
-> is deferred — low ROI for a small team; `node scripts/update-skill-creator.mjs --check` runs
-> manually when needed. PR 3 is the `/commit` surfacing edit only.
+> Tracked in #396; this is the closing PR (`Closes #396` in the body).
+> **Scope decision (2026-07-02, reversing 2026-06-26):** PR 3 is the drift-detection workflow;
+> the previously planned `/commit` Step 14 surfacing edit is **dropped**. Rationale: the Step 14
+> hook fires only when `.claude/skills/skill-creator/**` is in a staged payload — i.e. on a
+> refresh the human has *already decided to do* — so it structurally cannot detect upstream
+> staleness (nothing in our tree changes when upstream moves), and its eval reminder duplicates
+> what `update-skill-creator.mjs` and `UPSTREAM.md` already print at refresh time. The 2026-06-26
+> "low ROI" deferral had bundled this cheap issue-based version with the expensive auto-PR (PAT)
+> and behavioral-eval (custom headless job) variants; unbundled, the issue version needs only the
+> default `GITHUB_TOKEN`.
 
-- `/commit` SKILL.md: when the staged payload touches `.claude/skills/skill-creator/**`, surface
-  in the approval block: "skill-creator changed — run the `evals/skill-creator.evals.json`
-  acceptance evals and capture results in the Test Plan." Same pattern as the existing
-  schema-touch detection (spec §4.1 step 9). **Surface-and-capture only** — `/commit` does not
-  auto-run Python or behavioral evals in its critical path. `/commit` is the right stage: it is
-  the earliest gate, already runs `npm test` (which fires PR 2's gate), and its commit-message
-  convention already requires a Test Plan. `/pr` and `/ship` move already-committed work.
+- `.github/workflows/skill-creator-drift.yml`: monthly cron (05:07 UTC on the 1st) +
+  `workflow_dispatch`; `permissions: contents: read, issues: write`; a `skill-creator-drift`
+  concurrency group. Runs `node scripts/update-skill-creator.mjs --check`:
+  - exit 0 (current) → silent success;
+  - exit 2 (behind) → ensure the `skill-creator-drift` label exists, then open **one** tracking
+    issue (compare URL + refresh instructions in the body) labeled `dependencies` +
+    `skill-creator-drift` — mirroring Dependabot's `dependencies`+qualifier labeling. Dedup is
+    by the qualifier label and **fail-closed**: if the dedup query errors, the run goes red
+    rather than risk a duplicate;
+  - any other exit → red (the check itself is broken; fix before trusting drift results).
+- **Read-only toward the repo:** the workflow never syncs files or opens a PR. Refreshing stays
+  the deliberate, human-run `update-skill-creator.mjs` + acceptance evals + reviewed `/commit`
+  (the script itself prints those instructions).
+- **Exit-2 path proven pre-merge (2026-07-02):** new workflows can't be dispatched before
+  they exist on the default branch, so PR 3 carried a temporary throwaway commit (a
+  `pull_request` trigger + the `UPSTREAM.md` pin rolled back to the prior upstream SHA) to force
+  one real exit-2 run in CI — issue creation and label dedup verified live, then the test issue
+  was closed and the throwaway commit dropped via force-with-lease before merge.
 
 ## Spike — prove the eval loop (tracked in #396; parallel to PRs 2–3)
 
@@ -232,8 +250,8 @@ Upgrade PR 3's workflow tail: drop `--check`, let the script sync files, open a 
 is dirty (compare URL in the body). Known requirements, mapped now so they aren't rediscovered:
 PAT or GitHub App token (a default-`GITHUB_TOKEN` PR does not trigger `Lint & Functional Tests`,
 so branch protection would block it); honest PR body (green = structural gate + repo build; the
-human reviews the diff and runs the PR 1 evals per PR 3's `/commit` surfacing). Build when the
-issue-based cadence proves annoying, not before.
+human reviews the diff and runs the PR 1 evals per the refresh script's printed instructions).
+Build when the issue-based cadence proves annoying, not before.
 
 ## PR 5 — Behavioral evals in CI, advisory/scheduled (deferred)
 
@@ -247,6 +265,15 @@ unverified — spike before committing to this PR.
 
 ## Decision log
 
+- 2026-07-02 — Blake: **PR 3 redesigned** from the `/commit` Step 14 eval-surfacing edit to a
+  monthly scheduled drift check (`.github/workflows/skill-creator-drift.yml`: cron 05:07 UTC on
+  the 1st + `workflow_dispatch`; `--check`; exit 2 → one tracking issue labeled `dependencies` +
+  `skill-creator-drift`, label-deduped fail-closed; default `GITHUB_TOKEN`, no PAT). Reverses the
+  2026-06-26 deferral: that call had bundled the cheap issue-based automation with the expensive
+  auto-PR/behavioral variants, and the Step 14 hook couldn't serve the actual freshness goal — it
+  fires only on refresh commits (never when upstream moves) and duplicates the refresh script's
+  own printed eval instructions. PR 3 remains the closing PR for #396. Exit-2 path proven live
+  pre-merge via a throwaway `pull_request`-trigger + pin-rollback commit, dropped before merge.
 - 2026-07-02 — Blake: PR 2 (deterministic structural gate) implemented **on top of #484**, reversing the 2026-07-01 "independent, branch off `main`" call: `skill-nl-announce-affirmation` (#484) was merged first (`92984dc`) and the gate is written against the post-#484 repo state — eval counts 8/9/6 (commit/pr/ship), skill-creator 3, all ≥3. Gate lives at `tests/functional/skills/skill-contract.test.ts` in a **new `functional-skills` Vitest project** (its own home rather than folded into `functional-server`, so a skills contract test doesn't masquerade as a server test — and the `tests/functional/skills/` path is otherwise collected by no project and would silently not run). Runs in the required `Lint & Functional Tests` check. Allowlist `{commit, pr, ship}` only (skill-creator not held to our contract). Asserts: SKILL.md present; frontmatter parses with `name` + `description`; `name` == dir; per-skill invocation policy (commit/pr: `disable-model-invocation` absent, ship: `true`); body sections Invocation → Steps → Failure modes → `## Depends on` as a **subsequence**; >500 lines warns only; both eval JSONs' every `skill_path` resolves with ≥3 evals per skill. Spec citations re-derived post-#484: §2 L52–61, §3 L79–117.
 - 2026-07-01 — Blake: Studied PR #484 (`skill-nl-announce-affirmation`, now open — announce at the routing decision + delegation narration + semantic over-trigger evals). Confirmed still independent of PRs 2/3 (verified assertion-by-assertion). Corrections folded into the Sequencing note and PR 2 assertions: post-#484 eval counts are 8/9/6 (not 5/8/4); #484 touches `/ship` SKILL.md body-only (frontmatter untouched); Step 14 shifts +4 (→~109). Also hardened two PR 2 assertions against the real file shapes: section-order is a subsequence check, and `evals.json` nests cases under one `skill_path` per skill (count within group).
 - 2026-06-26 — Blake: Prereq correction — `skill-nl-announce-affirmation` is not required before PR 2 or PR 3. PR 2's assertions (key absence, section order, eval count ≥3) are insensitive to Step 0 announce content; eval ≥3 threshold is already satisfied (5/8/4). PR #468 is a procedural prerequisite (implementer should start from current `main`) but not a technical one.


### PR DESCRIPTION
Summary: Add a monthly scheduled workflow that compares the vendored
.claude/skills/skill-creator/ pin against upstream and opens one tracking
issue when it falls behind.

Why: The vendored copy is pinned by design, so nothing in the repo changes
when upstream moves — no PR-time gate can detect staleness, and remembering
to run `update-skill-creator.mjs --check` by hand doesn't scale. This is the
redesigned PR 3 of the vendoring plan (#396): the 2026-06-26 deferral had
bundled this cheap issue-based automation with the expensive auto-PR (PAT)
and behavioral-eval variants; unbundled, it needs only the default
GITHUB_TOKEN. It replaces the previously planned /commit Step 14 reminder,
which only fired on refresh commits and duplicated the refresh script's own
printed instructions.

Behavior: skill-creator-drift.yml runs at 05:07 UTC on the 1st of each month
(plus manual workflow_dispatch): `--check` exit 0 → silent; exit 2 → opens a
tracking issue (compare URL + refresh instructions) labeled dependencies +
skill-creator-drift, deduped by the qualifier label and fail-closed on dedup
errors; any other exit → red. Read-only toward the repo: it never syncs
files or opens PRs. Plan doc updated (PR 3 section, status header, decision
log); doc-skill-creator.md documents the workflow; devjournal entry added.

Test Plan:
- ran `npm test` locally — all suites green (functional-skills gate 17/17,
  Playwright e2e 37/37); re-ran after rebasing onto post-#488 main — green.
- workflow YAML parses (js-yaml); embedded script passes `bash -n`; exit-2
  issue-body generation simulated locally with stubbed --check output —
  renders clean (fenced output, compare URL, no indent artifacts).
- `node scripts/update-skill-creator.mjs --check` → exit 0 (pin current), so
  the scheduled run stays silent on today's state.
- exit-2 path + label dedup proven live in this PR via a temporary
  pull_request-trigger + pin-rollback commit (dropped before merge) — see
  the PR thread for the run links and the resulting test issue.

Closes #396

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
