### PR TITLE
fix(avatars): share signed-URL cache across instances and deploys

### DIFF
--- a/docs/design-profile-pictures.md
+++ b/docs/design-profile-pictures.md
@@ -100,10 +100,19 @@ once, so signing must not become N round-trips:
   which signs the whole directory in **one** round-trip. Never loop
   the single-path `createSignedUrl`.
 - **Cache** the signed URLs, keyed by object path, for most of the
-  TTL (a module-level `Map` on the Fluid Compute instance, or Next's
-  `use cache`). Signing then fires roughly once per TTL per warm
-  instance — not once per page view. The directory's hot path does
-  zero Storage round-trips.
+  TTL via **Vercel Runtime Cache** (`getCache()` from
+  `@vercel/functions`), not a module-level `Map`. A Map is scoped to
+  one Fluid Compute instance and one deployment: instance recycling,
+  scale-out, and every push-to-main deploy discard it, and each loss
+  re-signs the same path with a fresh `?token=` — a new cache key for
+  the browser and the optimizer, forcing both to re-download bytes
+  they already had (a 2026-07-03 HAR showed one navigation
+  re-downloading all 12 of a program's avatars against tokens minted
+  8 minutes apart; #382). Runtime Cache is shared across a region's
+  instances and survives deploys, so signing fires roughly once per
+  path per TTL per region. Reads and writes are best-effort and
+  instrumented (hit/miss counts and timings to Axiom); `next dev` and
+  tests fall back to an in-process cache.
 - The signed URL's `?token=` is part of `next/image`'s optimizer cache
   key, so each rotation forces a full re-fetch of every avatar's source
   object from Storage. The original 24h rotation did this daily; combined

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-07-05 | James | Avatar signed URLs cache in Vercel Runtime Cache
+
+Signed avatar URLs now cache in Vercel Runtime Cache instead of a per-instance module Map, so tokens stay stable across deploys and instances (#382).
+
 ## 2026-07-02 | Blake | Monthly drift check for the vendored skill-creator
 
 A new `skill-creator drift check` workflow (`.github/workflows/skill-creator-drift.yml`, monthly + manual dispatch) compares the vendored `.claude/skills/skill-creator/` pin against upstream and opens a single tracking issue (labels `dependencies` + `skill-creator-drift`) when it falls behind; refreshing stays the human-run `update-skill-creator.mjs` + reviewed `/commit`. Replaces the previously planned `/commit` Step 14 reminder, which only fired on refresh commits and couldn't detect upstream movement. (#396)

--- a/src/server/avatars.ts
+++ b/src/server/avatars.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { getCache } from "@vercel/functions";
 import { eq } from "drizzle-orm";
 import { log } from "next-axiom";
 import sharp from "sharp";
@@ -23,15 +24,40 @@ export const AVATAR_BUCKET = "avatars";
 // week. The cache window sits an hour under the TTL so a URL is re-signed
 // before it can expire mid-use.
 const SIGN_TTL_SECONDS = 5 * 24 * 60 * 60;
-const CACHE_TTL_MS = SIGN_TTL_SECONDS * 1000 - 60 * 60 * 1000;
+const CACHE_TTL_SECONDS = SIGN_TTL_SECONDS - 60 * 60;
 
-type CacheEntry = { url: string; expiresAt: number };
+// Signed-URL cache. Vercel Runtime Cache rather than a module-level Map:
+// a Map is scoped to one Fluid Compute instance and one deployment, so
+// instance recycling, scale-out, and every push-to-main deploy discard
+// it — and each loss re-signs the same object path with a fresh
+// `?token=`, which is part of the browser's and the image optimizer's
+// cache key, forcing both to re-download bytes they already had. (A
+// 2026-07-03 HAR capture showed one navigation re-downloading all 12 of
+// a program's avatars against tokens minted 8 minutes apart; #382.)
+// Runtime Cache is shared across a region's instances and survives
+// deploys. getCache() resolves its backing store lazily per operation,
+// so binding it at module scope is safe; where the runtime store is
+// unavailable (`next dev`, vitest) it falls back to a per-process
+// in-memory cache — the old Map behavior.
+const cache = getCache({ namespace: "avatar-url" });
 
-// Module-level cache keyed by object path. On Fluid Compute the
-// instance is reused across requests, so signing fires roughly once
-// per path per TTL rather than once per page view — the directory's
-// hot path then does zero Storage round-trips.
-const signedUrlCache = new Map<string, CacheEntry>();
+// Cache reads and writes are best-effort, like signing itself: a cache
+// outage must cost us a re-sign, never a failed page.
+const cacheGet = async (path: string): Promise<string | null> => {
+  try {
+    return ((await cache.get(path)) as string | null) ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const cacheSet = async (path: string, url: string): Promise<void> => {
+  try {
+    await cache.set(path, url, { ttl: CACHE_TTL_SECONDS, tags: ["avatar-url"] });
+  } catch {
+    // A lost write just means a future re-sign.
+  }
+};
 
 // Signs a batch of avatar object paths, returning a path → signed-URL
 // map. Cache hits skip the network; misses are signed in a single
@@ -42,39 +68,60 @@ export const resolveAvatarUrls = async (
   paths: readonly (string | null | undefined)[],
 ): Promise<Map<string, string>> => {
   const result = new Map<string, string>();
-  const now = Date.now();
+  const uniquePaths = [...new Set(paths.filter((p): p is string => !!p))];
+  if (uniquePaths.length === 0) return result;
+
+  const getStart = performance.now();
+  const cached = await Promise.all(uniquePaths.map((path) => cacheGet(path)));
+  const cacheGetMs = Math.round(performance.now() - getStart);
+
   const misses: string[] = [];
+  uniquePaths.forEach((path, i) => {
+    const url = cached[i];
+    if (url) result.set(path, url);
+    else misses.push(path);
+  });
 
-  for (const path of paths) {
-    if (!path || result.has(path)) continue;
-    const cached = signedUrlCache.get(path);
-    if (cached && cached.expiresAt > now) {
-      result.set(path, cached.url);
-    } else if (!misses.includes(path)) {
-      misses.push(path);
-    }
-  }
-
+  let signMs = 0;
+  let signFailed = false;
   if (misses.length > 0) {
+    const signStart = performance.now();
     const { data, error } = await supabaseAdmin.storage.from(AVATAR_BUCKET).createSignedUrls(misses, SIGN_TTL_SECONDS);
+    signMs = Math.round(performance.now() - signStart);
     if (error) {
       // Signing is best-effort. A transient Storage error — most often a
       // 429 "too many connections" when a burst of renders all sign at
       // once — must not 500 a page over a decorative avatar. Report it,
       // then leave the misses unsigned so they fall back to initials.
+      signFailed = true;
       log.error("avatar sign failed", {
         count: misses.length,
         message: error.message,
         statusCode: (error as { statusCode?: string }).statusCode,
       });
-      return result;
-    }
-    for (const row of data ?? []) {
-      if (row.error || !row.path || !row.signedUrl) continue;
-      signedUrlCache.set(row.path, { url: row.signedUrl, expiresAt: now + CACHE_TTL_MS });
-      result.set(row.path, row.signedUrl);
+    } else {
+      const sets: Promise<void>[] = [];
+      for (const row of data ?? []) {
+        if (row.error || !row.path || !row.signedUrl) continue;
+        result.set(row.path, row.signedUrl);
+        sets.push(cacheSet(row.path, row.signedUrl));
+      }
+      await Promise.all(sets);
     }
   }
+
+  // One event per resolve. The hit rate is the ground truth on whether the
+  // shared cache is working (persistently low in prod means it isn't and
+  // we're back to per-instance signing churn); cacheGetMs/signMs bound what
+  // the lookup and the signing round-trip cost the request.
+  log.info("avatar url cache", {
+    batch: uniquePaths.length,
+    hits: uniquePaths.length - misses.length,
+    misses: misses.length,
+    cacheGetMs,
+    signMs,
+    signFailed,
+  });
 
   return result;
 };


### PR DESCRIPTION
Summary: Replace the per-instance module-level signed-URL Map in `resolveAvatarUrls` with Vercel Runtime Cache, and instrument cache hit/miss counts and timings to Axiom.

Why: A module-level Map is scoped to one Fluid Compute instance and one deployment — instance recycling, scale-out, and every push-to-main deploy discard it, re-signing the same avatar paths with fresh `?token=` values. Each fresh token is a new cache key for the browser and the image optimizer, forcing both to re-download bytes they already had. A 2026-07-03 HAR capture showed one navigation re-downloading all 12 of a program's avatars against tokens minted 8 minutes apart. (#382)

Behavior: Signed avatar URLs stay stable across instances and deploys within the 5-day sign TTL (Runtime Cache is regional and survives deploys; `next dev` and tests fall back to an in-process cache). Cache reads and writes are best-effort — a cache outage degrades to a re-sign, never a failed page. Each resolve emits an Axiom "avatar url cache" event with batch/hits/misses/cacheGetMs/signMs/signFailed, so the prod hit rate will show whether the shared cache is actually working.

Test Plan:

- ran `npm test` locally before commit (614 functional + 37 e2e; first e2e run had one transient Playwright worker crash (0xC0000409) on version-update.spec.ts — full re-run green, 37/37)
- re-ran full `npm test` after rebasing onto main — green first try (614 functional + 37 e2e)

(#382)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VstZwRmgyZg4964az5uFi8
