### PR TITLE
docs: add local dev ports quick reference

### DIFF
--- a/docs/doc-dev-ports.md
+++ b/docs/doc-dev-ports.md
@@ -1,0 +1,9 @@
+# Local dev ports — quick reference
+
+| Service | Port |
+|---|---|
+| Next.js dev server | 3000 (or the lane's `LANE_DEV_PORT`) |
+| Supabase Postgres | 54322 |
+| Supabase Studio | 54323 |
+
+Lanes offset these ports per worktree — see `docs/strategy-worktree-lanes.md`. Full stack details: `docs/architecture-devstack.md`.


### PR DESCRIPTION
Adds a one-table quick reference for the local dev ports (dev server, Supabase Postgres, Studio) so newcomers don't have to hunt through CLAUDE.md, with pointers to the lane and devstack docs for the details.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Po5gDoqXztrVXLs1RTjzC)_