### PR TITLE
fix(myweb): old-browser-safe name halos + Baseline support policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Requires Docker Desktop. `npm run dev` auto-starts a local Supabase stack (Postg
 - Schema/API migrations use the **expand-contract pattern** (see `docs/strategy-committing.md`)
 - All pushes trigger Vercel deployment; docs-only changes (`docs/**`, root `CLAUDE.md`) skip automatically (see `docs/strategy-committing.md`)
 - Add `docs/devjournal.md` entries for decisions teammates should know about
+- All first-party code must stick to **Baseline widely available** (`docs/strategy-browser-support.md`)
 
 ## CI/CD
 
@@ -82,6 +83,7 @@ A fourth skill, Anthropic's upstream `skill-creator` (used to build and eval the
 - `docs/strategy-db-transactions.md` — writing transactions that survive the Supabase connection pooler
 - `docs/strategy-project-management.md` — GitHub Projects board conventions
 - `docs/strategy-security.md` — security headers and rationale for each directive
+- `docs/strategy-browser-support.md` — three browser-support tiers: Baseline-widely-available full fidelity, best-effort down to the hard floor, legacy-check blocker below
 - `docs/strategy-ui.md` — theme tokens, the `/colors` dev page, Button variants, buttons vs anchors
 - `docs/design-welcome.md` — multi-step onboarding/welcome flow design
 - `docs/design-emails.md` — auth email template authoring and prod sync

--- a/docs/devjournal.md
+++ b/docs/devjournal.md
@@ -4,6 +4,10 @@ Each entry: **Date** | **Author** | **Title**, followed by description text. Mos
 
 ---
 
+## 2026-07-05 | James | Browser support policy: Baseline widely available
+
+Full support requires Baseline widely available — check the MDN badge before hand-writing any CSS property, JS API, or syntax feature; older browsers get best-effort down to the hard floor (Chrome/Edge 85 / Safari 13.1 / Firefox 77, the legacy-check blocker). Details in `docs/strategy-browser-support.md`; member-facing summary on `/about`.
+
 ## 2026-07-05 | James | Avatar signed URLs cache in Vercel Runtime Cache
 
 Signed avatar URLs now cache in Vercel Runtime Cache instead of a per-instance module Map, so tokens stay stable across deploys and instances (#382).

--- a/docs/strategy-browser-support.md
+++ b/docs/strategy-browser-support.md
@@ -1,0 +1,50 @@
+# Browser Support Strategy
+
+How old a browser the IS Web App supports, and what "supports" means at each
+age. The membership is globally distributed and reaches the app on whatever
+device they have — including machines whose OS caps the browser version
+(Windows 7/8.1 ends at Chrome 109; older macOS caps Safari and Chrome
+similarly). A member-facing summary of this policy lives on `/about`.
+
+## The three tiers
+
+1. **Full support — Baseline widely available.** Every flow works and
+   renders as designed on browsers current with the
+   [Web Platform Baseline](https://web.dev/baseline): features supported
+   by all four core browsers (Chrome, Edge, Firefox, Safari) for at least
+   30 months. Before hand-writing a CSS property, JS API, or syntax
+   feature, check its MDN badge: **"Baseline widely available" means
+   usable at full fidelity; "newly available" or no badge means it must
+   not be relied upon.**
+2. **Best effort — older than the Baseline cohort, down to the hard
+   floor.** Core flows work (sign-in, signup, forms, navigation) and all
+   content is readable. Polish like colors, halos, shadows may simplify.
+   A feature whose absence would break function or readability needs a
+   fallback that reaches this tier.
+3. **Blocked — below the hard floor.** `public/legacy-check.js` detects the
+   engine at boot and reveals the plain-HTML `LegacyBrowserNotice` instead
+   of a silently broken app (#365).
+
+## The hard floor: Chrome/Edge 85, Safari 13.1, Firefox 77
+
+The engine generation that parses the syntax Next 16 / React 19 emit
+(optional chaining, nullish coalescing) and has the APIs the bundle assumes
+(`String.prototype.replaceAll`, `Promise.allSettled`, `fetch`). Below it the
+bundle throws a `SyntaxError` before React hydrates, so no in-app fallback
+can help — hence the boot-time blocker. The floor moves only when the
+framework stack raises its emitted-syntax baseline; when it does, update
+`legacy-check.js`, this section, and the `/about` summary together.
+
+## Why these tiers
+
+Two shipped regressions came from reaching past the tiers by accident:
+Safari ≤10 members hit a silently dead signup form (#365 — bundle syntax
+below the hard floor), and a Chrome 109 member saw white-on-white graph
+name labels (`paint-order` on HTML text reached Baseline newly available in
+March 2024 and is widely available only from ~September 2026 — the badge
+check catches exactly this).
+
+Tailwind v4's own requirements (Chrome 111 / Safari 16.4, March 2023) are
+inside Baseline widely available as of late 2025, and its sRGB color
+fallbacks (v4.1+) carry the best-effort tier the rest of the way down to
+the hard floor.

--- a/public/legacy-check.js
+++ b/public/legacy-check.js
@@ -14,6 +14,15 @@
  * Keep this ES5 (var, no arrow functions, no `?.`/`??`) so the warning can
  * display on the very browsers it is meant to warn. It is excluded from
  * Biome for the same reason — see biome.json.
+ *
+ * The generation this check gates on — Chrome/Edge 85, Safari 13.1,
+ * Firefox 77 — is the app's hard minimum spec: the "blocked" tier of
+ * docs/strategy-browser-support.md. This blocker fails legibly below the
+ * floor; the support commitments above it (Baseline-widely-available
+ * full fidelity, best-effort in between) live in that doc. Move the
+ * floor only in
+ * lockstep with the framework stack's emitted-syntax baseline, updating
+ * this check and the doc together.
  */
 (function () {
   // Each of these landed in Safari 13.1 / Chrome 85 / Firefox 77 — the same

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -72,6 +72,24 @@ export default async function AboutPage() {
           .
         </p>
       </section>
+
+      <section className="w-full max-w-2xl">
+        <h2 className="text-lg font-semibold">Browser support</h2>
+        <p className="mt-2 text-base text-muted-foreground">
+          This app is built to the{" "}
+          <a
+            href="https://web.dev/baseline"
+            rel="noopener noreferrer"
+            className="underline text-muted-foreground hover:text-foreground"
+          >
+            Web Platform Baseline
+          </a>{" "}
+          "Widely Available" standard: we rely on a web feature only when every major browser (Chrome, Edge, Firefox,
+          Safari) has supported it for at least 30 months. Older browsers are supported on a best-effort basis,
+          prioritizing functionality over visuals. Browsers too old to run the app at all (roughly pre-2020) see an
+          update notice instead.
+        </p>
+      </section>
     </main>
   );
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -56,7 +56,6 @@ export default async function AboutPage() {
           This app is built by the IS Dev Team: James, Benji, Ola, Alexis, and Blake. The code is open — read it at{" "}
           <a
             href="https://github.com/Intentional-Society/is-app"
-            target="_blank"
             rel="noopener noreferrer"
             className="underline text-muted-foreground hover:text-foreground"
           >

--- a/src/app/myweb/web-graph-renderers.tsx
+++ b/src/app/myweb/web-graph-renderers.tsx
@@ -119,22 +119,24 @@ function MemberNode({ id, data }: NodeProps<Node<MemberNodeData>>) {
       {/* Hidden by default, faded in when labeled (hover or lit path). Kept
           mounted at opacity 0 rather than unmounted so the node's height never
           shifts as names appear (no reflow against the fixed layout). The
-          viewer's own node reads "You" in place of their name (mini-map cue). */}
+          viewer's own node reads "You" in place of their name (mini-map cue).
+          Canvas-colored halo so the name reads over the dense edge lines behind
+          it — those strokes are canvas-foreground, the same color family as the
+          text, so without a moat the glyphs blend in. The halo is a stroked
+          duplicate layered *under* the fill text: -webkit-text-stroke alone
+          paints over the fill, and paint-order:stroke (the one-element fix)
+          only applies to HTML text since Chrome 123, which turned names
+          canvas-on-canvas invisible on older Chromes. */}
       <div
         aria-hidden={!labeled}
-        className="pointer-events-none max-w-[8rem] truncate text-sm font-medium transition-opacity duration-150"
-        style={{
-          opacity: labeled ? 1 : 0,
-          // Canvas-colored halo so the name reads over the dense edge lines
-          // behind it — those strokes are canvas-foreground, the same color
-          // family as the text, so without a moat the glyphs blend in.
-          // paint-order:stroke draws the stroke behind the fill, so it's a true
-          // outline (glyphs stay crisp) rather than a thinned weight.
-          paintOrder: "stroke",
-          WebkitTextStroke: "3px var(--color-canvas)",
-        }}
+        className="pointer-events-none relative max-w-[8rem] text-sm font-medium transition-opacity duration-150"
+        style={{ opacity: labeled ? 1 : 0 }}
       >
-        {isViewer ? "You" : (data.displayName ?? "—")}
+        <span aria-hidden className="absolute inset-0 truncate" style={{ WebkitTextStroke: "3px var(--color-canvas)" }}>
+          {isViewer ? "You" : (data.displayName ?? "—")}
+        </span>
+        {/* relative so the fill paints above the positioned halo (DOM order). */}
+        <span className="relative block truncate">{isViewer ? "You" : (data.displayName ?? "—")}</span>
       </div>
     </div>
   );

--- a/src/lib/changelog.tsx
+++ b/src/lib/changelog.tsx
@@ -39,7 +39,7 @@ export const changelog: ChangelogEntry[] = [
   {
     date: "2026-07-05",
     title: "Browser support",
-    description: "Browser support policy (30 months full support, 6 years functional) now on the About page.",
+    description: "Browser support policy (30 months full, 6 years functional) now listed on the About page.",
   },
   {
     date: "2026-06-24",
@@ -48,8 +48,8 @@ export const changelog: ChangelogEntry[] = [
   },
   {
     date: "2026-06-20",
-    title: "Improved program descriptions",
-    description: "Program descriptions can now run as long as they need.",
+    title: "Improved program listings",
+    description: "Separate summaries, details link, longer descriptions, facepiles.",
   },
   {
     date: "2026-06-18",

--- a/src/lib/changelog.tsx
+++ b/src/lib/changelog.tsx
@@ -37,6 +37,21 @@ export type ChangelogEntry = {
 // ordering; a functional test asserts it stays sorted.
 export const changelog: ChangelogEntry[] = [
   {
+    date: "2026-07-05",
+    title: "Browser support",
+    description: "Browser support policy (30 months full support, 6 years functional) now on the About page.",
+  },
+  {
+    date: "2026-06-24",
+    title: "Photos when relating",
+    description: "The dialog for setting a relationship now shows the member's photo.",
+  },
+  {
+    date: "2026-06-20",
+    title: "Improved program descriptions",
+    description: "Program descriptions can now run as long as they need.",
+  },
+  {
     date: "2026-06-18",
     title: "Spacing slider",
     description: "My Web has a spacing slider to adjust map density, plus clarity and hover improvements.",


### PR DESCRIPTION
Summary: Fixes white-on-white graph name labels on browsers that ignore
paint-order on HTML text, and codifies the browser-support policy that
prevents the next such miss.

Why: A member on Chrome 109 reported an unreadable profile mini-map:
the labels' 3px canvas-colored text stroke relied on paint-order:
stroke, which Chrome honors on HTML text only since 123 (Mar 2024), so
older Chromes painted the stroke over the glyphs. The support target
was previously undocumented, so features newer than the membership's
browsers shipped by accident twice (#365 was the first).

Behavior:
- Graph name labels (profile mini-map + /myweb hover) render as a
  stroked halo copy under plain fill text — identical on current
  browsers, readable everywhere.
- New docs/strategy-browser-support.md: full support requires Baseline
  widely available; best-effort down to the hard floor (Chrome/Edge 85,
  Safari 13.1, Firefox 77 — the legacy-check blocker); CLAUDE.md
  pointers; devjournal entry.
- /about gains a member-facing "Browser support" section below The
  team, linking to web.dev/baseline (both /about external links now
  navigate in-tab).

Test Plan:
- ran `npm test` locally
- drove the dev app with Playwright: mini-map and /myweb hover labels
  render dark-on-light, halo tracks --color-canvas in dark mode, both
  layers truncate identically on a long name; /about renders the new
  section and Baseline link
- one gate run hit the pre-existing version-update 2h time-bomb,
  root-caused and filed as #492 (green on a fresh dev server)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VJdC6NypNJC2tUKjtec76S

🤖 Generated with [Claude Code](https://claude.com/claude-code)
